### PR TITLE
W-030160 - Refactor Lightning Component for Account Naming

### DIFF
--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp
@@ -1,5 +1,4 @@
 <aura:component extends="c:STG_CMP_Base">
-    <aura:handler name="init" value="{!this}" action="{!c.init}"/>
     <aura:handler event="c:STG_EVT_Save" action="{!c.saveSetting}"/>
     <aura:attribute name="isView" type="Boolean" default="true" />
     <aura:attribute name="nameFormat" type="String"/>

--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownController.js
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownController.js
@@ -5,9 +5,5 @@
    
     saveSetting : function(component, event, helper) {
         helper.saveSetting(component);
-    },
-
-    init : function(component, event, helper) {
-        helper.init(component);
     }
 })

--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownHelper.js
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_DropdownHelper.js
@@ -1,10 +1,4 @@
 ({
-    //@TODO: Need to refactor this method to avoid calling each of these two methods twice
-    init : function(component) {
-        //Retrieving account naming options
-        this.getAdminAccNameFormatOptions(component);
-        this.getHHAccNameFormatOptions(component);
-    },
     onSelectChange : function(component) {
         var selectedVal = component.find("nameFormatDropDown").get("v.value");
         var prefix = component.get("v.namespacePrefix");
@@ -30,28 +24,5 @@
             selectedVal = component.find("otherText").get("v.value");
             component.set("v.otherSetting", selectedVal);
         }
-    },
-
-    getAdminAccNameFormatOptions : function(component) {
-        var adminAccNameFormatOptions = [];
-        var prefix = component.get("v.namespacePrefix");
-        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameAdminAcc"));
-        adminAccNameFormatOptions.push($A.get("$Label.c.firstNameLastNameAdminACC"));
-        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameAdminAcc"));
-        adminAccNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
-        component.set("v.adminAccNameFormatOptions", adminAccNameFormatOptions);
-    },
-
-    getHHAccNameFormatOptions : function(component) {
-        var hhNameFormatOptions = [];
-        var prefix = component.get("v.namespacePrefix");
-        hhNameFormatOptions.push($A.get("$Label.c.lastNameHH"));
-        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameHH"));
-        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameHH"));
-        hhNameFormatOptions.push($A.get("$Label.c.lastNameFamily"));
-        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameFamily"));
-        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameFamily"));
-        hhNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
-        component.set("v.hhNameFormatOptions", hhNameFormatOptions);
     }
 })

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -12,7 +12,9 @@
     <aura:attribute name="adminNameFormat" type="String" />    
     <aura:attribute name="hhNameFormat" type="String" />
     <aura:attribute name="adminOtherDisplay" type="Boolean"/> 
-    <aura:attribute name="hhOtherDisplay" type="Boolean"/> 
+    <aura:attribute name="hhOtherDisplay" type="Boolean"/>
+    <aura:attribute name="adminAccNameFormatOptions" type="String[]"/>
+    <aura:attribute name="hhNameFormatOptions" type="String[]"/> 
 
         <div class="slds-grid slds-wrap">
         <div class="slds-col slds-size--1-of-2">
@@ -209,6 +211,8 @@
                 namespacePrefix="{!v.namespacePrefix}"
                 otherDisplay="{!v.adminOtherDisplay}"
                 otherSetting="{!v.hierarchySettings.Admin_Other_Name_Setting__c}"
+                adminAccNameFormatOptions="{!v.adminAccNameFormatOptions}" 
+                hhNameFormatOptions="{!v.hhNameFormatOptions}"
             />
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">
@@ -229,6 +233,8 @@
                 namespacePrefix="{!v.namespacePrefix}"
                 otherDisplay="{!v.hhOtherDisplay}"
                 otherSetting="{!v.hierarchySettings.Household_Other_Name_Setting__c}"
+                adminAccNameFormatOptions="{!v.adminAccNameFormatOptions}" 
+                hhNameFormatOptions="{!v.hhNameFormatOptions}"
             />
         </div>
         <div class="slds-col slds-size--1-of-1 slds-m-bottom--medium">

--- a/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp
@@ -42,6 +42,8 @@
     <aura:attribute name="hhNameFormat" type="String" />
     <aura:attribute name="adminOtherDisplay" type="Boolean"/> 
     <aura:attribute name="hhOtherDisplay" type="Boolean"/> 
+    <aura:attribute name="adminAccNameFormatOptions" type="String[]"/>
+    <aura:attribute name="hhNameFormatOptions" type="String[]"/>
 
     <aura:handler event="c:STG_EVT_Save" action="{!c.saveSettings}" />
     <aura:handler event="c:STG_EVT_Cancel" action="{!c.resetSettings}" />
@@ -125,7 +127,8 @@
         <div aura:id="systemTabContent" class="site-code--content slds-scrollable--x slds-tabs__content" role="tabpanel">
             <c:STG_CMP_System hierarchySettings="{!v.hierarchySettings}" isView="{!v.isView}" namespacePrefix="{!v.namespacePrefix}"
                 accRecTypes="{!v.accRecTypes}" accRecTypeId="{!v.accRecTypeId}" accRecTypeName="{!v.accRecTypeName}"  
-                hhNameFormat="{!v.hhNameFormat}" adminNameFormat="{!v.adminNameFormat}" adminOtherDisplay="{!v.adminOtherDisplay}" hhOtherDisplay="{!v.hhOtherDisplay}"/>
+                hhNameFormat="{!v.hhNameFormat}" adminNameFormat="{!v.adminNameFormat}" adminOtherDisplay="{!v.adminOtherDisplay}" hhOtherDisplay="{!v.hhOtherDisplay}" 
+                adminAccNameFormatOptions="{!v.adminAccNameFormatOptions}" hhNameFormatOptions="{!v.hhNameFormatOptions}"/>
         </div>
     </div>
 </aura:component>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_TabsHelper.js
@@ -2,6 +2,8 @@
     init : function(component) {
         //Retrieving hierarchy settings
         this.getHierarchySettings(component);
+        this.getAdminAccNameFormatOptions(component);
+        this.getHHAccNameFormatOptions(component);
 
         // since we can't call this.processTabs(component, 'afflTabBtn') from here
         // well process the tabs manually here.
@@ -381,6 +383,29 @@
         }else{
             return false;
         }
+    },
+
+    getAdminAccNameFormatOptions : function(component) {
+        var adminAccNameFormatOptions = [];
+        var prefix = component.get("v.namespacePrefix");
+        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameAdminAcc"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.firstNameLastNameAdminACC"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameAdminAcc"));
+        adminAccNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
+        component.set("v.adminAccNameFormatOptions", adminAccNameFormatOptions);
+    },
+
+    getHHAccNameFormatOptions : function(component) {
+        var hhNameFormatOptions = [];
+        var prefix = component.get("v.namespacePrefix");
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameHH"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.lastNameFirstNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.firstNameLastNameFamily"));
+        hhNameFormatOptions.push($A.get("$Label.c.acctNamingOther"));
+        component.set("v.hhNameFormatOptions", hhNameFormatOptions);
     }
 
 })


### PR DESCRIPTION
Move init() to Tab component so it is not called twice
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
