### PR TITLE
Error Message on Relationship object

### DIFF
--- a/src/objectTranslations/Relationship__c-en_US.objectTranslation
+++ b/src/objectTranslations/Relationship__c-en_US.objectTranslation
@@ -168,7 +168,7 @@
     </layouts>
     <startsWith>Consonant</startsWith>
     <validationRules>
-        <errorMessage><!-- Rather than change the contacts in an existing relationship, delete this relationship and create a new on between the new contacts --></errorMessage>
+        <errorMessage><!-- Rather than change the Contacts in an existing Relationship, delete this Relationship and create a new one.--></errorMessage>
         <name>Related_Contact_Do_Not_Change</name>
     </validationRules>
 </CustomObjectTranslation>

--- a/src/objects/Relationship__c.object
+++ b/src/objects/Relationship__c.object
@@ -336,6 +336,6 @@ TEXT(Contact__r.Salutation) + &quot; &quot; + Contact__r.FirstName + &quot; &quo
         <description>Do not allow user to change Related Contact value as it damages the paired relationship data</description>
         <errorConditionFormula>and(not( ISNEW()), ISCHANGED( RelatedContact__c ))</errorConditionFormula>
         <errorDisplayField>RelatedContact__c</errorDisplayField>
-        <errorMessage>Rather than change the contacts in an existing relationship, delete this relationship and create a new on between the new contacts</errorMessage>
+        <errorMessage>Rather than change the Contacts in an existing Relationship, delete this Relationship and create a new one.</errorMessage>
     </validationRules>
 </CustomObject>


### PR DESCRIPTION
# Critical Changes

# Changes

## Updates to Relationship Objects
We've made some minor editorial changes to the error message that displays when users try to change the Related Contact on a Relationship record.

# Issues Closed
Fixes #865 

# New Metadata

# Deleted Metadata

# Testing Notes
