### PR TITLE
W-037283: Course Connection "Contact" Field Description should match the "Final Description" in Spec Doc

### DIFF
--- a/src/objects/Course_Enrollment__c.object
+++ b/src/objects/Course_Enrollment__c.object
@@ -97,9 +97,9 @@
     <fields>
         <fullName>Contact__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <description>The Contact connected to the Course Offering, as either a student or faculty member.</description>
+        <description>The Contact connected to the Course Offering, for example a student or faculty member.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The Contact connected to the Course Offering, as either a student or faculty member.</inlineHelpText>
+        <inlineHelpText>The Contact connected to the Course Offering, for example a student or faculty member.</inlineHelpText>
         <label>Contact</label>
         <referenceTo>Contact</referenceTo>
         <relationshipLabel>Course Connections</relationshipLabel>


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated the description and help text for the Contact lookup field on Course Connection. 

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
