### PR TITLE
Added Namespaced Prerelease Configuration

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -197,6 +197,9 @@ orgs:
             namespaced: True
         prerelease:
             config_file: orgs/prerelease.json
+        prerelease_namespaced:
+            config_file: orgs/prerelease.json
+            namespaced: True
 
 plans:
     install:


### PR DESCRIPTION
Added configuration to be able to create a prerelease scratch org with a namespace. This will help us with Winter '20 regression of a few critical updates.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
