### PR TITLE
Add trialforce template org config

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -233,6 +233,8 @@ orgs:
         prerelease_namespaced:
             config_file: orgs/prerelease.json
             namespaced: True
+        trial:
+            config_file: orgs/trial.json
 
 plans:
     install:

--- a/orgs/trial.json
+++ b/orgs/trial.json
@@ -1,0 +1,12 @@
+{
+  "orgName": "EDA - Trial Org",
+  "template": "0TT1Q000004XHA5",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    }
+  }
+}


### PR DESCRIPTION
----
This PR adds a new org config `trial` that will create a scratch org based upon the current production trial template.
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

``` shellsession
$ cci org browser trial
```