### PR TITLE
adding Chose Full Name field to EDA contact object

### DIFF
--- a/src/layouts/Contact-HEDA Contact Layout.layout
+++ b/src/layouts/Contact-HEDA Contact Layout.layout
@@ -25,6 +25,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Chosen_Full_Name__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>AccountId</field>
             </layoutItems>
             <layoutItems>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -20,6 +20,16 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Chosen_Full_Name__c</fullName>
+        <externalId>false</externalId>
+        <label>Chosen Full Name</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Citizenship__c</fullName>
         <externalId>false</externalId>
         <label>Citizenship</label>

--- a/src/package.xml
+++ b/src/package.xml
@@ -257,6 +257,7 @@
         <members>Attribute__c.Expired__c</members>
         <members>Attribute__c.Start_Date__c</members>
         <members>Contact.AlternateEmail__c</members>
+        <members>Contact.Chosen_Full_Name__c</members>
         <members>Contact.Citizenship__c</members>
         <members>Contact.Country_of_Origin__c</members>
         <members>Contact.Current_Address__c</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- We have added the ability to specify a contact's Chosen Full Name. Existing customers wishing to leverage this impactful field will need to add it to their page layouts.
# Issues Closed
Fixes #807
# New Metadata
- Contact.Chosen_Full_Name__c
# Deleted Metadata

# Testing Notes
