### PR TITLE
Update GEM namespace from gem0 to gem

### DIFF
--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -71,7 +71,7 @@
     </fields>
     <fields>
         <fullName>Advancement_Namespace__c</fullName>
-        <defaultValue>&quot;gem0&quot;</defaultValue>
+        <defaultValue>&quot;gem&quot;</defaultValue>
         <description>The namespace of the Gift Entry Management managed package.</description>
         <externalId>false</externalId>
         <inlineHelpText>The namespace of the Gift Entry Management managed package.</inlineHelpText>


### PR DESCRIPTION
# Critical Changes

# Changes
- Update Advancement Namespace default value to support the final `gem` namespace.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
When gem is installed and this PR is applied, all apex tests from the EDA package should pass. That part of testing is only possible after a release has been cut.