### PR TITLE
[EDA] Add New Picklist Value on Primary Address Type Field On Contact

### DIFF
--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -4531,6 +4531,11 @@
                     <label>Home</label>
                 </value>
                 <value>
+                    <fullName>Vacation Residence</fullName>
+                    <default>false</default>
+                    <label>Vacation Residence</label>
+                </value>
+                <value>
                     <fullName>Work</fullName>
                     <default>false</default>
                     <label>Work</label>
@@ -4751,17 +4756,17 @@
         <externalId>false</externalId>
         <formula>if(
     ISPICKVAL(Primary_Address_Type__c,&quot;Work&quot;),
-    if(ISBLANK(MailingStreet) , &quot;&quot; , MailingStreet &amp; &quot;, &quot;) &amp; 
-    if(ISBLANK(MailingCity) , &quot;&quot; , MailingCity &amp; &quot;, &quot;) &amp; 
-    if(ISBLANK(MailingState) , &quot;&quot; , MailingState &amp; &quot; &quot;) &amp; 
-    if(ISBLANK(MailingPostalCode) , &quot;&quot; , MailingPostalCode) &amp; 
+    if(ISBLANK(MailingStreet) , &quot;&quot; , MailingStreet &amp; &quot;, &quot;) &amp;
+    if(ISBLANK(MailingCity) , &quot;&quot; , MailingCity &amp; &quot;, &quot;) &amp;
+    if(ISBLANK(MailingState) , &quot;&quot; , MailingState &amp; &quot; &quot;) &amp;
+    if(ISBLANK(MailingPostalCode) , &quot;&quot; , MailingPostalCode) &amp;
     If(ISBLANK(MailingCountry ) , &quot;&quot; , &quot;, &quot; &amp; MailingCountry)
     ,
     if(ISPICKVAL(Secondary_Address_Type__c,&quot;Work&quot;),
-    if(ISBLANK(OtherStreet) , &quot;&quot; , OtherStreet &amp; &quot;, &quot;) &amp; 
-    if(ISBLANK(OtherCity) , &quot;&quot; , OtherCity &amp; &quot;, &quot;) &amp; 
-    if(ISBLANK(OtherState) , &quot;&quot; , OtherState &amp; &quot; &quot;) &amp; 
-    if(ISBLANK(OtherPostalCode) , &quot;&quot; , OtherPostalCode) &amp; 
+    if(ISBLANK(OtherStreet) , &quot;&quot; , OtherStreet &amp; &quot;, &quot;) &amp;
+    if(ISBLANK(OtherCity) , &quot;&quot; , OtherCity &amp; &quot;, &quot;) &amp;
+    if(ISBLANK(OtherState) , &quot;&quot; , OtherState &amp; &quot; &quot;) &amp;
+    if(ISBLANK(OtherPostalCode) , &quot;&quot; , OtherPostalCode) &amp;
     If(ISBLANK(OtherCountry ) , &quot;&quot; , &quot;, &quot; &amp; OtherCountry)
     ,
     &quot;&quot;)

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -4696,6 +4696,11 @@
                     <label>Home</label>
                 </value>
                 <value>
+                    <fullName>Vacation Residence</fullName>
+                    <default>false</default>
+                    <label>Vacation Residence</label>
+                </value>
+                <value>
                     <fullName>Work</fullName>
                     <default>false</default>
                     <label>Work</label>


### PR DESCRIPTION
# Critical Changes

# Changes
## New Picklist Values on Contact
We've added a new picklist value, "Vacation Residence," to the "Primary Address Type" and "Secondary Address Type" fields on Contact. With these new picklist values, the "Primary Address Type" and "Secondary Address Type" picklists on Contact are now consistent with the "Address Type" picklist on the Address object. 

For new EDA installations, the new picklist values are automatically added to Contact. If your organization has an existing EDA installation, manually add "Vacation Residence" as a new picklist value to the "Primary Address Type" field and "Secondary Address Type" field on Contact. For information, check out [Add Custom Fields and Picklist Values](https://powerofus.force.com/s/article/EDA-Add-Custom-Picklist-Values).

**Note:** We've also updated the EDA Documentation to clarify the behavior of the "Simple Address Change Treated as Update" setting in EDA Settings. For more information, see  [Add or Update Addresses](https://powerofus.force.com/s/article/EDA-Add-or-Update-Addresses).

# Issues Closed
#888 

# New Metadata
- New picklist value: "Vacation Residence"
# Deleted Metadata

# Testing Notes

- Create a new Contact and select "Primary Address Type" or "Secondary Address Type" field on Contact, and I should be able to see "Vacation Residence" as an option.  Ensure that the picklist values are in alphabetical order and that "Other" is the listed as the last value. 
- Find an existing Contact record and select "Primary Address Type" or "Secondary Address Type" field on Contact, and I should be able to see "Vacation Residence" as an option. Ensure that the picklist values are in alphabetical order and that "Other" is the listed as the last value. 
