### PR TITLE
adding Day Absence and Day Tardy as picklist options on attendance event

### DIFF
--- a/src/objects/Attendance_Event__c.object
+++ b/src/objects/Attendance_Event__c.object
@@ -85,6 +85,16 @@
                     <default>false</default>
                     <label>Class Tardy</label>
                 </value>
+                <value>
+                    <fullName>Day Absence</fullName>
+                    <default>false</default>
+                    <label>Day Absence</label>
+                </value>
+                <value>
+                    <fullName>Day Tardy</fullName>
+                    <default>false</default>
+                    <label>Day Tardy</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>


### PR DESCRIPTION
# Critical Changes

# Changes

## Day Absences and Tardies

We've added two new options, Day Absence and Day Tardy, to the Attendance Type picklist on the Attendance Event page layout.

For new EDA installations, these options are automatically available from the Attendance Type picklist. You can remove any that you don't want to use. If your organization has an existing EDA installation, you can manually add these picklist values to the Attendance Type picklist. For information, check out [Add or Edit Picklist Values](https://help.salesforce.com/articleView?id=updating_picklists.htm&type=5).

# Issues Closed
Fixes #846 
# New Metadata

# Deleted Metadata

# Testing Notes
