### PR TITLE
W-033755: Update EDA Settings Text to Support K-12 Products

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1021,7 +1021,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpAccountModel</shortDescription>
-        <value>Setting for the Account model. &quot;Administrative&quot; is the recommended model.</value>
+        <value>For Higher Education institutions, we recommend the &quot;Administrative&quot; Account model. For K-20 schools, we recommend the &quot;Household&quot; Account model.</value>
     </labels>
     <labels>
         <fullName>stgHelpAccoutsDeletedIfChildContactsDeleted</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1021,7 +1021,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpAccountModel</shortDescription>
-        <value>For Higher Education institutions, we recommend the &quot;Administrative&quot; Account model. For K-20 schools, we recommend the &quot;Household&quot; Account model.</value>
+        <value>For Higher Education institutions, we recommend the &quot;Administrative&quot; Account model. For K-12 schools, we recommend the &quot;Household&quot; Account model.</value>
     </labels>
     <labels>
         <fullName>stgHelpAccoutsDeletedIfChildContactsDeleted</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes

## General Updates
- We've updated the text under EDA Settings | System | Default Account Model to clarify that while the Administrative Account model is recommended for Higher Education institutions, the Household Account model is recommended for K-12 schools.

# Issues Closed
- Fixes #900
# New Metadata

# Deleted Metadata

# Testing Notes
