### PR TITLE
Fix failing EDA Unit Tests that fail only when installed and run from a K12 org.

### DIFF
--- a/src/classes/AFFL_AccChange_TDTM.cls
+++ b/src/classes/AFFL_AccChange_TDTM.cls
@@ -72,15 +72,23 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
                 Integer i = 0;
                 for (SObject so : newlist) {
                		Affiliation__c affl = (Affiliation__c)so;
-               		String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-           			String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
+               		String lookupLabelOrAPIName = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+                  if (lookupLabelOrAPIName == NULL) {
+                      String affiliationTypeAPI = afflMapper.accRecTypeLabelToAPI.get(affl.Affiliation_Type__c);
+                      lookupLabelOrAPIName = afflMapper.accRecTypeToContactLabel.get(affiliationTypeAPI);
+                  }
+           			  String lookupFieldAPIName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupLabelOrAPIName);
 
                		Affiliation__c afflOld;
-               		String lookupFieldLabelOld, lookupFieldNameOld;
+               		String lookupFieldLabelOrAPIOld, lookupFieldAPINameOld;
                		if(oldlist[i] != null) {
                    		afflOld = (Affiliation__c)oldlist[i];
-                   		lookupFieldLabelOld = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(afflOld.Affiliation_Type__c);
-                   		lookupFieldNameOld = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabelOld);
+                   		lookupFieldLabelOrAPIOld = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(afflOld.Affiliation_Type__c);
+                        if (lookupFieldLabelOrAPIOld == NULL) {
+                            String affiliationTypeAPI = afflMapper.accRecTypeLabelToAPI.get(afflOld.Affiliation_Type__c);
+                            lookupFieldLabelOrAPIOld = afflMapper.accRecTypeToContactLabel.get(affiliationTypeAPI);
+                        }
+                   		lookupFieldAPINameOld = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabelOrAPIOld);
                		}
 
                		if (isAfflTypeEnforced == true) {
@@ -95,29 +103,29 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
 
                    		//ACCOUNT FIELD CHANGED
                    		if(affl.Primary__c && affl.Account__c != null && afflOld.Account__c != null
-                       		&& affl.Account__c != afflOld.Account__c && lookupFieldName != null) {
+                       		&& affl.Account__c != afflOld.Account__c && lookupFieldAPIName != null) {
 
                        		if(affl.Affiliation_Type__c == afflOld.Affiliation_Type__c) {
                            		//If the primary affl now points to an Account of the same type, update the
                            		//same primary field in Contact.
-                           		relatedContact.put(lookupFieldName, affl.Account__c);
+                           		relatedContact.put(lookupFieldAPIName, affl.Account__c);
                        		} else {
                            		//If the primary affl now points to an Account of different type, clear the old
                            		//primary field in Contact and populate the matching new field.
-                           		if (lookupFieldNameOld != null) {
-                               		relatedContact.put(lookupFieldNameOld, null);
-                               		relatedContact.put(lookupFieldName, affl.Account__c);
+                           		if (lookupFieldAPINameOld != null) {
+                               		relatedContact.put(lookupFieldAPINameOld, null);
+                               		relatedContact.put(lookupFieldAPIName, affl.Account__c);
                            		}
                        		}
                        		dmlWrapper.objectsToUpdate.add(relatedContact);
 
-                       		//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
+                       		  //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
                            	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
                        	}
-
-                       	//ACCOUNT FIELD CLEARED - the matching primary field in Contact needs to be cleared.
-                       	if(affl.Primary__c && afflOld.Account__c != null && affl.Account__c == null && lookupFieldNameOld != null) {
-                           	relatedContact.put(lookupFieldNameOld, null);
+                        
+                        //ACCOUNT FIELD CLEARED - the matching primary field in Contact needs to be cleared.
+                       	if(affl.Primary__c && afflOld.Account__c != null && affl.Account__c == null && lookupFieldAPINameOld != null) {
+                           	relatedContact.put(lookupFieldAPINameOld, null);
                            	dmlWrapper.objectsToUpdate.add(relatedContact);
                        	}
                        	TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_AccChange_TDTM, true);

--- a/src/classes/AFFL_AccChange_TDTM.cls
+++ b/src/classes/AFFL_AccChange_TDTM.cls
@@ -80,7 +80,8 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
            			  String lookupFieldAPIName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupLabelOrAPIName);
 
                		Affiliation__c afflOld;
-               		String lookupFieldLabelOrAPIOld, lookupFieldAPINameOld;
+               		String lookupFieldLabelOrAPIOld;
+                    String lookupFieldAPINameOld;
                		if(oldlist[i] != null) {
                    		afflOld = (Affiliation__c)oldlist[i];
                    		lookupFieldLabelOrAPIOld = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(afflOld.Affiliation_Type__c);
@@ -119,8 +120,6 @@ public with sharing class AFFL_AccChange_TDTM extends TDTM_Runnable {
                        		}
                        		dmlWrapper.objectsToUpdate.add(relatedContact);
 
-                       		  //afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
-                           	//AFFL_MultiRecordType_TDTM will run after this class, and will take care of that.
                        	}
                         
                         //ACCOUNT FIELD CLEARED - the matching primary field in Contact needs to be cleared.

--- a/src/classes/AFFL_AccRecordType_TEST.cls
+++ b/src/classes/AFFL_AccRecordType_TEST.cls
@@ -45,6 +45,8 @@ public with sharing class AFFL_AccRecordType_TEST {
         UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         STG_InstallScript.insertMappings();
+        RecordType univ = [SELECT Id, Name FROM RecordType WHERE DeveloperName = 'University_Department'];
+        System.assertNotEquals(null, univ, 'University_Department Record Type was not found');
         
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();

--- a/src/classes/AFFL_ContactChange_TDTM.cls
+++ b/src/classes/AFFL_ContactChange_TDTM.cls
@@ -72,7 +72,7 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
                         newRelatedContactsMap = afflMulti.queryAfflLookupFields(newlist);
                     }
                     if (oldlist != null) {
-                       oldRelatedContactsMap = afflMulti.queryAfflLookupFields(oldlist);
+                        oldRelatedContactsMap = afflMulti.queryAfflLookupFields(oldlist);
                     }
                 }
 
@@ -81,10 +81,13 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
                     Affiliation__c afflOld;
                		if(oldlist[i] != null)
                    		afflOld = (Affiliation__c)oldlist[i];
-
-	               	String lookupFieldLabel = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-	               	String lookupFieldName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupFieldLabel);
-
+	               	String lookupLabelOrAPIName = AFFL_MultiRecordType_TDTM.afflMapper.accRecTypeToContactLabel.get(affl.Affiliation_Type__c);
+                    if (lookupLabelOrAPIName == NULL) {
+                        String affiliationTypeAPI = afflMapper.accRecTypeLabelToAPI.get(affl.Affiliation_Type__c);
+                        lookupLabelOrAPIName = afflMapper.accRecTypeToContactLabel.get(affiliationTypeAPI);
+                    }
+	               	String lookupFieldAPIName = AFFL_MultiRecordType_TDTM.afflMapper.contactLabelNames.get(lookupLabelOrAPIName);
+                    
 					if (isAfflTypeEnforced == true) {
 						ERR_ExceptionHandler.handleAfflNullRecordTypeException(affl, afflMapper.validAccRecordTypesInMappings);
 					}
@@ -102,14 +105,14 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 
 	                   	//CONTACT FIELD CHANGED
 	                   	if(affl.Primary__c && affl.Contact__c != null && afflOld.Contact__c != null
-	                   		&& affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldName != null) {
+	                   		&& affl.Contact__c != afflOld.Contact__c && newRelatedContact != null && oldRelatedContact != null && lookupFieldAPIName != null) {
 
 	                       	//Clear matching primary affiliation field in old Contact
-	                       	oldRelatedContact.put(lookupFieldName, null);
+	                       	oldRelatedContact.put(lookupFieldAPIName, null);
 	                       	dmlWrapper.objectsToUpdate.add(oldRelatedContact);
 
 	                       	//Populate same field in new Contact
-	                       	newRelatedContact.put(lookupFieldName, affl.Account__c);
+	                       	newRelatedContact.put(lookupFieldAPIName, affl.Account__c);
                             dmlWrapper.objectsToUpdate.add(newRelatedContact);
 
 	                       	//afflMulti.uncheckOtherPrimariesSameType(); --> we don't need to call this because
@@ -117,8 +120,8 @@ public with sharing class AFFL_ContactChange_TDTM extends TDTM_Runnable {
 	                   	}
 
 	                   	//CONTACT FIELD CLEARED - same as if the Affiliation was deleted.
-	                   	if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldName != null) {
-	                       	afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldName, dmlWrapper);
+	                   	if(affl.Primary__c && afflOld.Contact__c != null && affl.Contact__c == null && lookupFieldAPIName != null) {
+	                       	afflMulti.processAfflDeleted(afflOld, oldRelatedContact, lookupFieldAPIName, dmlWrapper);
 	                   	}
 	               	}
 	               	i++;

--- a/src/classes/AFFL_MultiRecordTypeMapper.cls
+++ b/src/classes/AFFL_MultiRecordTypeMapper.cls
@@ -168,6 +168,14 @@ public with sharing class AFFL_MultiRecordTypeMapper {
         			String fieldName = contactLabelNames.get(fieldLabel);
         			return fieldName;
         		}
+            } else if(Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName) != null) {
+                ID rcId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName).getRecordTypeId();
+                String recTypeLabel = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName).getName();
+                if(rcId == recordTypeId) {
+                    String fieldLabel = accRecTypeToContactLabel.get(recTypeLabel);
+        			String fieldName = contactLabelNames.get(fieldLabel);
+        			return fieldName;
+                }
             }else{
                 //Setup null pointer error message
                 String[] params = new String[]{

--- a/src/classes/AFFL_MultiRecordTypeMapper.cls
+++ b/src/classes/AFFL_MultiRecordTypeMapper.cls
@@ -37,11 +37,11 @@
 */
 public with sharing class AFFL_MultiRecordTypeMapper {
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description Map of Contact field names to Contact field labels.
     ********************************************************************************************************/
-	public Map<String, String> contactLabelNames;
-		
+    public Map<String, String> contactLabelNames;
+        
     /*******************************************************************************************************
     * @description Affiliation Account-record-type-to-Contact-field mappings.
     ********************************************************************************************************/
@@ -59,10 +59,10 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     ********************************************************************************************************/
     public List<String> accountRecordTypes;
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description List of valid account record types in mappings.
     ********************************************************************************************************/
-	public List<String> validAccRecordTypesInMappings;
+    public List<String> validAccRecordTypesInMappings;
 
     /*******************************************************************************************************
     * @description List of primary affiliation lookup fields names on Contact.
@@ -78,118 +78,118 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     * @description Constructor that initializes class properties.
     ********************************************************************************************************/
     public AFFL_MultiRecordTypeMapper() {
-    	//List of Contact field names.
-		List<SObjectField> contactFields = Contact.sObjectType.getDescribe().fields.getMap().values();
-		
-		//Map of Contact field labels to Contact field Names.
-		contactLabelNames = getContactLabelsNamesMap(contactFields);
-		
-		//List of primary affiliation lookup fields names.
-		List<String> contactFieldNames = contactLabelNames.values();
-		
-		//Affiliation Account-record-type-to-Contact-field mappings.
-		populateMaps();
+        //List of Contact field names.
+        List<SObjectField> contactFields = Contact.sObjectType.getDescribe().fields.getMap().values();
+        
+        //Map of Contact field labels to Contact field Names.
+        contactLabelNames = getContactLabelsNamesMap(contactFields);
+        
+        //List of primary affiliation lookup fields names.
+        List<String> contactFieldNames = contactLabelNames.values();
+        
+        //Affiliation Account-record-type-to-Contact-field mappings.
+        populateMaps();
 
         // Map of Account RecordType Label To API
         accRecTypeLabelToAPI = getAccRecTypeLabelToAPIMap();
-		
-		//List of primary affiliation lookup fields labels.
-		List<String> primaryAfflFieldLabels = accRecTypeToContactLabel.values();
-		
-		//List of primary affiliation Contact fields.
-		List<SObjectField> primaryAfflFields = getPrimaryAfflFields(contactFields, primaryAfflFieldLabels);
+        
+        //List of primary affiliation lookup fields labels.
+        List<String> primaryAfflFieldLabels = accRecTypeToContactLabel.values();
+        
+        //List of primary affiliation Contact fields.
+        List<SObjectField> primaryAfflFields = getPrimaryAfflFields(contactFields, primaryAfflFieldLabels);
 
-		//List of Valid Account Record types in mappings
-		validAccRecordTypesInMappings = getValidAccRecordTypesInMappings(accountRecordTypes);
+        //List of Valid Account Record types in mappings
+        validAccRecordTypesInMappings = getValidAccRecordTypesInMappings(accountRecordTypes);
 
         //List of Valid Primary Contact Fields in mappings
         List<String> validContactAfflFields = getValidAfflFields(contactFields, primaryAfflFieldLabels);
         
-		//Check if any mismatch in mappings
-		if (UTIL_CustomSettingsFacade.getSettings().Affiliation_Record_Type_Enforced__c
-				&& (primaryAfflFieldLabels.size() != validContactAfflFields.size()
-					|| accountRecordTypes.size() != validAccRecordTypesInMappings.size())) {
-			throw new ERR_ExceptionHandler.AffAccountRecordTypeMappingsException(Label.afflAccoutMappingError);
-		}
+        //Check if any mismatch in mappings
+        if (UTIL_CustomSettingsFacade.getSettings().Affiliation_Record_Type_Enforced__c
+                && (primaryAfflFieldLabels.size() != validContactAfflFields.size()
+                    || accountRecordTypes.size() != validAccRecordTypesInMappings.size())) {
+            throw new ERR_ExceptionHandler.AffAccountRecordTypeMappingsException(Label.afflAccoutMappingError);
+        }
 
-		UTIL_Debug.debug('****MRT: primaryAfflFieldNames: ' + JSON.serializePretty(primaryAfflFieldNames));
+        UTIL_Debug.debug('****MRT: primaryAfflFieldNames: ' + JSON.serializePretty(primaryAfflFieldNames));
     }
     
     private Map<String, String> getContactLabelsNamesMap(List<SObjectField> cf) {
-    	Map<String, String> labelsnames = new Map<String, String>();
-		for(SObjectField field : cf) {
-			labelsnames.put(field.getDescribe().getLabel(), field.getDescribe().getName());
-		}
-		return labelsnames;
+        Map<String, String> labelsnames = new Map<String, String>();
+        for(SObjectField field : cf) {
+            labelsnames.put(field.getDescribe().getLabel(), field.getDescribe().getName());
+        }
+        return labelsnames;
     }
     
     // @Desription Returns a Map of Record type label to its API
     private Map<String, String> getAccRecTypeLabelToAPIMap() {
-    	Map<String, String> labelsnames = new Map<String, String>();
-		for (RecordType field : [SELECT  Name, DeveloperName FROM RecordType Where SobjectType = 'Account']) {
-			labelsnames.put(field.Name, field.DeveloperName);
-		}
-		return labelsnames;
+        Map<String, String> labelsnames = new Map<String, String>();
+        for (RecordType field : [SELECT  Name, DeveloperName FROM RecordType Where SobjectType = 'Account']) {
+            labelsnames.put(field.Name, field.DeveloperName);
+        }
+        return labelsnames;
     }
     
     private void populateMaps() {
-    	accRecTypeToContactLabel = new Map<String, String>();
-    	accTypeToEnrollCreate = new Map<String, Boolean>();
-    	accTypeToEnrollCreateRole = new Map<String, String>();
-    	accTypeToEnrollCreateStatus = new Map<String, String>();
+        accRecTypeToContactLabel = new Map<String, String>();
+        accTypeToEnrollCreate = new Map<String, Boolean>();
+        accTypeToEnrollCreateRole = new Map<String, String>();
+        accTypeToEnrollCreateStatus = new Map<String, String>();
         accountRecordTypes = new List<String>();
 
-		//Put affl mappings in a map.
-		for(Affl_Mappings__c mapping : UTIL_CustomSettingsFacade.getAfflMappings()) {
-			if(!String.isBlank(mapping.Account_Record_Type__c) && !String.isBlank(mapping.Primary_Affl_Field__c)) {
-				accRecTypeToContactLabel.put(mapping.Account_Record_Type__c, mapping.Primary_Affl_Field__c);
-				accTypeToEnrollCreate.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment__c);
-				accTypeToEnrollCreateRole.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment_Role__c);
-				accTypeToEnrollCreateStatus.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment_Status__c);
+        //Put affl mappings in a map.
+        for(Affl_Mappings__c mapping : UTIL_CustomSettingsFacade.getAfflMappings()) {
+            if(!String.isBlank(mapping.Account_Record_Type__c) && !String.isBlank(mapping.Primary_Affl_Field__c)) {
+                accRecTypeToContactLabel.put(mapping.Account_Record_Type__c, mapping.Primary_Affl_Field__c);
+                accTypeToEnrollCreate.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment__c);
+                accTypeToEnrollCreateRole.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment_Role__c);
+                accTypeToEnrollCreateStatus.put(mapping.Account_Record_Type__c, mapping.Auto_Program_Enrollment_Status__c);
                 accountRecordTypes.add(mapping.Account_Record_Type__c);
             }
-		}
-	}
-	
-	/***************************************************************************************************************
+        }
+    }
+    
+    /***************************************************************************************************************
     * @description Returns those fields from the provided list that are in the provided list of labels or API names. 
     * @param contactFields List of fields on Contact.
     * @param primaryAfflFieldLabels List of field labels or API Names.
     * @return List<SObjectField> List of fields in object that are in the provided list of labels or API names.
     ****************************************************************************************************************/
-	private List<SObjectField> getPrimaryAfflFields(List<SObjectField> contactFields, List<String> primaryAfflFieldLabelsOrAPINames) {
-		Set<String> primaryAfflFieldLabelsOrAPIs = new Set<String>(primaryAfflFieldLabelsOrAPINames);
-		List<SObjectField> primaryFields = new List<SObjectField>();
-		primaryAfflFieldNames = new List<String>();
-		for(SObjectField field : contactFields) {
-			if (primaryAfflFieldLabelsOrAPIs.contains(field.getDescribe().getLabel()) || primaryAfflFieldLabelsOrAPIs.contains(field.getDescribe().getName())) {
-				primaryAfflFieldNames.add(field.getDescribe().getName());
-				primaryFields.add(field);
-			}
-		}
-		return primaryFields;
-	}
-	
-	/*******************************************************************************************************
+    private List<SObjectField> getPrimaryAfflFields(List<SObjectField> contactFields, List<String> primaryAfflFieldLabelsOrAPINames) {
+        Set<String> primaryAfflFieldLabelsOrAPIs = new Set<String>(primaryAfflFieldLabelsOrAPINames);
+        List<SObjectField> primaryFields = new List<SObjectField>();
+        primaryAfflFieldNames = new List<String>();
+        for(SObjectField field : contactFields) {
+            if (primaryAfflFieldLabelsOrAPIs.contains(field.getDescribe().getLabel()) || primaryAfflFieldLabelsOrAPIs.contains(field.getDescribe().getName())) {
+                primaryAfflFieldNames.add(field.getDescribe().getName());
+                primaryFields.add(field);
+            }
+        }
+        return primaryFields;
+    }
+    
+    /*******************************************************************************************************
     * @description Returns the name of the key affiliation Contact field that matches the Account record type provided.
     * @param recordTypeId The ID of an Account record type.
     * @return String The name of the key affiliation Contact field.
     ********************************************************************************************************/
-	public String getKeyAfflFieldByAccRecordType(ID recordTypeId) {
-		for (String recTypeName : accRecTypeToContactLabel.keySet()) {
+    public String getKeyAfflFieldByAccRecordType(ID recordTypeId) {
+        for (String recTypeName : accRecTypeToContactLabel.keySet()) {
             if (Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName) != null) {
-        		ID rcId = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName).getRecordTypeId();
-        		if (rcId == recordTypeId) {
-        			String fieldLabel = accRecTypeToContactLabel.get(recTypeName);
-        			String fieldName = contactLabelNames.get(fieldLabel);
-        			return fieldName;
-        		}
+                ID rcId = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName).getRecordTypeId();
+                if (rcId == recordTypeId) {
+                    String fieldLabel = accRecTypeToContactLabel.get(recTypeName);
+                    String fieldName = contactLabelNames.get(fieldLabel);
+                    return fieldName;
+                }
             } else if (Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName) != null) {
                 ID rcId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName).getRecordTypeId();
                 if(rcId == recordTypeId) {
                     String fieldLabel = accRecTypeToContactLabel.get(recTypeName);
-        			String fieldName = contactLabelNames.get(fieldLabel);
-        			return fieldName;
+                    String fieldName = contactLabelNames.get(fieldLabel);
+                    return fieldName;
                 }
             } else {
                 //Setup null pointer error message
@@ -199,8 +199,8 @@ public with sharing class AFFL_MultiRecordTypeMapper {
                 String nullPointerMsg = String.format(Label.afflNullPointerError, params);
                 throw new AfflNullPointerException(nullPointerMsg);
             }
-		}
-		return null;
+        }
+        return null;
     }
     
     public class AfflNullPointerException extends Exception {}
@@ -214,34 +214,34 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     public Boolean needsProgramEnrollment(Affiliation__c affl) {
         Boolean autoEnrollment = false;
         String autoRole, autoStatus;
-    	if(affl.Affiliation_Type__c != null) {
-    	    if(accTypeToEnrollCreate.get(affl.Affiliation_Type__c) != null) {
-    	       autoEnrollment = accTypeToEnrollCreate.get(affl.Affiliation_Type__c);
-    	    }
-    	    autoRole = accTypeToEnrollCreateRole.get(affl.Affiliation_Type__c);
-    	    autoStatus = accTypeToEnrollCreateStatus.get(affl.Affiliation_Type__c);
-    	}
-    	if(autoEnrollment && affl != null && affl.Role__c != null && autoRole == affl.Role__c && affl.Status__c != null 
-    	&& autoStatus == affl.Status__c) { 
-    	   return true;
-    	}
-    	return false;
+        if(affl.Affiliation_Type__c != null) {
+            if(accTypeToEnrollCreate.get(affl.Affiliation_Type__c) != null) {
+               autoEnrollment = accTypeToEnrollCreate.get(affl.Affiliation_Type__c);
+            }
+            autoRole = accTypeToEnrollCreateRole.get(affl.Affiliation_Type__c);
+            autoStatus = accTypeToEnrollCreateStatus.get(affl.Affiliation_Type__c);
+        }
+        if(autoEnrollment && affl != null && affl.Role__c != null && autoRole == affl.Role__c && affl.Status__c != null 
+        && autoStatus == affl.Status__c) { 
+           return true;
+        }
+        return false;
     }
 
-	/*******************************************************************************************************
+    /*******************************************************************************************************
     * @description Returns valid record types in Account Record type and contact primary field mapping.
     * @param accRecordTypesInMappings List of record types in mapping.
     * @return List<String> List of Valid record types in mapping.
     ********************************************************************************************************/
-	private List<String> getValidAccRecordTypesInMappings(List<String> accRecordTypesInMappings) {
-		List<String> validAccRecordTypesInMappings = new List<String>();
-		for (String accRecordTypesInMapping : accRecordTypesInMappings) {
-			if (SObjectType.Account.getRecordTypeInfosByName().containsKey(accRecordTypesInMapping)) {
-				validAccRecordTypesInMappings.add(accRecordTypesInMapping);
-			}
-		}
-		return validAccRecordTypesInMappings;
-	}
+    private List<String> getValidAccRecordTypesInMappings(List<String> accRecordTypesInMappings) {
+        List<String> validAccRecordTypesInMappings = new List<String>();
+        for (String accRecordTypesInMapping : accRecordTypesInMappings) {
+            if (SObjectType.Account.getRecordTypeInfosByName().containsKey(accRecordTypesInMapping)) {
+                validAccRecordTypesInMappings.add(accRecordTypesInMapping);
+            }
+        }
+        return validAccRecordTypesInMappings;
+    }
 
     /*******************************************************************************************************
     * @description Returns valid contact primary affiliation fields from mappings

--- a/src/classes/AFFL_MultiRecordTypeMapper.cls
+++ b/src/classes/AFFL_MultiRecordTypeMapper.cls
@@ -68,6 +68,11 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     * @description List of primary affiliation lookup fields names on Contact.
     ********************************************************************************************************/
     public List<String> primaryAfflFieldNames;
+
+    /*******************************************************************************************************
+    * @description Map of Account Record Type Label to API
+    ********************************************************************************************************/
+    public Map<String, String> accRecTypeLabelToAPI;
     
     /*******************************************************************************************************
     * @description Constructor that initializes class properties.
@@ -84,6 +89,9 @@ public with sharing class AFFL_MultiRecordTypeMapper {
 		
 		//Affiliation Account-record-type-to-Contact-field mappings.
 		populateMaps();
+
+        // Map of Account RecordType Label To API
+        accRecTypeLabelToAPI = getAccRecTypeLabelToAPIMap();
 		
 		//List of primary affiliation lookup fields labels.
 		List<String> primaryAfflFieldLabels = accRecTypeToContactLabel.values();
@@ -111,6 +119,15 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     	Map<String, String> labelsnames = new Map<String, String>();
 		for(SObjectField field : cf) {
 			labelsnames.put(field.getDescribe().getLabel(), field.getDescribe().getName());
+		}
+		return labelsnames;
+    }
+    
+    // @Desription Returns a Map of Record type label to its API
+    private Map<String, String> getAccRecTypeLabelToAPIMap() {
+    	Map<String, String> labelsnames = new Map<String, String>();
+		for (RecordType field : [SELECT  Name, DeveloperName FROM RecordType Where SobjectType = 'Account']) {
+			labelsnames.put(field.Name, field.DeveloperName);
 		}
 		return labelsnames;
     }
@@ -159,24 +176,22 @@ public with sharing class AFFL_MultiRecordTypeMapper {
     * @return String The name of the key affiliation Contact field.
     ********************************************************************************************************/
 	public String getKeyAfflFieldByAccRecordType(ID recordTypeId) {
-		for(String recTypeName : accRecTypeToContactLabel.keySet()) {
-            if (Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName) != null)
-            {
+		for (String recTypeName : accRecTypeToContactLabel.keySet()) {
+            if (Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName) != null) {
         		ID rcId = Schema.Sobjecttype.Account.getRecordTypeInfosByName().get(recTypeName).getRecordTypeId();
-        		if(rcId == recordTypeId) {
+        		if (rcId == recordTypeId) {
         			String fieldLabel = accRecTypeToContactLabel.get(recTypeName);
         			String fieldName = contactLabelNames.get(fieldLabel);
         			return fieldName;
         		}
-            } else if(Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName) != null) {
+            } else if (Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName) != null) {
                 ID rcId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName).getRecordTypeId();
-                String recTypeLabel = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get(recTypeName).getName();
                 if(rcId == recordTypeId) {
-                    String fieldLabel = accRecTypeToContactLabel.get(recTypeLabel);
+                    String fieldLabel = accRecTypeToContactLabel.get(recTypeName);
         			String fieldName = contactLabelNames.get(fieldLabel);
         			return fieldName;
                 }
-            }else{
+            } else {
                 //Setup null pointer error message
                 String[] params = new String[]{
                     recTypeName

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls
@@ -57,38 +57,40 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
         List<Affiliation__c> afflsMadePrimary = new List<Affiliation__c>();
-        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)
+        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)
                 || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)
                 || !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert)) {
 
             //Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
             Map<ID, Contact> relatedContactsMap;
-            if(newlist != null) {
+            if (newlist != null) {
                 relatedContactsMap = queryAfflLookupFields(newlist);
-            } else if(oldlist != null) {
+            } else if (oldlist != null) {
                 relatedContactsMap = queryAfflLookupFields(oldlist);
             }
 
-            if(newlist != null && newlist.size() > 0) {
+            if (newlist != null && newlist.size() > 0) {
                 Integer i = 0;
                 for (SObject so : newlist) {
                     Affiliation__c affl = (Affiliation__c)so;
-          
+
                     // Get the 'Primary Affl Field' value(could be Lookup Label or the Lookup API name) that is stored in 'Affl Mapping' Custom Settings
                     String lookupLabelOrAPIName = afflMapper.accRecTypeToContactLabel.get(affl.Affiliation_Type__c);
-
+                    if (lookupLabelOrAPIName == NULL) {
+                        String affiliationTypeAPI = afflMapper.accRecTypeLabelToAPI.get(affl.Affiliation_Type__c);
+                        lookupLabelOrAPIName = afflMapper.accRecTypeToContactLabel.get(affiliationTypeAPI);
+                    }
                     // Get the API name of the lookup field if lookupLabelOrAPIName is actually a Label and assig it to lookupFieldAPIName
                     String lookupFieldAPIName = afflMapper.contactLabelNames.get(lookupLabelOrAPIName);
-          
                     // If lookupFieldAPIName of the Contact is not found, check if lookupLabelOrAPIName is actually a field API Name, if yes assign it to lookupFieldAPIName.
                     // This way the API name can be used to populate primay Affiliation lookup on contact even when language is not English
-                        
+ 
                     if ((lookupLabelOrAPIName != NULL && lookupLabelOrAPIName != '') && (lookupFieldAPIName == '' || lookupFieldAPIName == NULL)) {
                         // Check if lookupLabelOrAPIName is in the List of Contact field API names, if yes assign lookupLabelOrAPIName to lookupFieldAPIName
-                        List<String> contactFieldAPINamesList = afflMapper.contactLabelNames.values();                     
+                        List<String> contactFieldAPINamesList = afflMapper.contactLabelNames.values();
                         if (contactFieldAPINamesList.contains(lookupLabelOrAPIName)) {
-                            lookupFieldAPIName = lookupLabelOrAPIName;                            
-                        }                        
+                            lookupFieldAPIName = lookupLabelOrAPIName;
+                        }
                     }
 
                     if (isAfflTypeEnforced == true) {
@@ -99,7 +101,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
                     //BEFORE INSERT - we do it in the Before so we don't get the affiliation we just created when we query for
                     //affls of the same type.
-                    if (triggerAction == TDTM_Runnable.Action.BeforeInsert 
+                    if (triggerAction == TDTM_Runnable.Action.BeforeInsert
                         && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert)) {
                         if (affl.Primary__c && affl.Contact__c != null && affl.Account__c != null && affl.Affiliation_Type__c != null && lookupFieldAPIName != null) {
                             afflsMadePrimary.add(affl);
@@ -111,7 +113,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
                     // AFTER UPDATE - Runs when AFTER UPDATE Code has not already been run (checked from Recursion Flag - TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)
                     // And when BEFORE INSERT code has not already been run (checked from Recursion Flag - TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary) so that values
                     // populated in BEFORE INSERT is not getting over-written in AFTER UPDATE
-                    if (triggerAction == TDTM_Runnable.Action.AfterUpdate 
+                    if (triggerAction == TDTM_Runnable.Action.AfterUpdate
                         && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update)) {
                         Affiliation__c afflOld = (Affiliation__c)oldlist[i];
 
@@ -120,8 +122,8 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
                                 && !affl.Primary__c
                                 && lookupFieldAPIName != null
                                 && relatedContact.get(lookupFieldAPIName) == affl.Account__c) {
-                            if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)													
-                               && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary)) {
+                            if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)										
+                                && !TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary)) {
                                 relatedContact.put(lookupFieldAPIName, null);
                                 dmlWrapper.objectsToUpdate.add(relatedContact);
                             }
@@ -137,21 +139,18 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
                     }
                     i++;
                 }
-                if (triggerAction == TDTM_Runnable.Action.BeforeInsert)
-                {
+                if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
                     TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, true);
-                }else if (triggerAction == TDTM_Runnable.Action.AfterUpdate)
-                {
+                } else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
                     TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, true);
-
                 }
-                if(afflsMadePrimary.size() > 0) {
+                if (afflsMadePrimary.size() > 0) {
                     uncheckOtherPrimariesSameType(afflsMadePrimary, dmlWrapper);
                 }
             }
 
-            if(oldlist != null && oldlist.size() > 0) {
-                for(SObject so : oldlist) {
+            if (oldlist != null && oldlist.size() > 0) {
+                for (SObject so : oldlist) {
                     Affiliation__c afflOld = (Affiliation__c)so;
                     String lookupFieldLabel = afflMapper.accRecTypeToContactLabel.get(afflOld.Affiliation_Type__c);
                     String lookupFieldAPIName = afflMapper.contactLabelNames.get(lookupFieldLabel);
@@ -159,7 +158,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
                     Contact relatedContact = relatedContactsMap.get(afflOld.Contact__c);
 
                     //AFTER DELETE - delete lookup relationship, if necessary
-                    if (triggerAction == TDTM_Runnable.Action.AfterDelete && lookupFieldAPIName != null ) {
+                    if (triggerAction == TDTM_Runnable.Action.AfterDelete && lookupFieldAPIName != null) {
                         processAfflDeleted(afflOld, relatedContact, lookupFieldAPIName, dmlWrapper);
                     }
                 }
@@ -167,8 +166,9 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         }
 
 		//AFTER INSERT - Runs when AFTER INSERT Code has not already been run (checked from Recursion Flag - TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert)
-		if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert) && triggerAction == TDTM_Runnable.Action.AfterInsert) {
-			if(newlist != null && newlist.size() > 0) {
+		if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert) 
+             && triggerAction == TDTM_Runnable.Action.AfterInsert) {
+			if (newlist != null && newlist.size() > 0) {
 				for (SObject so : newlist) {
 					Affiliation__c affl = (Affiliation__c)so;
 					createProgramEnrollmentIfNecessary(affl, dmlWrapper);
@@ -180,10 +180,10 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 		dmlWrapper = null;
 		if (triggerAction == TDTM_Runnable.Action.AfterInsert){
 			TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Insert, false);
-		}else if (triggerAction == TDTM_Runnable.Action.BeforeInsert){
+		} else if (triggerAction == TDTM_Runnable.Action.BeforeInsert){
 			TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_Before_Insert, false);
 			TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary);
-		}else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
+		} else if (triggerAction == TDTM_Runnable.Action.AfterUpdate){
 			TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_After_Update, false);
 			TDTM_ProcessControl.resetRecursionFlag(TDTM_ProcessControl.registeredTrigger.AFFL_MultiRecordType_TDTM_afflMadePrimary);
 		}
@@ -193,8 +193,8 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
     public void processAfflDeleted(Affiliation__c afflOld, Contact relatedContact, String lookupFieldAPIName, DmlWrapper dmlWrapper) {
         //If the affl is primary, and the lookup field of this type is pointing to the account that is part of the affl ==> clear the lookup
-        if(afflOld.Primary__c && lookupFieldAPIName != null && relatedContact != null && relatedContact.get(lookupFieldAPIName) == afflOld.Account__c) {
-            if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
+        if (afflOld.Primary__c && lookupFieldAPIName != null && relatedContact != null && relatedContact.get(lookupFieldAPIName) == afflOld.Account__c) {
+            if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
                 relatedContact.put(lookupFieldAPIName, null);
                 dmlWrapper.objectsToUpdate.add(relatedContact);
             }
@@ -205,14 +205,14 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         //Query the primary affiliation fields for all contacts at once
         String contactIDs = '(';
         Map<ID, Contact> relatedContactsMap = new Map<ID, Contact>();
-        if(afflsList != null && afflsList.size() > 0) {
+        if (afflsList != null && afflsList.size() > 0) {
             Affiliation__c firstAffl = (Affiliation__c)afflsList[0];
-            if(firstAffl.Contact__c != null)
+            if (firstAffl.Contact__c != null)
                 contactIDs += '\'' + firstAffl.Contact__c + '\'';
             Integer i = 1;
-            while(i < afflsList.size()) {
+            while (i < afflsList.size()) {
                 Affiliation__c affl = (Affiliation__c)afflsList[i];
-                if(affl.Contact__c != null)
+                if (affl.Contact__c != null)
                     contactIDs += ', \'' + affl.Contact__c + '\'';
                 i++;
             }
@@ -220,12 +220,12 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
 
             //Query all the primary affiliation lookup fields on the contact - they are not available in the trigger.
             String dynamicQuery = 'select ID';
-            for(String primaryField : afflMapper.primaryAfflFieldNames) {
+            for (String primaryField : afflMapper.primaryAfflFieldNames) {
                 dynamicQuery = dynamicQuery + ', ' + primaryField;
             }
             dynamicQuery += ' from Contact where ID IN '+ contactIDs;
             UTIL_Debug.debug('****MRT: Dynamic query: ' + dynamicQuery);
-            if(contactIDs != '()') {
+            if (contactIDs != '()') {
                 List<Contact> relatedContactsList = Database.query(dynamicQuery);
                 for(Contact contact : relatedContactsList) {
                     relatedContactsMap.put(contact.ID, contact);
@@ -238,9 +238,9 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
     private void populateKeyAffls(Affiliation__c affl, String lookupFieldAPIName, Contact relatedContact, DmlWrapper dmlWrapper) {
         //If the reason why Affiliations have been made primary is that key affiliation fields on Contact have been populated,
         //we don't need to try populating them. In fact, this causes an error notification to be sent (W-009272).
-        if(!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
+        if (!TDTM_ProcessControl.getRecursionFlag(TDTM_ProcessControl.registeredTrigger.CON_PrimaryAffls_TDTM_keyAfflLookupUpdated)) {
             //If we have a mapping, populate the lookup field defined in the mapping.
-            if(!String.isBlank(lookupFieldAPIName)) {
+            if (!String.isBlank(lookupFieldAPIName)) {
                 relatedContact.put(lookupFieldAPIName, affl.Account__c);
                 dmlWrapper.objectsToUpdate.add(relatedContact);
             }
@@ -253,7 +253,7 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         Set<String> afflTypes = new Set<String>();
         List<Affiliation__c> oldPrimaryAffls = new List<Affiliation__c>();
 
-        for(Affiliation__c affl : affls) {
+        for (Affiliation__c affl : affls) {
             newPrimaryAffls.add(affl.ID);
             afflContactIDs.add(affl.Contact__c);
             afflTypes.add(affl.Affiliation_Type__c);
@@ -264,10 +264,10 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         from Affiliation__c where Affiliation_Type__c in :afflTypes and Contact__c in :afflContactIDs
         and Primary__c = true and ID not in :newPrimaryAffls];
         //Refine the result
-        for(Affiliation__c otherPrimaryAffl : otherPrimaryAffls) {
+        for (Affiliation__c otherPrimaryAffl : otherPrimaryAffls) {
             //Any pre-existing Affl with the same Contact and the same Type as any new Affl should be added to oldPrimaryAffls
-            for(Affiliation__c newAffl : affls) {
-                if(otherPrimaryAffl.Contact__c == newAffl.Contact__c && otherPrimaryAffl.Affiliation_Type__c == newAffl.Affiliation_Type__c) {
+            for (Affiliation__c newAffl : affls) {
+                if (otherPrimaryAffl.Contact__c == newAffl.Contact__c && otherPrimaryAffl.Affiliation_Type__c == newAffl.Affiliation_Type__c) {
                     oldPrimaryAffls.add(otherPrimaryAffl);
                     break;
                 }
@@ -275,17 +275,17 @@ public class AFFL_MultiRecordType_TDTM extends TDTM_Runnable {
         }
 
         //If the newly created affiliation is the primary, uncheck other primary affiliations of the same type.
-        for(Affiliation__c otherAffl : oldPrimaryAffls) {
+        for (Affiliation__c otherAffl : oldPrimaryAffls) {
             otherAffl.Primary__c = false;
         }
         dmlWrapper.objectsToUpdate.addAll((List<SObject>)oldPrimaryAffls);
     }
 
     private void createProgramEnrollmentIfNecessary(Affiliation__c affl, DmlWrapper dmlWrapper) {
-        if(affl != null && affl.Affiliation_Type__c != null) {
+        if (affl != null && affl.Affiliation_Type__c != null) {
             Boolean needsProgramEnrollment = afflMapper.needsProgramEnrollment(affl);
             UTIL_Debug.debug('****needsProgramEnrollment: ' + needsProgramEnrollment);
-            if(needsProgramEnrollment != null && needsProgramEnrollment) {
+            if (needsProgramEnrollment != null && needsProgramEnrollment) {
                 Program_Enrollment__c enroll = new Program_Enrollment__c(Affiliation__c = affl.ID, Contact__c = affl.Contact__c, Account__c = affl.Account__c);
                 dmlWrapper.objectsToInsert.add(enroll);
             }

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -142,12 +142,12 @@ global without sharing class STG_InstallScript implements InstallHandler {
     global static void insertMappings() {
         List<Affl_Mappings__c> mappings = [select ID from Affl_Mappings__c where Account_Record_Type__c != null AND Primary_Affl_Field__c != null];
         if(mappings.size() == 0) {
-            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic Program', Primary_Affl_Field__c = 'Primary Academic Program', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
-            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational Institution', Primary_Affl_Field__c = 'Primary Educational Institution'));
-            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University Department', Primary_Affl_Field__c = 'Primary Department'));
-            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports Organization', Primary_Affl_Field__c = 'Primary Sports Organization'));
+            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic_Program', Primary_Affl_Field__c = 'Primary Academic Program', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
+            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
+            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'HH_Account', Primary_Affl_Field__c = 'Primary Household'));
+            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational_Institution', Primary_Affl_Field__c = 'Primary Educational Institution'));
+            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University_Department', Primary_Affl_Field__c = 'Primary Department'));
+            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports_Organization', Primary_Affl_Field__c = 'Primary Sports Organization'));            
             insert mappings;
         }
     }


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated the way Affiliation Mappings works when EDA orgs are created for new customers. Now, Affiliations Mappings will use API names for Account record types instead of using labels. We've also updated several Affiliations TDTM classes to accommodate this difference. With these changes, EDA unit tests will pass when run on orgs that also have the K-12 Architecture Kit installed. 

# Issues Closed
#1088 

# New Metadata

# Deleted Metadata

# Testing Notes
