### PR TITLE
Fix analytics template preflight check

### DIFF
--- a/tasks/check_einstein.py
+++ b/tasks/check_einstein.py
@@ -13,7 +13,8 @@ class CheckPermSetLicenses(BaseSalesforceApiTask):
     def _run_task(self):
         query = self._get_query()
         result = self.tooling.query(query)
-        return result["size"] > 0
+        if result["size"] > 0:
+            self.return_values["has_einstein_perms"] = True
 
     def _get_query(self):
         where_targets = [f"'{name}'" for name in self.options["permission_sets"]]


### PR DESCRIPTION
Returning `True` directly from `_run_task` didn't work.

----

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes