### PR TITLE
Updated "cannotdelete" error msg

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -54,7 +54,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>CannotDelete</shortDescription>
-        <value>This record can't be deleted because it has one or more related records associated with it. Delete the associated records first, then delete this record. To determine which records should be deleted first, click the Related tab. If you don't see related records, or if you're unable to delete them, contact your System Administrator for assistance.</value>
+        <value>This record can&apos;t be deleted because it has one or more related records associated with it. Delete the associated records first, then delete this record. To determine which records should be deleted first, click the Related tab. If you don&apos;t see related records, or if you&apos;re unable to delete them, contact your System Administrator for assistance.</value>
     </labels>
     <labels>
         <fullName>DefaultAccountName</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -54,7 +54,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>CannotDelete</shortDescription>
-        <value>Record cannot be deleted because children records exist. Delete children first.</value>
+        <value>This record can't be deleted because it has one or more related records associated with it. Delete the associated records first, then delete this record. To determine which records should be deleted first, click the Related tab. If you don't see related records, or if you're unable to delete them, contact your System Administrator for assistance.</value>
     </labels>
     <labels>
         <fullName>DefaultAccountName</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
## General Updates
- We've updated the error message you see when attempting to delete certain records that have one or more related records associated with them. For example, if you try to delete a Program Plan record that has Plan Requirement records associated with it, you'll now see: 
*This record can't be deleted because it has one or more related records associated with it. Delete the associated records first, then delete this record. To determine which records should be deleted first, click the Related tab. If you don't see related records, or if you're unable to delete them, contact your System Administrator for assistance.*

# Issues Closed
Fixes #938
# New Metadata

# Deleted Metadata

# Testing Notes
