### PR TITLE
EDA Affiliations documentation URL

### DIFF
--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp
@@ -247,7 +247,7 @@
         <div aura:id="mappingsTabContent" class="slds-tabs__content" role="tabpanel">
             <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
                 <ui:outputText value="{!$Label.c.AfflMappingsDescription + ' '}" class="slds-text-body--small" />
-                <ui:outputURL value="http://powerofus.force.com/HEDA_Affiliations" class="slds-text-body--small slds-type-focus" 
+                <ui:outputURL value="https://powerofus.force.com/s/article/EDA-Create-Accounts-and-Affiliations" class="slds-text-body--small slds-type-focus" 
                     label="EDA documentation." target="_blank" />
             </div>
             <div class="slds-grid slds-wrap">


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated the URL in EDA settings Tab under Affiliations Mapping to correctly direct to documentation on Affiliations in EDA.

# Issues Closed
Fixes #889 

# New Metadata

# Deleted Metadata

# Testing Notes
Go to "EDA Settings" -> Affiliations -> Affiliation Mapping -> Click on "EDA Documentation"  
