### PR TITLE
fix execute_qa_apex script to use namespace placeholder for UTIL_CustomSettings_API

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -225,6 +225,7 @@ flows:
                 task: execute_qa_apex
                 options:
                     managed: True
+                    namespaced: True
             3:
                 task: deploy_qa_config
                 options:

--- a/scripts/setup.cls
+++ b/scripts/setup.cls
@@ -4,7 +4,7 @@ public static void qaSetup() {
 
 //Wrapper class to config QA custom settings
 private static void configQACustomSettings() {
-    %%%NAMESPACE%%%Hierarchy_Settings__c orgSettings = UTIL_CustomSettingsFacade.getSettings();
+    %%%NAMESPACE%%%Hierarchy_Settings__c orgSettings = %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getSettings();
     enableCourseConnections(orgSettings);
     enableSpecifyRoleForCreatedAffiliations(orgSettings);
     enableCopyAffiliationStartDateFromProgramEnrollment(orgSettings);

--- a/scripts/setup.cls
+++ b/scripts/setup.cls
@@ -4,7 +4,7 @@ public static void qaSetup() {
 
 //Wrapper class to config QA custom settings
 private static void configQACustomSettings() {
-    %%%NAMESPACE%%%Hierarchy_Settings__c orgSettings = %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getSettings();
+    %%%NAMESPACE%%%Hierarchy_Settings__c orgSettings = %%%NAMESPACED_RT%%%UTIL_CustomSettings_API.getSettings();
     enableCourseConnections(orgSettings);
     enableSpecifyRoleForCreatedAffiliations(orgSettings);
     enableCopyAffiliationStartDateFromProgramEnrollment(orgSettings);


### PR DESCRIPTION
This is a minor fix to a backend setup script that started failing with the addition of the Phone Translation fixes.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
