### PR TITLE
adding spanish mexico translation placeholders for test, test score, application

### DIFF
--- a/src/objectTranslations/Application__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Application__c-es_MX.objectTranslation
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Application</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Applications</value>
+    </caseValues>
+    <fields>
+        <help><!-- The date when the student decides whether to enroll. --></help>
+        <label><!-- Applicant Decision Date --></label>
+        <name>Applicant_Decision_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Contact applying to the institution or program. --></help>
+        <label><!-- Applicant --></label>
+        <name>Applicant__c</name>
+        <relationshipLabel><!-- Applications (Applicant) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The date and time when the application was submitted. --></help>
+        <label><!-- Application Date --></label>
+        <name>Application_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The date when the institution decides whether to accept the applicant. --></help>
+        <label><!-- Application Decision Date --></label>
+        <name>Application_Decision_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The status of the application review process. --></help>
+        <label><!-- Application Status --></label>
+        <name>Application_Status__c</name>
+        <picklistValues>
+            <masterLabel>Accepted Offer</masterLabel>
+            <translation><!-- Accepted Offer --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Admit</masterLabel>
+            <translation><!-- Admit --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Declined Offer</masterLabel>
+            <translation><!-- Declined Offer --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Deferred Offer</masterLabel>
+            <translation><!-- Deferred Offer --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Deny</masterLabel>
+            <translation><!-- Deny --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>In Review</masterLabel>
+            <translation><!-- In Review --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Incomplete</masterLabel>
+            <translation><!-- Incomplete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Received</masterLabel>
+            <translation><!-- Received --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Submitted</masterLabel>
+            <translation><!-- Submitted --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Waitlist</masterLabel>
+            <translation><!-- Waitlist --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The type of program or track the applicant is applying to. For example, Undergraduate, Graduate, or Transfer. --></help>
+        <label><!-- Application Type --></label>
+        <name>Application_Type__c</name>
+        <picklistValues>
+            <masterLabel>Graduate</masterLabel>
+            <translation><!-- Graduate --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Transfer</masterLabel>
+            <translation><!-- Transfer --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Undergraduate</masterLabel>
+            <translation><!-- Undergraduate --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The academic program or major the applicant is applying to. --></help>
+        <label><!-- Applying To --></label>
+        <name>Applying_To__c</name>
+        <relationshipLabel><!-- Applications --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
+        <label><!-- Preparer --></label>
+        <name>Preparer__c</name>
+        <relationshipLabel><!-- Applications (Preparer) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The term when the applicant wants to enroll. --></help>
+        <label><!-- Term --></label>
+        <name>Term__c</name>
+        <relationshipLabel><!-- Applications --></relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>EDA Application Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Application__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Application__c-es_MX.objectTranslation
@@ -116,5 +116,5 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <startsWith>Consonant</startsWith>
+    <gender>Masculine</gender>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Test_Score__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Test_Score__c-es_MX.objectTranslation
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Test Score</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Test Scores</value>
+    </caseValues>
+    <fields>
+        <help><!-- The percentile ranking for this score. --></help>
+        <label><!-- Percentile --></label>
+        <name>Percentile__c</name>
+    </fields>
+    <fields>
+        <help><!-- The numeric value of the score received. --></help>
+        <label><!-- Score --></label>
+        <name>Score__c</name>
+    </fields>
+    <fields>
+        <help><!-- The subject matter or category for this test score. --></help>
+        <label><!-- Subject Area --></label>
+        <name>Subject_Area__c</name>
+        <picklistValues>
+            <masterLabel>Language</masterLabel>
+            <translation><!-- Language --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mathematics</masterLabel>
+            <translation><!-- Mathematics --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Overall</masterLabel>
+            <translation><!-- Overall --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Reading</masterLabel>
+            <translation><!-- Reading --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Science</masterLabel>
+            <translation><!-- Science --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Writing</masterLabel>
+            <translation><!-- Writing --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Displays the Test Type name from the associated Test record. For example, SAT or GRE. --></help>
+        <label><!-- Test Type --></label>
+        <name>Test_Type__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Test for which this score is being recorded. --></help>
+        <label><!-- Test --></label>
+        <name>Test__c</name>
+        <relationshipLabel><!-- Test Scores --></relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>EDA Test Score Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Test_Score__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Test_Score__c-es_MX.objectTranslation
@@ -58,6 +58,7 @@
         <name>Test__c</name>
         <relationshipLabel><!-- Test Scores --></relationshipLabel>
     </fields>
+    <gender>Masculine</gender>
     <layouts>
         <layout>EDA Test Score Layout</layout>
         <sections>
@@ -65,5 +66,4 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/objectTranslations/Test__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Test__c-es_MX.objectTranslation
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Test</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Tests</value>
+    </caseValues>
+    <fields>
+        <help><!-- The student who took the test. --></help>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel><!-- Tests --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The date the test score is added to the system, either by manual upload or directly from an official source. --></help>
+        <label><!-- Date Received --></label>
+        <name>Date_Received__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates whether the applicant or an official source reported this test. --></help>
+        <label><!-- Source --></label>
+        <name>Source__c</name>
+        <picklistValues>
+            <masterLabel>Official</masterLabel>
+            <translation><!-- Official --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Self Reported</masterLabel>
+            <translation><!-- Self Reported --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The date the applicant or official source indicates the test was started. --></help>
+        <label><!-- Test Date --></label>
+        <name>Test_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The formal name for the test taken. --></help>
+        <label><!-- Test Type --></label>
+        <name>Test_Type__c</name>
+        <picklistValues>
+            <masterLabel>ACT</masterLabel>
+            <translation><!-- ACT --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>GMAT</masterLabel>
+            <translation><!-- GMAT --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>GRE</masterLabel>
+            <translation><!-- GRE --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>SAT</masterLabel>
+            <translation><!-- SAT --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>TOEFL</masterLabel>
+            <translation><!-- TOEFL --></translation>
+        </picklistValues>
+    </fields>
+    <layouts>
+        <layout>EDA Test Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Test__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Test__c-es_MX.objectTranslation
@@ -62,6 +62,7 @@
             <translation><!-- TOEFL --></translation>
         </picklistValues>
     </fields>
+    <gender>Masculine</gender>
     <layouts>
         <layout>EDA Test Layout</layout>
         <sections>
@@ -69,5 +70,4 @@
             <section>Custom Links</section>
         </sections>
     </layouts>
-    <startsWith>Consonant</startsWith>
 </CustomObjectTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -841,6 +841,7 @@
         <members>Application__c-en_GB</members>
         <members>Application__c-en_US</members>
         <members>Application__c-es</members>
+        <members>Application__c-es_MX</members>
         <members>Application__c-fr</members>
         <members>Attendance_Event__c-ca</members>
         <members>Attendance_Event__c-en_GB</members>
@@ -982,11 +983,13 @@
         <members>Test_Score__c-en_GB</members>
         <members>Test_Score__c-en_US</members>
         <members>Test_Score__c-es</members>
+        <members>Test_Score__c-es_MX</members>
         <members>Test_Score__c-fr</members>
         <members>Test__c-ca</members>
         <members>Test__c-en_GB</members>
         <members>Test__c-en_US</members>
         <members>Test__c-es</members>
+        <members>Test__c-es_MX</members>
         <members>Test__c-fr</members>
         <members>Time_Block__c-ca</members>
         <members>Time_Block__c-en_GB</members>


### PR DESCRIPTION
adding fix to have Spanish/Mexico translation placeholders for Test, Test Score, and Application
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
