### PR TITLE
[EDA]: Ensure that Account Naming for HouseHold is in Alphabetical Order

### DIFF
--- a/src/classes/UTIL_ACCT_Naming.cls
+++ b/src/classes/UTIL_ACCT_Naming.cls
@@ -408,7 +408,7 @@ public class UTIL_ACCT_Naming {
         Pattern MyPattern = Pattern.compile(regexPattern);
         Matcher MyMatcher = MyPattern.matcher(acctNameFormat);
 
-        //Checks {!{FirstName}}
+        //Checks {!{!FirstName}}
         String regexPatternDoubleToken = '\\{![^\\}]*\\{!.*\\}[^\\{!]*\\}';
         Pattern MyPatternDoubleTokenCheck = Pattern.compile(regexPatternDoubleToken);
         Matcher MyMatcherDoubleTokenCheck = MyPatternDoubleTokenCheck.matcher(acctNameFormat);
@@ -550,7 +550,6 @@ public class UTIL_ACCT_Naming {
         }
 
         //Handles processing fullNameSpec
-        System.debug('processNames checkFullNameSpec -->' + ns.fullNameSpec);
         String acctName = stringConNames(cons[i], ns.fullNameSpec);
         acctName = acctName.replace('FirstNameSpec', firstName);
 
@@ -569,9 +568,7 @@ public class UTIL_ACCT_Naming {
     * return String
     */
     private static String stringConNames(Contact con, String fullNameSpec) {
-        System.debug('stringConNames Method -->' + fullNameSpec);
         String currentFormatValue = fullNameSpec;
-        System.debug('stringConNames currentFormatValue -->' + currentFormatValue);
 
         // First, instantiate a new Pattern object looking for {...} without any nested {'s.
         Pattern MyPattern = Pattern.compile('\\{![^\\{!]*\\}');
@@ -582,16 +579,13 @@ public class UTIL_ACCT_Naming {
         while (MyMatcher.find()) {
             //Get the fieldname without the {}'s, ie. {!LastName} -> LastName
             String strField = fullNameSpec.substring(MyMatcher.start() + chLToken.length(), MyMatcher.end()-chRToken.length());
-            System.debug('stringConNames strField -->' + strField);
 
             //Separate cross object references, ie. (LastName)
             List<String> splitField = (strField.split('\\.',0));
-            System.debug('stringConNames splitField -->' + splitField);
 
             //Remove the field name itself to only include parent object references. ie.  {!LastName} -> LastName
             String fieldName = splitField[splitField.size()-1].trim();
             splitField.remove(splitField.size()-1);
-            System.debug('stringConNames fieldNameCheck -->' + fieldName);
 
             //Use the correct sObject
             sObject thisObj;
@@ -601,7 +595,6 @@ public class UTIL_ACCT_Naming {
             } else {
                 thisObj = con;
             }
-            System.debug('stringConNames sObject -->' + thisObj);
 
             //Traverse parent relationships until the last one
             for (String parentObj : splitField) {
@@ -609,14 +602,11 @@ public class UTIL_ACCT_Naming {
                     thisObj = thisObj.getsObject(parentObj);
                 }
             }
-			System.debug('stringConNames sObject2 -->' + thisObj);
 
             String val;
             if (thisObj != null) {
                 //Assigns the actual value of the Salutation/FN/LN to val
-                System.debug('stringConNames val -->' + val);
                 val = String.valueOf(thisObj.get(fieldName));
-                System.debug('stringConNames valAfter -->' + val);
             }
 
             //Add back the {}'s for string substitution

--- a/src/classes/UTIL_ACCT_Naming.cls
+++ b/src/classes/UTIL_ACCT_Naming.cls
@@ -135,7 +135,9 @@ public class UTIL_ACCT_Naming {
         }
 
         if (defaultRecTypeId == hhAccountRecordTypeId) {
-            dynamicSoql += 'Phone, Fax FROM Contacts WHERE Exclude_from_Household_Name__c != true)';
+            dynamicSoql += 'Phone, Fax FROM Contacts WHERE Exclude_from_Household_Name__c != true ORDER BY LastName, FirstName)';
+        } else {
+            dynamicSoql += 'FROM Contacts ORDER BY LastName, FirstName)';
         }
 
         dynamicSoql += 'FROM Account WHERE Id IN :accIdsToRename';
@@ -372,7 +374,6 @@ public class UTIL_ACCT_Naming {
             string strField = firstNameSpec.substring(MyMatcher.start() + chLToken.length(), MyMatcher.end()-chRToken.length());
             nameFormat.add(strField.trim());
         }
-
         return nameFormat;
     }
 
@@ -400,6 +401,8 @@ public class UTIL_ACCT_Naming {
     * @return String.
     */
     private static String cleanFirstNameFormat(String acctNameFormat) {
+        String firstNameFormat = '';
+
         //Checks {!FirstName}
         String regexPattern = '(?:^|\\W)FirstName(?:$|\\W)';
         Pattern MyPattern = Pattern.compile(regexPattern);
@@ -410,16 +413,18 @@ public class UTIL_ACCT_Naming {
         Pattern MyPatternDoubleTokenCheck = Pattern.compile(regexPatternDoubleToken);
         Matcher MyMatcherDoubleTokenCheck = MyPatternDoubleTokenCheck.matcher(acctNameFormat);
 
-        //Set setFNSpec if it finds {!{FirstName}}
         if (MyMatcherDoubleTokenCheck.find()) {
+            //If it finds {!{!FirstName}}
             setFNSpec = true;
+            firstNameFormat = acctNameFormat.subString(MyMatcherDoubleTokenCheck.start(), MyMatcherDoubleTokenCheck.end());
+        } else if (MyMatcher.find()) {
+            //If it finds  {!FirstName}
+            firstNameFormat = acctNameFormat.subString(MyMatcher.start()-1, MyMatcher.end());
+        } else {
+            firstNameFormat = '';
         }
 
-        if (MyMatcher.find()) {
-            return acctNameFormat.subString(MyMatcher.start()-1, MyMatcher.end());
-        } else {
-            return '';
-        }
+        return firstNameFormat;
     }
 
     /*******************************************************************************************************
@@ -545,6 +550,7 @@ public class UTIL_ACCT_Naming {
         }
 
         //Handles processing fullNameSpec
+        System.debug('processNames checkFullNameSpec -->' + ns.fullNameSpec);
         String acctName = stringConNames(cons[i], ns.fullNameSpec);
         acctName = acctName.replace('FirstNameSpec', firstName);
 
@@ -563,7 +569,9 @@ public class UTIL_ACCT_Naming {
     * return String
     */
     private static String stringConNames(Contact con, String fullNameSpec) {
+        System.debug('stringConNames Method -->' + fullNameSpec);
         String currentFormatValue = fullNameSpec;
+        System.debug('stringConNames currentFormatValue -->' + currentFormatValue);
 
         // First, instantiate a new Pattern object looking for {...} without any nested {'s.
         Pattern MyPattern = Pattern.compile('\\{![^\\{!]*\\}');
@@ -574,13 +582,16 @@ public class UTIL_ACCT_Naming {
         while (MyMatcher.find()) {
             //Get the fieldname without the {}'s, ie. {!LastName} -> LastName
             String strField = fullNameSpec.substring(MyMatcher.start() + chLToken.length(), MyMatcher.end()-chRToken.length());
+            System.debug('stringConNames strField -->' + strField);
 
             //Separate cross object references, ie. (LastName)
             List<String> splitField = (strField.split('\\.',0));
+            System.debug('stringConNames splitField -->' + splitField);
 
             //Remove the field name itself to only include parent object references. ie.  {!LastName} -> LastName
             String fieldName = splitField[splitField.size()-1].trim();
             splitField.remove(splitField.size()-1);
+            System.debug('stringConNames fieldNameCheck -->' + fieldName);
 
             //Use the correct sObject
             sObject thisObj;
@@ -590,6 +601,7 @@ public class UTIL_ACCT_Naming {
             } else {
                 thisObj = con;
             }
+            System.debug('stringConNames sObject -->' + thisObj);
 
             //Traverse parent relationships until the last one
             for (String parentObj : splitField) {
@@ -597,11 +609,14 @@ public class UTIL_ACCT_Naming {
                     thisObj = thisObj.getsObject(parentObj);
                 }
             }
+			System.debug('stringConNames sObject2 -->' + thisObj);
 
             String val;
             if (thisObj != null) {
                 //Assigns the actual value of the Salutation/FN/LN to val
+                System.debug('stringConNames val -->' + val);
                 val = String.valueOf(thisObj.get(fieldName));
+                System.debug('stringConNames valAfter -->' + val);
             }
 
             //Add back the {}'s for string substitution


### PR DESCRIPTION
# Critical Changes

# Changes
We have fixed the issue with the inconsistent Account naming in alphabetical order. 

# Issues Closed
Closes #966

# New Metadata

# Deleted Metadata

# Testing Notes
