### PR TITLE
Emergency fix for Preferred Phone for 1.84

### DIFF
--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -89,6 +89,32 @@
             <ui:outputText value="{!$Label.c.stgHelpContactPreferredPhone}" class="slds-text-body--small" />
         </div>
 
+        <div class="slds-col slds-size--1-of-2">
+            <ui:outputText value="{!$Label.c.stgEnablePreferredPhoneSync}"/>
+        </div>
+        <div class="slds-col slds-size--1-of-2">
+            <div class="slds-form-element">
+                <div class="slds-form-element__control">
+                    <label class="slds-checkbox">
+                        <aura:if isTrue="{!v.isView}">
+                            <ui:outputCheckbox value="{!v.hierarchySettings.Enable_New_Preferred_Phone_Sync__c}"
+                                               class="contact-preferred-phone-sync-enabled" />
+                        <aura:set attribute="else">
+                            <ui:inputCheckbox value="{!v.hierarchySettings.Enable_New_Preferred_Phone_Sync__c}"
+                                              class="contact-preferred-phone-sync-enabled" />
+                            <span class="slds-checkbox--faux"></span>
+                            <span class="slds-form-element__label"></span>
+                        </aura:set>
+                        </aura:if>
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium">
+            <ui:outputText value="{!$Label.c.stgHelpContactPreferredPhoneSync}" class="slds-text-body--small" />
+        </div>
+        <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium"> </div>
+
         <div class="slds-col slds-size--1-of-2 slds-p-right--xx-large">
             <h2>
                 <ui:outputText value="{!$Label.c.stgPreferredEmailDataCleanup}" class="slds-text-body--small" />

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -17,6 +17,7 @@
     <aura:attribute name="householdRecTypeId" type="String" />
     <aura:attribute name="adminAccRecTypeName" type="String" />
     <aura:attribute name="adminAccRecTypeId" type="String" />
+    <aura:attribute name="prefPhoneErrorsDisabled" type="Boolean" default="false" />
 
     <div class="slds-grid slds-wrap">
 
@@ -73,10 +74,13 @@
                     <label class="slds-checkbox">
                         <aura:if isTrue="{!v.isView}">
                             <ui:outputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
-                                               class="contact-addr-enabled" />
+                                               class="contact-addr-enabled"
+                                               aura:id="disablePhoneErrors" />
                         <aura:set attribute="else">
                             <ui:inputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
-                                              class="contact-addr-enabled" />
+                                              class="contact-addr-enabled"
+                                              aura:id="disablePhoneErrors"
+                                              disabled="{!v.prefPhoneErrorsDisabled}"/>
                             <span class="slds-checkbox--faux"></span>
                             <span class="slds-form-element__label"></span>
                         </aura:set>
@@ -98,10 +102,13 @@
                     <label class="slds-checkbox">
                         <aura:if isTrue="{!v.isView}">
                             <ui:outputCheckbox value="{!v.hierarchySettings.Enable_New_Preferred_Phone_Sync__c}"
-                                               class="contact-preferred-phone-sync-enabled" />
+                                               class="contact-preferred-phone-sync-enabled"
+                                               aura:id="enablePrefPhone" />
                         <aura:set attribute="else">
                             <ui:inputCheckbox value="{!v.hierarchySettings.Enable_New_Preferred_Phone_Sync__c}"
-                                              class="contact-preferred-phone-sync-enabled" />
+                                              class="contact-preferred-phone-sync-enabled"
+                                              aura:id="enablePrefPhone" 
+                                              click="{!c.handlePhoneSync}"/>
                             <span class="slds-checkbox--faux"></span>
                             <span class="slds-form-element__label"></span>
                         </aura:set>

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp
@@ -64,34 +64,6 @@
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
             <ui:outputText value="{!$Label.c.stgHelpContactPreferredEmail}" class="slds-text-body--small" />
         </div>
-        
-        <div class="slds-col slds-size--1-of-2">
-            <ui:outputText value="{!$Label.c.stgDisablePreferredPhoneEnforcement}"/>
-        </div>
-        <div class="slds-col slds-size--1-of-2">
-            <div class="slds-form-element">
-                <div class="slds-form-element__control">
-                    <label class="slds-checkbox">
-                        <aura:if isTrue="{!v.isView}">
-                            <ui:outputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
-                                               class="contact-addr-enabled"
-                                               aura:id="disablePhoneErrors" />
-                        <aura:set attribute="else">
-                            <ui:inputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
-                                              class="contact-addr-enabled"
-                                              aura:id="disablePhoneErrors"
-                                              disabled="{!v.prefPhoneErrorsDisabled}"/>
-                            <span class="slds-checkbox--faux"></span>
-                            <span class="slds-form-element__label"></span>
-                        </aura:set>
-                        </aura:if>
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
-            <ui:outputText value="{!$Label.c.stgHelpContactPreferredPhone}" class="slds-text-body--small" />
-        </div>
 
         <div class="slds-col slds-size--1-of-2">
             <ui:outputText value="{!$Label.c.stgEnablePreferredPhoneSync}"/>
@@ -107,8 +79,8 @@
                         <aura:set attribute="else">
                             <ui:inputCheckbox value="{!v.hierarchySettings.Enable_New_Preferred_Phone_Sync__c}"
                                               class="contact-preferred-phone-sync-enabled"
-                                              aura:id="enablePrefPhone" 
-                                              click="{!c.handlePhoneSync}"/>
+                                              aura:id="enablePrefPhoneEdit" 
+                                              change="{!c.handlePhoneSync}"/>
                             <span class="slds-checkbox--faux"></span>
                             <span class="slds-form-element__label"></span>
                         </aura:set>
@@ -117,10 +89,39 @@
                 </div>
             </div>
         </div>
-        <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium">
+        
+        <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
             <ui:outputText value="{!$Label.c.stgHelpContactPreferredPhoneSync}" class="slds-text-body--small" />
         </div>
-        <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium"> </div>
+        
+        <div class="slds-col slds-size--1-of-2 slds-p-left--large">
+            <ui:outputText value="{!$Label.c.stgDisablePreferredPhoneEnforcement}"/>
+        </div>
+        <div class="slds-col slds-size--1-of-2">
+            <div class="slds-form-element">
+                <div class="slds-form-element__control">
+                    <label class="slds-checkbox">
+                        <aura:if isTrue="{!v.isView}">
+                            <ui:outputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
+                                               class="contact-addr-enabled"
+                                               aura:id="disablePhoneErrors" />
+                        <aura:set attribute="else">
+                            <ui:inputCheckbox value="{!v.hierarchySettings.Disable_Preferred_Phone_Enforcement__c}"
+                                              class="contact-addr-enabled"
+                                              aura:id="disablePhoneErrorsEdit"
+                                              disabled="{!v.prefPhoneErrorsDisabled}"/>
+                            <span class="slds-checkbox--faux"></span>
+                            <span class="slds-form-element__label"></span>
+                        </aura:set>
+                        </aura:if>
+                    </label>
+                </div>
+            </div>
+        </div>
+
+        <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium slds-p-left--large">
+            <ui:outputText value="{!$Label.c.stgHelpContactPreferredPhone}" class="slds-text-body--small" />
+        </div>
 
         <div class="slds-col slds-size--1-of-2 slds-p-right--xx-large">
             <h2>
@@ -156,7 +157,7 @@
         
         </div>
         
-	<!-- End of Preferred Email -->
+	    <!-- End of Preferred Email -->
         
         <hr class="slds-border--top slds-m-top--medium slds-m-bottom--medium" style="width:100%;" />
         

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
@@ -1,6 +1,9 @@
 ({
-    toggleIsView : function(component, event) {
+    toggleIsView : function(component, event, helper) {
         component.set("v.isView", event.getParam("isView"));
+        var enablePrefPhone = component.find("enablePrefPhoneEdit").get("v.value");
+
+        helper.toggleDisablePhoneEnforcementCheckbox(component, enablePrefPhone);
     },
     runBackfill : function (component, event, helper) {
         helper.runBackfill(component);

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrController.js
@@ -1,11 +1,14 @@
 ({
-toggleIsView : function(component, event) {
-	component.set("v.isView", event.getParam("isView"));
-},
-runBackfill : function (component, event, helper) {
-	helper.runBackfill(component);
-},
-runCleanUp : function (component, event, helper) {
-	helper.runCleanUp(component);
-},
+    toggleIsView : function(component, event) {
+        component.set("v.isView", event.getParam("isView"));
+    },
+    runBackfill : function (component, event, helper) {
+        helper.runBackfill(component);
+    },
+    runCleanUp : function (component, event, helper) {
+        helper.runCleanUp(component);
+    },
+    handlePhoneSync : function (component, event, helper) {
+        helper.handlePhoneSync(component, event);
+    },
 })

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
@@ -30,12 +30,15 @@
     handlePhoneSync : function (component, event) {
         var enablePrefPhone = event.getSource().get("v.value");
         
-        if(enablePrefPhone) {
+        this.toggleDisablePhoneEnforcementCheckbox(component, enablePrefPhone);
+        
+        $A.get('e.force:refreshView').fire();
+	},
+	toggleDisablePhoneEnforcementCheckbox : function (component, enablePrefPhone) {
+		if(enablePrefPhone) {
         	component.set("v.prefPhoneErrorsDisabled", false);
         } else {
         	component.set("v.prefPhoneErrorsDisabled", true);
         }
-        
-        $A.get('e.force:refreshView').fire();
-    },
+	},
 })

--- a/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
+++ b/src/aura/STG_CMP_Addr/STG_CMP_AddrHelper.js
@@ -26,5 +26,16 @@
 		    }
 		});
 		$A.enqueueAction(runBatchAction);
-	},
+    },
+    handlePhoneSync : function (component, event) {
+        var enablePrefPhone = event.getSource().get("v.value");
+        
+        if(enablePrefPhone) {
+        	component.set("v.prefPhoneErrorsDisabled", false);
+        } else {
+        	component.set("v.prefPhoneErrorsDisabled", true);
+        }
+        
+        $A.get('e.force:refreshView').fire();
+    },
 })

--- a/src/classes/CON_PreferredPhone_TDTM.cls
+++ b/src/classes/CON_PreferredPhone_TDTM.cls
@@ -34,13 +34,21 @@
 * @group-content ../../ApexDocContent/Contacts.htm
 * @description Populates default phone field according to user preferences and/or enforces use of 'Preferred Phone'.
 */
-public class CON_PreferredPhone_TDTM extends TDTM_Runnable{
+public class CON_PreferredPhone_TDTM extends TDTM_Runnable {
 /*******************************************************************************************************
     * @description Populates default phone field according to user preferences and/or enforces use of 'Preferred Phone'
+    * Exits early if the "Enable New Preferred Phone Sync" custom setting is not enabled.
     * @return dmlWrapper
     ********************************************************************************************************/
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        // Is the new Preferred Phone functionality enabled? If not, exit immediately.
+        Boolean isNewPreferredPhoneFunctionalityEnabled = (UTIL_CustomSettingsFacade.getSettings().Enable_New_Preferred_Phone_Sync__c == true);
+
+        if (!isNewPreferredPhoneFunctionalityEnabled) {
+            return null;
+        }
              
         if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PreferredPhone_TDTM) 
             && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) && newlist != null) {

--- a/src/classes/CON_PreferredPhone_TEST.cls
+++ b/src/classes/CON_PreferredPhone_TEST.cls
@@ -36,26 +36,24 @@
 */
 @isTest
 private class CON_PreferredPhone_TEST {
-    
-    @testSetup
-    static void dataSetup() {
-        
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
+
+    private static Hierarchy_Settings__c enablePreferredPhone() {
+        return UTIL_CustomSettingsFacade.getSettingsForTests(
+            new Hierarchy_Settings__c(
+                Disable_Preferred_Phone_Enforcement__c = false, 
+                Enable_New_Preferred_Phone_Sync__c = true
+            )
         );
-        
-        // Simulate a user adding their own handler, should not need User_Managed__c to be true
-        Trigger_Handler__c newHandler = new Trigger_Handler__c(
-            Active__c = true,
-            Asynchronous__c = false,
-            Class__c = 'CON_PreferredPhone_TDTM',
-            Load_Order__c = 0.2,
-            Object__c = 'Contact',
-            Trigger_Action__c = 'BeforeInsert;BeforeUpdate'
-        );
-        insert newHandler;
     }
-  
+
+    private static Hierarchy_Settings__c disablePreferredPhone() {
+        return UTIL_CustomSettingsFacade.getSettingsForTests(
+            new Hierarchy_Settings__c(
+                Disable_Preferred_Phone_Enforcement__c = true, 
+                Enable_New_Preferred_Phone_Sync__c = false
+            )
+        );
+    }
   
     /* When Preferred Phone is blank and the count of valued phone fields is one
         update Preferred Phone to label of valued phone and copy the value to 
@@ -63,6 +61,7 @@ private class CON_PreferredPhone_TEST {
     */
     @isTest 
     static void testSinglePhoneSmartSet() {
+        enablePreferredPhone();
 
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
@@ -84,7 +83,8 @@ private class CON_PreferredPhone_TEST {
        to Other and update Other Phone to the value of Standard Phone.
     */
     @isTest 
-    static void testUpdatePrefPhoneTOther() {
+    static void testUpdatePrefPhoneToOther() {
+        enablePreferredPhone();
 
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
@@ -99,7 +99,6 @@ private class CON_PreferredPhone_TEST {
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone, PreferredPhone__c FROM Contact WHERE Id =: newCont.Id];
         
-         
         System.assertEquals('0000000000', newContAfterList.OtherPhone);
         System.assertEquals('Other', newContAfterList.PreferredPhone__c);
     }
@@ -107,24 +106,24 @@ private class CON_PreferredPhone_TEST {
     /* Clear the value in Standard Phone when the other valued Phone is cleared */
     @isTest 
     static void testClearPhoneValue() {
+        enablePreferredPhone();
 
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
             Phone = '111111111',
-            otherPhone = '0000000000'
+            OtherPhone = '0000000000'
         );
         insert newCont;
         
-        Contact newContAfter = [SELECT Id, FirstName, LastName, Name, Phone, otherPhone, PreferredPhone__c  FROM Contact];
+        Contact newContAfter = [SELECT Id, FirstName, LastName, Name, Phone, OtherPhone, PreferredPhone__c  FROM Contact];
         Test.startTest();
-            newContAfter.otherPhone = '';
+            newContAfter.OtherPhone = '';
             newContAfter.PreferredPhone__c = '';
             update newContAfter;
         Test.stopTest();
 
-        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone FROM Contact];
-        
+        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, OtherPhone , Phone FROM Contact];
         
         System.assertEquals(null, newContAfterList.Phone);
 
@@ -134,13 +133,14 @@ private class CON_PreferredPhone_TEST {
     the label of another Phone.  */
     @isTest 
     static void testOnClearOther() {
-                 
+        enablePreferredPhone();
+
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
             WorkPhone__c  = '111111111',
             PreferredPhone__c = 'Work',
-            OtherPhone  = '0000000000'
+            OtherPhone = '0000000000'
         );
         insert newCont;
         
@@ -162,29 +162,22 @@ private class CON_PreferredPhone_TEST {
      Update Preferred Phone to 'Phone (Standard)' when standard Phone's value is not same as 
      any other Phone values and when Preferred Phone is Blank and the Context is batch.
     */
-
     @isTest 
     static void testBatchPhoneNull() {
-         
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = True)
-            );
+        disablePreferredPhone();
         
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
             Phone  = '111111111',
-            OtherPhone  = '0000000000'
+            OtherPhone = '0000000000'
         );
         insert newCont;
         
-        
         Test.startTest();
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
-            );
+            enablePreferredPhone();
             CON_Email_BATCH batch = new CON_Email_BATCH(null);
-             Database.executeBatch(batch);
+            Database.executeBatch(batch);
         Test.stopTest();
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, PreferredPhone__c FROM Contact];
@@ -197,29 +190,22 @@ private class CON_PreferredPhone_TEST {
      Updates Preferred Phone to the label of the Phone field that has a value which is not same as 
      standard phone
     */
-
     @isTest 
     static void testBatchOther() {
-         
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = True)
-            );
+        disablePreferredPhone();
         
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
             Phone  = '111111111',
-            OtherPhone  = '111111111'
+            OtherPhone = '111111111'
         );
         insert newCont;
         
-        
         Test.startTest();
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
-            );
+            enablePreferredPhone();
             CON_Email_BATCH batch = new CON_Email_BATCH(null);
-             Database.executeBatch(batch);
+            Database.executeBatch(batch);
         Test.stopTest();
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, PreferredPhone__c  FROM Contact];
@@ -231,63 +217,67 @@ private class CON_PreferredPhone_TEST {
     /*  Validation when there are more than one phone fields but not Preferred Phone */
     @isTest 
     static void testErrorPrefBlank() {
-        
+        enablePreferredPhone();
+
         try {
             Contact newCont = new Contact(
                 FirstName = 'JohnnyTest1',
                 LastName = 'JohnnyTest',
                 WorkPhone__c  = '111111111',
-                OtherPhone  = '0000000000'
-        );
+                OtherPhone = '0000000000'
+            );
+            
             Test.startTest();
             insert newCont;
-            
             Test.stopTest();
             
-        }catch(Exception error) {
+        } catch(Exception error) {
              System.assert(error.getMessage().contains(Label.PreferredPhoneRequiredError));
 
       } 
         
     } 
    
-     /* Validation when Preferred Phone is selected but no other Phone Fields have a value */
+    /* Validation when Preferred Phone is selected but no other Phone Fields have a value */
     @isTest 
     static void testPrefPhoneNotBlank() {
-        
+        enablePreferredPhone();
+
         try {
             Contact newCont = new Contact(
                 FirstName = 'JohnnyTest1',
                 LastName = 'JohnnyTest',
                 PreferredPhone__c  = 'Work'
-        );
+            );
+            
             Test.startTest();
             insert newCont;
-            
             Test.stopTest();
             
-        }catch(Exception error) {
+        } catch(Exception error) {
              System.assert(error.getMessage().contains(Label.PreferredPhoneMatchNotNull));
 
       } 
-    }     
+    }
+
     /* Validation when Preferred Phone label doesn't match any of the other fields */
     @isTest 
     static void testPrefDiffValue() {
-        
+        enablePreferredPhone();
+
         try {
             Contact newCont = new Contact(
                 FirstName = 'JohnnyTest1',
                 LastName = 'JohnnyTest',
                 WorkPhone__c  = '111111111',
                 PreferredPhone__c  = 'ForTestingPurposes'
-        );
+            );
+
             Test.startTest();
             insert newCont;
-            
             Test.stopTest();
             
-        }catch(Exception error) {
+        } catch(Exception error) {
              System.assert(error.getMessage().contains(Label.PreferredPhoneMatchMustExist));
         }     
     } 
@@ -297,31 +287,23 @@ private class CON_PreferredPhone_TEST {
     */
     @isTest 
     static void testBatchWPreferredPhoneSelection() {
-         
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = True)
-            );
-            
+        disablePreferredPhone();
         
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
-            OtherPhone  = '0000000000',
-            homePhone = '111111111'
+            OtherPhone = '0000000000',
+            HomePhone = '111111111'
         );
         insert newCont;
         
-        
         Test.startTest();
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
-            );
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Preferred_Phone_Selection__c = 'homePhone')
-            );    
+            Hierarchy_Settings__c settings = enablePreferredPhone();
+            settings.Preferred_Phone_Selection__c = 'homePhone';
+            UTIL_CustomSettingsFacade.getSettingsForTests(settings);    
         
             CON_Email_BATCH batch = new CON_Email_BATCH(null);
-             Database.executeBatch(batch);
+            Database.executeBatch(batch);
         Test.stopTest();
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, Phone, PreferredPhone__c  FROM Contact];
@@ -332,34 +314,25 @@ private class CON_PreferredPhone_TEST {
     }   
 
     /*
-    Update Preferred Phone  and Phone when Phone Clean Up batch job is run with no selection done in EDA Settings. 
+    Update Preferred Phone and Phone when Phone Clean Up batch job is run with no selection done in EDA Settings. 
     */
-
     @isTest 
     static void testBatchWNoPreferredPhoneSelection() {
-         
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = True)
-            );
-            
+        disablePreferredPhone();
         
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
-            OtherPhone  = '0000000000',
-            homePhone = '111111111'
+            OtherPhone = '0000000000',
+            HomePhone = '111111111'
         );
         insert newCont;
         
         
         Test.startTest();
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
-            );
-                
-        
+            enablePreferredPhone();
             CON_Email_BATCH batch = new CON_Email_BATCH(null);
-             Database.executeBatch(batch);
+            Database.executeBatch(batch);
         Test.stopTest();
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, Phone, PreferredPhone__c  FROM Contact];
@@ -376,32 +349,23 @@ private class CON_PreferredPhone_TEST {
 
     @isTest 
     static void testBatchWPreferredPhoneSelectionMisMatch() {
-         
-        UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = True)
-            );
-            
-        
+        disablePreferredPhone();
+
         Contact newCont = new Contact(
             FirstName = 'JohnnyTest1',
             LastName = 'JohnnyTest',
-            OtherPhone  = '0000000000',
+            OtherPhone = '0000000000',
             MobilePhone  = '0000000000'
         );
         insert newCont;
         
-        
         Test.startTest();
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Disable_Preferred_Phone_Enforcement__c = False)
-            );
-                
-            UTIL_CustomSettingsFacade.getSettingsForTests(
-            new Hierarchy_Settings__c(Preferred_Phone_Selection__c = 'homePhone')
-            );
+            Hierarchy_Settings__c settings = enablePreferredPhone();
+            settings.Preferred_Phone_Selection__c = 'homePhone';
+            UTIL_CustomSettingsFacade.getSettingsForTests(settings);  
             
             CON_Email_BATCH batch = new CON_Email_BATCH(null);
-             Database.executeBatch(batch);
+            Database.executeBatch(batch);
         Test.stopTest();
 
         Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, Phone, PreferredPhone__c  FROM Contact];
@@ -415,21 +379,18 @@ private class CON_PreferredPhone_TEST {
      Copy value of Standard Phone Field to Other when Preferred Phone is Null, Standard Phone is not null and
      all other phones are null.
     */
-
     @isTest 
     static void testCopyStdPhoneToOther() {
-         
-               
+        enablePreferredPhone();
+
         Test.startTest();
             Contact newCont = new Contact(
-            FirstName = 'JohnnyTest1',
-            LastName = 'JohnnyTest',
-            Phone  = '0000000000'
+                FirstName = 'JohnnyTest1',
+                LastName = 'JohnnyTest',
+                Phone  = '0000000000'
+            );
         
-        );
-        
-        
-        insert newCont;
+            insert newCont;
  
         Test.stopTest();
 
@@ -445,27 +406,27 @@ private class CON_PreferredPhone_TEST {
     */
     @isTest 
     static void testUpdatePrefPhoneTOtherBulk() {
-        
-        List<contact> contactsToInsert = new List<contact>();
-        for(Integer i = 0; i < 100; i++) {
+        enablePreferredPhone();
+
+        List<Contact> contactsToInsert = new List<Contact>();
+        for (Integer i = 0; i < 100; i++) {
             Contact a = new Contact(FirstName='TestAccount' + i, LastName = 'JohnnyTest' + i );
             contactsToInsert.add(a);
         }
         insert contactsToInsert;
     
         Test.startTest();
-        for (contact each: contactsToInsert) {
-            each.Phone = '0000000000';
-        }
+            for (Contact each : contactsToInsert) {
+                each.Phone = '0000000000';
+            }
             update contactsToInsert;
         Test.stopTest();
 
-        List<contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone, PreferredPhone__c FROM Contact];
+        List<Contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone, PreferredPhone__c FROM Contact];
         
-        for (contact each: newContAfterList) { 
+        for (Contact each : newContAfterList) { 
             System.assertEquals('0000000000', each.OtherPhone);
             System.assertEquals('Other', each.PreferredPhone__c);
         }
     }
-  
 }

--- a/src/classes/CON_PreferredPhone_TEST.cls
+++ b/src/classes/CON_PreferredPhone_TEST.cls
@@ -97,7 +97,7 @@ private class CON_PreferredPhone_TEST {
             update newCont;
         Test.stopTest();
 
-        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone, PreferredPhone__c FROM Contact WHERE Id =: newCont.Id];
+        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, OtherPhone, Phone, PreferredPhone__c FROM Contact WHERE Id =: newCont.Id];
         
         System.assertEquals('0000000000', newContAfterList.OtherPhone);
         System.assertEquals('Other', newContAfterList.PreferredPhone__c);
@@ -123,7 +123,7 @@ private class CON_PreferredPhone_TEST {
             update newContAfter;
         Test.stopTest();
 
-        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, OtherPhone , Phone FROM Contact];
+        Contact newContAfterList = [SELECT Id, FirstName, LastName, Name, OtherPhone, Phone FROM Contact];
         
         System.assertEquals(null, newContAfterList.Phone);
 
@@ -422,7 +422,7 @@ private class CON_PreferredPhone_TEST {
             update contactsToInsert;
         Test.stopTest();
 
-        List<Contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, otherPhone , Phone, PreferredPhone__c FROM Contact];
+        List<Contact> newContAfterList = [SELECT Id, FirstName, LastName, Name, OtherPhone, Phone, PreferredPhone__c FROM Contact];
         
         for (Contact each : newContAfterList) { 
             System.assertEquals('0000000000', each.OtherPhone);

--- a/src/classes/CON_Preferred_TDTM.cls
+++ b/src/classes/CON_Preferred_TDTM.cls
@@ -49,7 +49,8 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
             // While this logic is not performing any DML currently, the recursion flag is utilized here to be ready for any future logic changes.
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_Preferred_TDTM, true);
             
-            List<Trigger_Handler__c> preferredPhoneOnOff = [SELECT Active__c FROM Trigger_Handler__c WHERE Class__c = 'CON_PreferredPhone_TDTM'];
+            // Is the new Preferred Phone functionality enabled?
+            Boolean isNewPreferredPhoneFunctionalityEnabled = (UTIL_CustomSettingsFacade.getSettings().Enable_New_Preferred_Phone_Sync__c == true);
 
             for(SObject so : newlist) {
                 Contact contact = (Contact)so;
@@ -57,8 +58,8 @@ public class CON_Preferred_TDTM extends TDTM_Runnable {
                 // Process the Prefered Email
                 CON_Email.processPreferredEmail(contact, oldlist);
                 
-                // Process the Preferred Phone.
-                if(!String.isBlank(contact.PreferredPhone__c) && (preferredPhoneOnOff == null || preferredPhoneOnOff.size() == 0 || preferredPhoneOnOff[0].Active__c == False)) {
+                // Process the Preferred Phone if there's a Preferred Phone value set and the new Preferred Phone functionality is disabled.
+                if(!String.isBlank(contact.PreferredPhone__c) && !isNewPreferredPhoneFunctionalityEnabled) {
                     if(contact.PreferredPhone__c == 'Home') {
                         contact.Phone = contact.HomePhone;
                     } else if(contact.PreferredPhone__c == 'Work') {

--- a/src/classes/CON_Preferred_TEST.cls
+++ b/src/classes/CON_Preferred_TEST.cls
@@ -39,19 +39,6 @@ public with sharing class CON_Preferred_TEST {
 
     @isTest
     public static void preferredEmailPhoneInsert() {
-    
-        Test.testInstall(new STG_InstallScript(), null);
-        List<trigger_handler__c> preferredPhoneHandler = [SELECT id, class__c, active__c FROM trigger_handler__c WHERE class__c = 'CON_PreferredPhone_TDTM' AND Object__c = 'Contact'];
-        
-        System.assertEquals(1,preferredPhoneHandler.size());
-        System.assertEquals(true, preferredPhoneHandler[0].active__c);
-      
-        if (preferredPhoneHandler != NULL && preferredPhoneHandler.size() > 0) {
-        
-            preferredPhoneHandler[0].active__c = false;
-            update preferredPhoneHandler[0];
-        
-        }
         
         Contact contact1 = new Contact(LastName = 'TestersonA', UniversityEmail__c = 'fake@test1.com', Preferred_Email__c = 'University', 
             HomePhone = '555-432-4433', PreferredPhone__c = 'Home');
@@ -93,16 +80,6 @@ public with sharing class CON_Preferred_TEST {
     
     @isTest
     public static void preferredEmailPhoneUpdate() {
-    
-        Test.testInstall(new STG_InstallScript(), null);
-        List<trigger_handler__c> preferredPhoneHandler = [SELECT id, name, active__c FROM trigger_handler__c WHERE class__c = 'CON_PreferredPhone_TDTM' AND Object__c = 'Contact'];
-        
-        if (preferredPhoneHandler != NULL && preferredPhoneHandler.size() > 0) {
-        
-            preferredPhoneHandler[0].active__c = false;
-            update preferredPhoneHandler[0];
-        
-        }
         
         // Preferred email is required to pass checks in preferred trigger
         Contact contact1 = new Contact(LastName = 'TestersonE', UniversityEmail__c = 'fake@test5.com', HomePhone = '555-432-4433',Preferred_Email__c = 'University');

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -52,6 +52,9 @@ global without sharing class STG_InstallScript implements InstallHandler {
             List<TDTM_Global_API.TdtmToken> defaultTokens = TDTM_Global_API.getDefaultTdtmConfig();
             TDTM_Global_API.setTdtmConfig(defaultTokens, 'hed');
 
+            // Enable new Preferred Phone sync functionality
+            enablePreferredPhoneSync();
+
             // Format existing contact email addresses
             CON_Email_BATCH contbatch = new CON_Email_BATCH(context);
             Database.executeBatch( contbatch );
@@ -77,14 +80,6 @@ global without sharing class STG_InstallScript implements InstallHandler {
             // Upgrade TDTM Configuration
             List<TDTM_Global_API.TdtmToken> defaultTokens = TDTM_Global_API.getDefaultTdtmConfig();
             TDTM_Global_API.setTdtmConfig(defaultTokens, 'hed');
-            
-            // Set CON_PreferredPhone_TDTM to false
-            List<Trigger_Handler__c> turnOffPreferredPhone = [SELECT Active__c FROM Trigger_Handler__c WHERE Class__c = 'CON_PreferredPhone_TDTM'];
-
-            if(turnOffPreferredPhone != NULL && turnOffPreferredPhone.size() != 0 && previousVersion.compareTo(new Version(1,82)) < 0) {
-                 turnOffPreferredPhone[0].Active__c = False;
-                 update turnOffPreferredPhone[0];
-            }
 
             // Submit telemetry data back to the LMO using Feature Management
             sendTelemetryData();
@@ -206,11 +201,10 @@ global without sharing class STG_InstallScript implements InstallHandler {
         }
     }
 
-     /*******************************************************************************************************
+    /*******************************************************************************************************
     * @description Disables Preferred Phone handling when upgrading to 1.82
     * @return void
     */
-    
     global static void disablePreferredPhoneEnforcement(Version previousVersion) {
         if(previousVersion != null && previousVersion.compareTo(new Version(1,82)) < 0) {
             UTIL_Debug.debug('***Upgrading to version 1.82');
@@ -220,6 +214,18 @@ global without sharing class STG_InstallScript implements InstallHandler {
             }
             upsert orgSettings;
         }
+    }
+
+    /*******************************************************************************************************
+    * @description Enabled Preferred Phone sync on initial installation.
+    * @return void
+    */
+    global static void enablePreferredPhoneSync() {
+        Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
+        if (orgSettings.Enable_New_Preferred_Phone_Sync__c == null || orgSettings.Enable_New_Preferred_Phone_Sync__c != true) {
+            orgSettings.Enable_New_Preferred_Phone_Sync__c = true;
+        }
+        upsert orgSettings;
     }
 
     /*******************************************************************************************************

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -65,6 +65,11 @@ public with sharing class STG_InstallScript_TEST {
         // Verify defaults are set on install
         Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
         System.assertEquals(Label.stgFluent, orgSettings.Default_Contact_Language_Fluency__c);
+        
+        System.assertEquals(true, orgSettings.Enable_New_Preferred_Phone_Sync__c,
+            'Expected the new Preferred Phone sync to be enabled on install.');
+        System.assertEquals(false, orgSettings.Disable_Preferred_Phone_Enforcement__c,
+            'Expected the Preferred Phone enforcement to be enabled on install.');
 
         // Making sure the Batch process ran successfully
         Contact cont2 = [SELECT Id, Name, Email, AlternateEmail__c, Preferred_Email__c FROM Contact WHERE Id =: cont.Id];
@@ -363,11 +368,11 @@ public with sharing class STG_InstallScript_TEST {
         Test.testInstall(new STG_InstallScript(), new Version(1,81), true);
         Test.stopTest();
 
-        List<Trigger_Handler__c> turnOffPreferredPhone = [SELECT Active__c FROM Trigger_Handler__c WHERE Class__c = 'CON_PreferredPhone_TDTM'];
         Hierarchy_Settings__c updatedSettings = UTIL_CustomSettingsFacade.getSettings();
         
-        System.assertEquals(True, updatedSettings.Disable_Preferred_Phone_Enforcement__c);
-        System.assertEquals(False, turnOffPreferredPhone[0].Active__c);
-
+        System.assertEquals(true, updatedSettings.Disable_Preferred_Phone_Enforcement__c,
+            'Expected the Preferred Phone enforcement to be disabled.');
+        System.assertEquals(false, updatedSettings.Enable_New_Preferred_Phone_Sync__c, 
+            'Expected the new Preferred Phone sync to be disabled.');
     }
 }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -141,6 +141,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Affl_ProgEnroll_Del_Status__c = mySettings.Affl_ProgEnroll_Del_Status__c;
         settings.Accounts_to_Delete__c =  mySettings.Accounts_to_Delete__c;
         settings.Enable_Course_Connections__c = mySettings.Enable_Course_Connections__c;
+        settings.Enable_New_Preferred_Phone_Sync__c = mySettings.Enable_New_Preferred_Phone_Sync__c;
         settings.Faculty_RecType__c = mySettings.Faculty_RecType__c;
         settings.Student_RecType__c = mySettings.Student_RecType__c;
         settings.Disable_Preferred_Email_Enforcement__c = mySettings.Disable_Preferred_Email_Enforcement__c;

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -984,6 +984,14 @@
         <value>Enable Course Connections:</value>
     </labels>
     <labels>
+        <fullName>stgEnablePreferredPhoneSync</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgEnablePreferredPhoneSync</shortDescription>
+        <value>Enable Preferred Phone sync:</value>
+    </labels>
+    <labels>
         <fullName>stgErrorNotiTo</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
@@ -1150,6 +1158,14 @@
         <protected>true</protected>
         <shortDescription>stgHelpContactPreferredPhone</shortDescription>
         <value>Do not require Contacts to have a Preferred Phone.</value>
+    </labels>
+    <labels>
+        <fullName>stgHelpContactPreferredPhoneSync</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgHelpContactPreferredPhoneSync</shortDescription>
+        <value>Turns on the Preferred Phone functionality that was released in EDA 1.82. This functionality replaces the Preferred Phone logic that was originally released in 2015. It syncs the field specified in the Preferred Phone field to the Contact&apos;s standard Phone field and validates that the field specified in Preferred Phone exists and has a value.</value>
     </labels>
     <labels>
         <fullName>stgHelpCopyQueuedEmailSent</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -989,7 +989,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>stgEnablePreferredPhoneSync</shortDescription>
-        <value>Enable Preferred Phone sync:</value>
+        <value>Enable Enhanced Preferred Phone Functionality:</value>
     </labels>
     <labels>
         <fullName>stgErrorNotiTo</fullName>
@@ -1165,7 +1165,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>stgHelpContactPreferredPhoneSync</shortDescription>
-        <value>Turns on the Preferred Phone functionality that was released in EDA 1.82. This functionality replaces the Preferred Phone logic that was originally released in 2015. It syncs the field specified in the Preferred Phone field to the Contact&apos;s standard Phone field and validates that the field specified in Preferred Phone exists and has a value.</value>
+        <value>Sync the Preferred Phone field to the Contact&apos;s standard Phone field and validate that the value in Preferred Phone exists and has a value.</value>
     </labels>
     <labels>
         <fullName>stgHelpCopyQueuedEmailSent</fullName>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -283,9 +283,9 @@
     <fields>
         <fullName>Enable_New_Preferred_Phone_Sync__c</fullName>
         <defaultValue>false</defaultValue>
-        <description>Turns on the Preferred Phone functionality that was released in EDA 1.82. This functionality replaces the Preferred Phone logic that was originally released in 2015. It syncs the field specified in the Preferred Phone field to the Contact&apos;s standard Phone field and validates that the field specified in Preferred Phone exists and has a value.</description>
+        <description>Turns on the Preferred Phone functionality that was released in EDA 1.82. This functionality syncs the Preferred Phone field to the Contact&apos;s standard Phone field and validate that the value in Preferred Phone exists and has a value.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Turns on the Preferred Phone functionality that was released in EDA 1.82.</inlineHelpText>
+        <inlineHelpText>Sync the Preferred Phone field to the Contact&apos;s standard Phone field and validate that the value in Preferred Phone exists and has a value.</inlineHelpText>
         <label>Enable New Preferred Phone Sync</label>
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -281,6 +281,16 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Enable_New_Preferred_Phone_Sync__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Turns on the Preferred Phone functionality that was released in EDA 1.82. This functionality replaces the Preferred Phone logic that was originally released in 2015. It syncs the field specified in the Preferred Phone field to the Contact&apos;s standard Phone field and validates that the field specified in Preferred Phone exists and has a value.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Turns on the Preferred Phone functionality that was released in EDA 1.82.</inlineHelpText>
+        <label>Enable New Preferred Phone Sync</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Error_Notifications_On__c</fullName>
         <defaultValue>false</defaultValue>
         <description>Flag that determines whether to send error notifications.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -405,6 +405,7 @@
         <members>Hierarchy_Settings__c.Disable_Preferred_Phone_Enforcement__c</members>
         <members>Hierarchy_Settings__c.Enable_Course_Connections__c</members>
         <members>Hierarchy_Settings__c.Enable_Debug__c</members>
+        <members>Hierarchy_Settings__c.Enable_New_Preferred_Phone_Sync__c</members>
         <members>Hierarchy_Settings__c.Error_Notifications_On__c</members>
         <members>Hierarchy_Settings__c.Error_Notifications_To__c</members>
         <members>Hierarchy_Settings__c.Faculty_RecType__c</members>
@@ -622,6 +623,7 @@
         <members>stgDisablePreferredEmailEnforcement</members>
         <members>stgDisablePreferredPhoneEnforcement</members>
         <members>stgEnableCourseConnectionsTitle</members>
+        <members>stgEnablePreferredPhoneSync</members>
         <members>stgErrorNotiTo</members>
         <members>stgErrorNotifRecipientsTitle</members>
         <members>stgEthnicityRaceBackfillContacts</members>
@@ -643,6 +645,7 @@
         <members>stgHelpContactAddrs</members>
         <members>stgHelpContactPreferredEmail</members>
         <members>stgHelpContactPreferredPhone</members>
+        <members>stgHelpContactPreferredPhoneSync</members>
         <members>stgHelpCopyQueuedEmailSent</members>
         <members>stgHelpCourseConnBackfillDescription</members>
         <members>stgHelpCoursesDataMigration</members>


### PR DESCRIPTION
# Critical Changes
When we released it in EDA 1.82, the Preferred Phone functionality was disabled by default for all existing customers. However, the EDA 1.83 push upgrade inadvertently activated the new Preferred Phone TDTM handler for all customers. This EDA 1.84 emergency release of the enhanced Preferred Phone functionality enables you to control the Preferred Phone TDTM handler with a new custom setting so you no longer need to update the TDTM class directly.

- If you are an existing EDA customer who enabled the Preferred Phone functionality when we released it in 1.82, re-enable the TDTM trigger by going to EDA Settings | Accounts and Contacts and checking the "Enable Enhanced Preferred Phone Functionality" checkbox.

- If you're installing in a new org, the enhanced Preferred Phone logic is enabled by default, so you don't need to change the new setting. However, we do recommend that you uncheck "Disable Preferred Phone enforcement" if you want to ensure that Contacts have a Preferred Phone value when more than one Phone field is specified on the Contact record.

# Changes
See "Critical Changes" above.

# Issues Closed
Fixes #941 

# New Metadata
New Custom Setting: `Hierarchy_Settings__c.Enable_New_Preferred_Phone_Sync__c`
New Custom Labels: `stgEnablePreferredPhoneSync` and `stgHelpContactPreferredPhoneSync`

# Deleted Metadata

# Testing Notes

1. Install EDA 1.81.
2. Upgrade to EDA 1.82. You will receive the new Preferred Phone functionality, disabled by default. The new Preferred Phone TDTM handler will also be disabled.
3. Upgrade to EDA 1.83. The Preferred Phone TDTM handler will be enabled on accident.
4. Upgrade to EDA 1.84 (which will include this fix). The Preferred Phone TDTM handler is still enabled, but it will now be controlled by the new "Enable Enhanced Preferred Phone Functionality" checkbox in the EDA Settings UI. This will be disabled by default for all existing customers and enabled by default for all new customers.