### PR TITLE
Change the incorrect Course Offering related list label to "Course Offerings"

### DIFF
--- a/src/objectTranslations/Course_Offering__c-en_US.objectTranslation
+++ b/src/objectTranslations/Course_Offering__c-en_US.objectTranslation
@@ -48,7 +48,7 @@
     <fields>
         <label><!-- Time Block --></label>
         <name>Time_Block__c</name>
-        <relationshipLabel><!-- Time Blocks --></relationshipLabel>
+        <relationshipLabel><!-- Course Offerings --></relationshipLabel>
     </fields>
     <layouts>
         <layout>HEDA Course Offering Layout</layout>

--- a/src/objects/Course_Offering__c.object
+++ b/src/objects/Course_Offering__c.object
@@ -157,7 +157,7 @@
         <externalId>false</externalId>
         <label>Time Block</label>
         <referenceTo>Time_Block__c</referenceTo>
-        <relationshipLabel>Time Blocks</relationshipLabel>
+        <relationshipLabel>Course Offerings</relationshipLabel>
         <relationshipName>Time_Blocks</relationshipName>
         <required>false</required>
         <trackTrending>false</trackTrending>


### PR DESCRIPTION
# Critical Changes

# Changes
The Course Offerings related list on the Time Block record is now correctly labeled "Course Offerings."

# Issues Closed
Fixes #922 

# New Metadata

# Deleted Metadata

# Testing Notes
1. Create a new Course Offering and specify a Time Block
2. Navigate to the Time Block
3. Click on the Related List tab
4. You will see a list of "Time Blocks" that are actually Course Offerings (you may need to add it to the Time Block page layout)