### PR TITLE
Update scratch org definitions to use settings

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,10 +1,10 @@
 {
   "orgName": "EDA - Beta Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,11 +1,11 @@
 {
   "orgName": "EDA - Dev Workspace",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "translation": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,10 +1,10 @@
 {
   "orgName": "EDA - Feature Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -2,11 +2,11 @@
   "orgName": "EDA - Prerelease Dev Workspace",
   "edition": "Developer",
   "instance": "CS46",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "Translation",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "translation": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,10 +1,10 @@
 {
   "orgName": "EDA - Release Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }


### PR DESCRIPTION
`orgPreferences` were deprecated and are generating a warning.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
