### PR TITLE
W-037217 - Re-enable Case Trigger

### DIFF
--- a/src/triggers/TDTM_Case.trigger
+++ b/src/triggers/TDTM_Case.trigger
@@ -30,7 +30,6 @@
 trigger TDTM_Case on Case (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    //Commenting out for now to prevent TDTM class in SAL from running twice.
-    //TDTM_Global_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-    //    Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Case);
+    TDTM_Global_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Case);
 }


### PR DESCRIPTION
# Critical Changes

# Changes
- We've added a trigger handler on Case. For more information, go [here](https://github.com/SalesforceFoundation/EDA/blob/master/src/triggers/TDTM_Case.trigger). If you already have a trigger for Case that calls the TDTM handler and TDTM classes without preventing re-entrancy for these objects, remove your trigger or the classes will get called twice.
# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
