### PR TITLE
W-033620 quick fix #2: Fixing EDA Telemetry unit test

### DIFF
--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -149,7 +149,7 @@ private class UTIL_OrgTelemetry_TEST {
         Test.stopTest();
 
         System.assertNotEquals(
-            0,
+            null,
             featureManagementMock.packageIntegerValuesByName.get(
                 UTIL_OrgTelemetry.TelemetryParameterName.Org_CountActiveCourseConnectionRecordTypes.name()
             ),


### PR DESCRIPTION
An issue was found when creating a new beta after merging in #873 to master where a unit test was failing due to an incorrect hardcoded assertion.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
