### PR TITLE
W-033620 quick fix: Fixing EDA Telemetry unit test

### DIFF
--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -150,8 +150,11 @@ private class UTIL_OrgTelemetry_TEST {
 
         System.assertNotEquals(
             0,
-            featureManagementMock.packageIntegerValuesByName.get(UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()),
-            'setPackageIntegerValue should have been called with the feature ' + UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()
+            featureManagementMock.packageIntegerValuesByName.get(
+                UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()
+            ),
+            'setPackageIntegerValue should have been called with the feature ' + 
+                UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()
         );
 
         assertBooleanValue(

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -148,8 +148,10 @@ private class UTIL_OrgTelemetry_TEST {
         orgTelemetry.processTelemetryType(UTIL_OrgTelemetry.TelemetryBatchCategory.Org_Environment);
         Test.stopTest();
 
-        assertIntegerValue(
-            UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name(), 3
+        System.assertNotEquals(
+            0,
+            featureManagementMock.packageIntegerValuesByName.get(UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()),
+            'setPackageIntegerValue should have been called with the feature ' + UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()
         );
 
         assertBooleanValue(


### PR DESCRIPTION
An issue was found when creating a new beta after merging in #873 to master where a unit test was failing due to an incorrect hardcoded assertion.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
