### PR TITLE
[EDA]: Allow Customers the Ability to Backfill Missing Affiliation on Existing Student Course Connection

### DIFF
--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
@@ -1,3 +1,14 @@
+<!--
+  @File Name          : STG_CMP_CourseConnections.cmp
+  @Description        : 
+  @Author             : ChangeMeIn@UserSettingsUnder.SFDoc
+  @Group              : 
+  @Last Modified By   : ChangeMeIn@UserSettingsUnder.SFDoc
+  @Last Modified On   : 11/18/2019, 11:47:59 AM
+  @Modification Log   : 
+  Ver       Date            Author      		    Modification
+  1.0    11/18/2019   ChangeMeIn@UserSettingsUnder.SFDoc     Initial Version
+-->
 <aura:component extends="c:STG_CMP_Base" controller="STG_CourseConnections">
 
   <aura:attribute name="courseConnectionRecTypes" type="Map" />
@@ -93,7 +104,7 @@
           <div class="slds-col slds-size--1-of-1">
             <ui:outputText value="{!$Label.c.stgHelpDefaultFacultyType}" class="slds-text-body--small" />
           </div>
-          
+
           <!--KIM UPDATE-->
           <div class="slds-col slds-grid slds-m-top--medium">
         	<div class="slds-col slds-size--1-of-2">
@@ -101,9 +112,9 @@
                 <div class="slds-col slds-size--1-of-1">
             		<ui:outputText value="{!$Label.c.stgHelpAutoPopulateAffiliation}" class="slds-text-body--small" />
           		</div>
-                
+
             </div>
-            
+
             <div class="slds-col slds-size--1-of-2">
             	<label class="slds-checkbox">
               		<aura:if isTrue="{!v.isView}">
@@ -116,11 +127,11 @@
                   		<span class="slds-checkbox--faux"></span>
               		</aura:set>
               		</aura:if>
-            	</label>             
+            	</label>
           	</div>
-            
+
           </div>
-          
+
       </div>
     </div>
 
@@ -137,19 +148,19 @@
           </div>
         </div>
       </span>
-        
+
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
           <ui:outputText value="{!$Label.c.stgTitleCourseConnectionBackfill}" class="slds-text-body--small" />
         </div>
       </div>
-        
+
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
           <ui:outputText value="{!$Label.c.stgHelpCourseConnBackfillDescription}" class="slds-text-body--small" />
         </div>
       </div>
-        
+
       <div class="slds-grid slds-grid--align-center">
         <div>
           <label class="slds-checkbox">
@@ -160,45 +171,45 @@
           </label>
         </div>
       </div>
-        
+
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">
         <div>
           <ui:button class="slds-button slds-button--neutral settings-edit-bttn" disabled="{!or(not(v.allowBackfill), v.backfillStarted)}" label="{!$Label.c.stgBtnRunBackfill}" press="{!c.startBackfill}"/>
         </div>
       </div>
-        
+
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">
         <div>
           <ui:outputText value="{!v.startBackfillMessage}" class="slds-text-body--small" />
         </div>
       </div>
-        
+
       <hr/>
-        
+
       <div class="slds-grid slds-wrap">
 		<div class="slds-col slds-size--1-of-2">
-                {!$Label.c.stgAffliationBackfilTitle}
+                {!$Label.c.stgAffiliationBackfillTitle}
                 <div class="slds-col slds-size--1-of-1">
             		<ui:outputText value="{!$Label.c.stgAffiliationBackfillDesc}" class="slds-text-body--small" />
           		</div>
          </div>
-       	
+
          <div class="slds-grid slds-grid--align-center slds-m-top--medium">
                	<lightning:button
-                                  label="Backfill Missing Affiliation" 
+                                  label="Backfill Missing Affiliation"
                                   title="backfillAffiliation"
                                   onclick="{!c.handleAffiliationBackfill}"/>
          </div>
-          
+
        	 <div class="slds-grid slds-grid--align-bottom slds-m-top--medium">
         	<div>
           		<ui:outputText value="{!v.startBackfillMessageForAffiliation}" class="slds-text-body--small" />
         	</div>
       	 </div>
       </div>
-      
-        
+
+
     </div>
-      
+
   </div>
 </aura:component>

--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp
@@ -1,14 +1,3 @@
-<!--
-  @File Name          : STG_CMP_CourseConnections.cmp
-  @Description        : 
-  @Author             : ChangeMeIn@UserSettingsUnder.SFDoc
-  @Group              : 
-  @Last Modified By   : ChangeMeIn@UserSettingsUnder.SFDoc
-  @Last Modified On   : 11/15/2019, 11:57:38 AM
-  @Modification Log   : 
-  Ver       Date            Author      		    Modification
-  1.0    11/15/2019   ChangeMeIn@UserSettingsUnder.SFDoc     Initial Version
--->
 <aura:component extends="c:STG_CMP_Base" controller="STG_CourseConnections">
 
   <aura:attribute name="courseConnectionRecTypes" type="Map" />
@@ -19,6 +8,7 @@
   <aura:attribute name="allowBackfill" type="Boolean" default="false" />
   <aura:attribute name="backfillStarted" type="Boolean" default="false" />
   <aura:attribute name="startBackfillMessage" type="String" default="" />
+  <aura:attribute name="startBackfillMessageForAffiliation" type="String" default=""/>
 
   <div id="relTabs" class="slds-tabs--scoped">
     <ul class="slds-tabs--scoped__nav" role="tablist">
@@ -103,17 +93,17 @@
           <div class="slds-col slds-size--1-of-1">
             <ui:outputText value="{!$Label.c.stgHelpDefaultFacultyType}" class="slds-text-body--small" />
           </div>
-
-
+          
+          <!--KIM UPDATE-->
           <div class="slds-col slds-grid slds-m-top--medium">
         	<div class="slds-col slds-size--1-of-2">
                 {!$Label.c.stgAutoPopulateAffiliationTitle}
                 <div class="slds-col slds-size--1-of-1">
             		<ui:outputText value="{!$Label.c.stgHelpAutoPopulateAffiliation}" class="slds-text-body--small" />
           		</div>
-
+                
             </div>
-
+            
             <div class="slds-col slds-size--1-of-2">
             	<label class="slds-checkbox">
               		<aura:if isTrue="{!v.isView}">
@@ -126,11 +116,11 @@
                   		<span class="slds-checkbox--faux"></span>
               		</aura:set>
               		</aura:if>
-            	</label>
+            	</label>             
           	</div>
-
+            
           </div>
-
+          
       </div>
     </div>
 
@@ -147,19 +137,19 @@
           </div>
         </div>
       </span>
-
+        
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
           <ui:outputText value="{!$Label.c.stgTitleCourseConnectionBackfill}" class="slds-text-body--small" />
         </div>
       </div>
-
+        
       <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-1">
           <ui:outputText value="{!$Label.c.stgHelpCourseConnBackfillDescription}" class="slds-text-body--small" />
         </div>
       </div>
-
+        
       <div class="slds-grid slds-grid--align-center">
         <div>
           <label class="slds-checkbox">
@@ -170,20 +160,45 @@
           </label>
         </div>
       </div>
-
+        
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">
         <div>
           <ui:button class="slds-button slds-button--neutral settings-edit-bttn" disabled="{!or(not(v.allowBackfill), v.backfillStarted)}" label="{!$Label.c.stgBtnRunBackfill}" press="{!c.startBackfill}"/>
         </div>
       </div>
-
+        
       <div class="slds-grid slds-grid--align-center slds-m-top--medium">
         <div>
           <ui:outputText value="{!v.startBackfillMessage}" class="slds-text-body--small" />
         </div>
       </div>
-
+        
+      <hr/>
+        
+      <div class="slds-grid slds-wrap">
+		<div class="slds-col slds-size--1-of-2">
+                {!$Label.c.stgAffliationBackfilTitle}
+                <div class="slds-col slds-size--1-of-1">
+            		<ui:outputText value="{!$Label.c.stgAffiliationBackfillDesc}" class="slds-text-body--small" />
+          		</div>
+         </div>
+       	
+         <div class="slds-grid slds-grid--align-center slds-m-top--medium">
+               	<lightning:button
+                                  label="Backfill Missing Affiliation" 
+                                  title="backfillAffiliation"
+                                  onclick="{!c.handleAffiliationBackfill}"/>
+         </div>
+          
+       	 <div class="slds-grid slds-grid--align-bottom slds-m-top--medium">
+        	<div>
+          		<ui:outputText value="{!v.startBackfillMessageForAffiliation}" class="slds-text-body--small" />
+        	</div>
+      	 </div>
+      </div>
+      
+        
     </div>
-
+      
   </div>
 </aura:component>

--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnectionsController.js
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnectionsController.js
@@ -11,4 +11,8 @@
     helper.startBackfill(component);
   },
 
+  handleAffiliationBackfill : function(component, event, helper) {
+    console.log('affiliationBackfill JS -->'); 
+    helper.handleAffiliationBackfill(component); 
+  },
 })

--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnectionsHelper.js
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnectionsHelper.js
@@ -37,4 +37,19 @@
       });
       $A.enqueueAction(action);
   },
+  
+  handleAffiliationBackfill : function(component, event, helper) {
+      console.log('affiliationBackfill HS -->'); 
+     var action = component.get("c.executeAffiliationBackfillOnCourseConnection"); 
+     action.setCallback(this, function(response) {
+     	if(response.getState() === "SUCCESS") {
+            console.log('affiliationBackfill HS SUCCES -->'); 
+          component.set('v.startBackfillMessageForAffiliation', 'Backfill was successfully started.');
+        } else if(response.getState() === "ERROR") {
+            console.log('affiliationBackfill HS ERROR -->'); 
+          component.set('v.startBackfillMessageForAffiliation', 'There was an error when starting the backfill.');
+      }
+      });
+      $A.enqueueAction(action);
+  }
 })

--- a/src/classes/CCON_AffiliationBackfill_BATCH.cls
+++ b/src/classes/CCON_AffiliationBackfill_BATCH.cls
@@ -1,0 +1,48 @@
+public class CCON_AffiliationBackfill_BATCH implements Database.Batchable<SObject>{
+	
+    public Database.Querylocator start(Database.BatchableContext bc) {
+        Id studentCCRecordTypeId = Schema.SObjectType.Account.getRecordTypeInfosByName().get('Student').getRecordTypeId();
+        System.debug('CCON_BATCH METHOD-->'); 
+        String query = 'SELECT Id, Program_Enrollment__c ' + 
+                        'FROM Course_Enrollment__c ' + 
+            			'WHERE Affiliation__c = NULL AND Program_Enrollment__c != NULL AND RecordTypeId = :studentCCRecordTypeId'; 
+        System.debug('CCON_BATCH -->' + query); 
+        return Database.getQueryLocator(query);  
+    }
+    
+    public void execute(Database.BatchableContext bc, List<Course_Enrollment__c> returnCourseEnrollments){
+        List<Id> pEnrollmentID = new List<Id>(); 
+        List<Course_Enrollment__c> courseEnrollmentsToUpdate = new List<Course_Enrollment__c>(); 
+        
+        if (returnCourseEnrollments.size () > 0) {
+            
+            for (Integer i = 0; i < returnCourseEnrollments.size(); i++) {
+                Course_Enrollment__c enroll = returnCourseEnrollments[i];
+                if (enroll.Program_Enrollment__c != NULL) {
+                    pEnrollmentID.add(enroll.Program_Enrollment__c); 
+                }
+            }
+            
+            if (pEnrollmentID.size () > 0) {
+                List<Program_Enrollment__c> queryPE = [SELECT Id, Affiliation__c, Account__c
+                                                  FROM Program_Enrollment__c 
+                                                  WHERE Id = :pEnrollmentID]; 
+                Map<Id, Program_Enrollment__c> pEnrollmentsMap = new Map<Id, Program_Enrollment__c>(queryPE); 
+                
+                for (Course_Enrollment__c courseEnroll : returnCourseEnrollments) {
+                    courseEnroll.Affiliation__c = pEnrollmentsMap.get(courseEnroll.Program_Enrollment__c).Affiliation__c;
+                    courseEnroll.Affiliation__c = pEnrollmentsMap.get(courseEnroll.Program_Enrollment__c).Account__c;
+                    courseEnrollmentsToUpdate.add(courseEnroll); 
+                }
+                
+            }
+        }
+        
+        if (courseEnrollmentsToUpdate.size() > 0) {
+            System.debug('CCON_BATCH B4Update ->' + courseEnrollmentsToUpdate); 
+            update courseEnrollmentsToUpdate;
+        }
+    }
+    
+    public void finish(Database.BatchableContext bc) {}
+}

--- a/src/classes/CCON_AffiliationBackfill_BATCH.cls-meta.xml
+++ b/src/classes/CCON_AffiliationBackfill_BATCH.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/STG_CourseConnections.cls
+++ b/src/classes/STG_CourseConnections.cls
@@ -44,4 +44,13 @@ public class STG_CourseConnections {
         Id ApexJobId = Database.executeBatch(batch, 200);
         return ApexJobId;
     }
+	
+    @AuraEnabled
+    public static Id executeAffiliationBackfillOnCourseConnection() {
+        CCON_AffiliationBackfill_BATCH batch = new CCON_AffiliationBackfill_BATCH(); 
+        Id ApexJobId = Database.executeBatch(batch, 200);
+        return ApexJobId; 
+        
+    }
+    
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -720,11 +720,11 @@
         <value>Status Specified for Created Affiliations:</value>
     </labels>
     <labels>
-        <fullName>stgAffliationBackfilTitle</fullName>
+        <fullName>stgAffiliationBackfillTitle</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>stgAffliationBackfilTitle</shortDescription>
+        <shortDescription>stgAffiliationBackfillTitle</shortDescription>
         <value>Affiliation Backfill on Student Course Connection:</value>
     </labels>
     <labels>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -656,6 +656,14 @@
         <value>Administrative Account Record Type:</value>
     </labels>
     <labels>
+        <fullName>stgAffiliationBackfillDesc</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgAffiliationBackfillDesc</shortDescription>
+        <value>This backfill allows you to pre-populate Affiliation on existing Student Course Connection if it is missing. If Affiliation record does not exist, the Affiliation lookup field on the existing Student Course Connection will not be pre-populated.</value>
+    </labels>
+    <labels>
         <fullName>stgAfflCopyProgramEnrollmentEndDate</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
@@ -710,6 +718,14 @@
         <protected>true</protected>
         <shortDescription>stgAfflProgEnrollSetStatusValue</shortDescription>
         <value>Status Specified for Created Affiliations:</value>
+    </labels>
+    <labels>
+        <fullName>stgAffliationBackfilTitle</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgAffliationBackfilTitle</shortDescription>
+        <value>Affiliation Backfill on Student Course Connection:</value>
     </labels>
     <labels>
         <fullName>stgAfterRunBackfill</fullName>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -344,6 +344,16 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Populate_Affiliation_on_Couse_Connection__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Check this checkbox if you want to auto populate Affiliation on new  Student Course Connection.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Check this checkbox if you want to auto populate Affiliation on new Student Course Connection.</inlineHelpText>
+        <label>Populate Affiliation on Couse Connection</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Preferred_Phone_Selection__c</fullName>
         <description>To select a desired Preferred Phone when Phone clean up Batch job runs</description>
         <externalId>false</externalId>


### PR DESCRIPTION
# Critical Changes

# Changes
We have added a new button on EDA Settings under Course Connection tab that allows customers to backfill existing Student Course Connection with missing Affiliation. 

# Issues Closed

# New Metadata
CCON_AffiliationBackfill_BATCH

# Deleted Metadata

# Testing Notes
