### PR TITLE
[EDA] - Prevent Deletion of Terms if there is a related Course Offering Record

### DIFF
--- a/src/classes/TERM_CannotDelete_TDTM.cls
+++ b/src/classes/TERM_CannotDelete_TDTM.cls
@@ -32,7 +32,8 @@
 * @date 2019
 * @group Terms
 * @group-content ../../ApexDocContent/Terms.htm
-* @description This class prevents Term records from being deleted if it has any Term Grade associations. 
+* @description This class prevents Term records from being deleted if it has any Term Grade 
+* or Course Offering or Application associations. 
 */
 public with sharing class TERM_CannotDelete_TDTM extends TDTM_Runnable {
     /*******************************************************************************************************
@@ -58,12 +59,12 @@ public with sharing class TERM_CannotDelete_TDTM extends TDTM_Runnable {
 
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
             for (Term__c term : [SELECT Id, 
-                                        (SELECT Id 
-                                        FROM Term_Grades__r 
-                                        LIMIT 1) 
-                                FROM Term__c 
+                                        (SELECT Id FROM Term_Grades__r LIMIT 1), 
+                                         (SELECT ID FROM Applications__r LIMIT 1),
+                                          (SELECT ID FROM Course_Offerings__r LIMIT 1)
+                                FROM Term__c
                                 WHERE Id IN :oldlist]) {
-                if (term.Term_Grades__r.size() > 0) {
+                if (term.Term_Grades__r.size() > 0 || term.Applications__r.size() > 0 || term.Course_Offerings__r.size() > 0) {
                     Term__c termInContext = oldmap.get(term.Id);
                     termInContext.addError(Label.CannotDelete);
                 }

--- a/src/classes/TERM_CannotDelete_TEST.cls
+++ b/src/classes/TERM_CannotDelete_TEST.cls
@@ -197,7 +197,7 @@ private class TERM_CannotDelete_TEST {
         
         // Ensure only 1 Term is deleted
         List<Term__c> termsAfterDelete = [SELECT Id FROM TERM__c];
-        System.assertEquals(1, termsAfterDelete.size());       
+        System.assertEquals(4, termsAfterDelete.size());       
     }
 
     /*********************************************************************************************************

--- a/src/classes/TERM_CannotDelete_TEST.cls
+++ b/src/classes/TERM_CannotDelete_TEST.cls
@@ -49,8 +49,8 @@ private class TERM_CannotDelete_TEST {
         insert term;
     }
     
-    /*********************************************************************************************************
-    * @description Test deletion of Terms with Term Grades
+    /*******************************************************************************************************************
+    * @description Tests the deletion of Term with Course Offering and Term Grade when “Prevent Term Deletion” is enabled. 
     */
     @isTest 
     static void testDeleteTermsWithTermGrades() {
@@ -83,7 +83,8 @@ private class TERM_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test deletion of Terms with no Term Grades
+    * @description Tests the deletion of Term without any related child records (Course Offering, Term Grade, 
+    * and Application) when “Prevent Term Deletion” is disabled. 
     */
     @isTest 
     static void testDeleteTermsWithNoTermGrades() {          
@@ -98,7 +99,7 @@ private class TERM_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test deletion of Terms with Term Grades and preventing deletion setting is turned off
+    * @description TTests the deletion of Term with Course Offering and Term Grade when “Prevent Term Deletion” is disabled. 
     */
     @isTest 
     static void testDeleteTermsWithTermGradesSettingOff() {  
@@ -130,7 +131,8 @@ private class TERM_CannotDelete_TEST {
     }
     
     /*********************************************************************************************************
-    * @description Test deletion of Terms with Term Grades and preventing deletion setting is turned off
+    * @description Bulk test deletion of Term records with Course Offering, Term Grade, Application when 
+    * “Prevent Term Deletion” is enabled. 
     */
     @isTest 
     static void testBulkDeleteSettingOn() {  
@@ -201,7 +203,7 @@ private class TERM_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test deletion of Terms with Term Grades and preventing deletion setting is turned off
+    * @description Bulk test deletion of Term records with Course Offering, Term Grade, Application when “Prevent Term Deletion” is disabled. 
     */
     @isTest 
     static void testBulkDeleteSettingOff() {  

--- a/src/classes/TERM_CannotDelete_TEST.cls
+++ b/src/classes/TERM_CannotDelete_TEST.cls
@@ -30,7 +30,7 @@
 * @group Terms
 * @group-content ../../ApexDocContent/Terms.htm
 * @description Unit tests for TERM_CannotDelete_TDTM. These tests
-* make sure Terms cannot be deleted when they have Term Grade Associations.
+* make sure Terms cannot be deleted when they have Term Grade or Course Offering or Application Associations.
 */
 
 
@@ -126,6 +126,148 @@ private class TERM_CannotDelete_TEST {
         Test.stopTest();
         
         List<Term__c> termsList = [SELECT Id FROM Term__c];      
-        System.assertEquals(0, termsList.size());       
-    }     
+        System.assertEquals(0, termsList.size()); 
+    }
+    
+    /*********************************************************************************************************
+    * @description Test deletion of Terms with Term Grades and preventing deletion setting is turned off
+    */
+    @isTest 
+    static void testBulkDeleteSettingOn() {  
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Term_Deletion__c = TRUE));
+        
+        Account academicAccount = [Select Id FROM Account LIMIT 1];
+        
+        Term__c term1 = [SELECT Id FROM Term__c LIMIT 1];
+        
+        List<Term__c> termsToInsert = new List<Term__c>();
+        
+        Term__c term2 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 18');
+        Term__c term3 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 19');
+        Term__c term4 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 21');
+        Term__c term5 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 21');
+        
+        termsToInsert.add(term2);
+        termsToInsert.add(term3);
+        termsToInsert.add(term4);
+        termsToInsert.add(term5);
+         
+        insert termsToInsert;
+        
+        // Insert Contact
+        Contact student = UTIL_UnitTestData_TEST.getContact();  
+        insert student;
+        
+        // Insert Course Offering for Term 1
+        Course_Offering__c courseOffering = UTIL_UnitTestData_TEST.createCourseOffering(NULL, term1.Id);
+        
+        // Insert a Course Connection
+        Course_Enrollment__c courseConnection = UTIL_UnitTestData_TEST.getCourseConnection(student.Id, courseOffering.Id);
+        insert courseConnection;
+        
+        // Insert Term Grade for Term 2
+        List<Term_Grade__c> termGradesToInsert = new List<Term_Grade__c>();
+        Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGradeWTermCourseConn(term2.Id, courseConnection.Id);
+        termGradesToInsert.add(termGrade);
+        
+        // Insert Application for Term 3
+        List<Application__c> applicaitonsToInsert = new List<Application__c>();
+        Application__c application =  UTIL_UnitTestData_TEST.getApplication(academicAccount.Id, student.Id, term3.Id);
+        applicaitonsToInsert.add(application);
+        
+        // Insert Course offering, Term Grades and Application for Term 4
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(NULL, term4.Id);
+        
+        Term_Grade__c termGrade2 = UTIL_UnitTestData_TEST.getTermGradeWTermCourseConn(term4.Id, courseConnection.Id);
+        termGradesToInsert.add(termGrade2);
+        
+        // Insert Term Grades
+        insert termGradesToInsert;
+        
+        Application__c application2 =  UTIL_UnitTestData_TEST.getApplication(academicAccount.Id, student.Id, term4.Id);
+        applicaitonsToInsert.add(application2);
+        
+        // Insert Applicaitons
+        insert applicaitonsToInsert;
+        
+        Test.startTest();
+            List<Term__c> termsToDelete = [SELECT Id FROM TERM__c];
+            Database.DeleteResult[] results = Database.delete(termsToDelete, false);
+        Test.stopTest();
+        
+        // Ensure only 1 Term is deleted
+        List<Term__c> termsAfterDelete = [SELECT Id FROM TERM__c];
+        System.assertEquals(1, termsAfterDelete.size());       
+    }
+
+    /*********************************************************************************************************
+    * @description Test deletion of Terms with Term Grades and preventing deletion setting is turned off
+    */
+    @isTest 
+    static void testBulkDeleteSettingOff() {  
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Term_Deletion__c = False));
+        
+        Account academicAccount = [Select Id FROM Account LIMIT 1];
+        
+        Term__c term1 = [SELECT Id FROM Term__c LIMIT 1];
+        
+        List<Term__c> termsToInsert = new List<Term__c>();
+        
+        Term__c term2 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 18');
+        Term__c term3 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 19');
+        Term__c term4 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 21');
+        Term__c term5 = UTIL_UnitTestData_TEST.getTerm(academicAccount.Id, 'Spring 21');
+        
+        termsToInsert.add(term2);
+        termsToInsert.add(term3);
+        termsToInsert.add(term4);
+        termsToInsert.add(term5);
+         
+        insert termsToInsert;
+        
+        // Insert Contact
+        Contact student = UTIL_UnitTestData_TEST.getContact();  
+        insert student;
+        
+        // Insert Course Offering for Term 1
+        Course_Offering__c courseOffering = UTIL_UnitTestData_TEST.createCourseOffering(NULL, term1.Id);
+        
+        // Insert a Course Connection
+        Course_Enrollment__c courseConnection = UTIL_UnitTestData_TEST.getCourseConnection(student.Id, courseOffering.Id);
+        insert courseConnection;
+        
+        // Insert Term Grade for Term 2
+        List<Term_Grade__c> termGradesToInsert = new List<Term_Grade__c>();
+        Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGradeWTermCourseConn(term2.Id, courseConnection.Id);
+        termGradesToInsert.add(termGrade);
+        
+        // Insert Application for Term 3
+        List<Application__c> applicaitonsToInsert = new List<Application__c>();
+        Application__c application =  UTIL_UnitTestData_TEST.getApplication(academicAccount.Id, student.Id, term3.Id);
+        applicaitonsToInsert.add(application);
+        
+        // Insert Course offering, Term Grades and Application for Term 4
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(NULL, term4.Id);
+        
+        Term_Grade__c termGrade2 = UTIL_UnitTestData_TEST.getTermGradeWTermCourseConn(term4.Id, courseConnection.Id);
+        termGradesToInsert.add(termGrade2);
+        
+        // Insert Term Grades
+        insert termGradesToInsert;
+        
+        Application__c application2 =  UTIL_UnitTestData_TEST.getApplication(academicAccount.Id, student.Id, term4.Id);
+        applicaitonsToInsert.add(application2);
+        
+        // Insert Applicaitons
+        insert applicaitonsToInsert;
+        
+        Test.startTest();
+            List<Term__c> termsToDelete = [SELECT Id FROM TERM__c];
+            Database.DeleteResult[] results = Database.delete(termsToDelete, false);
+        Test.stopTest();
+        
+        // Ensure all Terms are deleted
+        List<Term__c> termsAfterDelete = [SELECT Id FROM TERM__c];
+        System.assertEquals(0, termsAfterDelete.size());       
+    }   
 }

--- a/src/classes/TERM_CannotDelete_TEST.cls
+++ b/src/classes/TERM_CannotDelete_TEST.cls
@@ -99,7 +99,7 @@ private class TERM_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description TTests the deletion of Term with Course Offering and Term Grade when “Prevent Term Deletion” is disabled. 
+    * @description Tests the deletion of Term with Course Offering and Term Grade when “Prevent Term Deletion” is disabled. 
     */
     @isTest 
     static void testDeleteTermsWithTermGradesSettingOff() {  

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -162,6 +162,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Contact_Deletion__c = mySettings.Prevent_Contact_Deletion__c;
         settings.Prevent_Course_Offering_Deletion__c = mySettings.Prevent_Course_Offering_Deletion__c;
         settings.Prevent_Course_Connection_Deletion__c = mySettings.Prevent_Course_Connection_Deletion__c;
+        settings.Prevent_Term_Deletion__c = mySettings.Prevent_Term_Deletion__c;
         orgSettings = settings;
         return settings;
     }

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -620,9 +620,9 @@ public class UTIL_UnitTestData_TEST {
     
     /*********************************************************************************************************
     * @description Gets an Application for testing.
-    @Params appyingTo The Id of the Account 
-    @params student The Id of the Contact
-    @params terms the Id of the Term
+    * @Params appyingTo The Id of the Account 
+    * @params student The Id of the Contact
+    * @params terms the Id of the Term
     * @return The Application record.
     **********************************************************************************************************/
     public static Application__c getApplication(Id appyingTo, Id student, Id term) {

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -617,6 +617,18 @@ public class UTIL_UnitTestData_TEST {
         Facility__c facility = new Facility__c(Name = 'Test Facility ' + Datetime.now().getTime());
         return facility;
     }
+    
+    /*********************************************************************************************************
+    * @description Gets an Application for testing.
+    @Params appyingTo The Id of the Account 
+    @params student The Id of the Contact
+    @params terms the Id of the Term
+    * @return The Application record.
+    **********************************************************************************************************/
+    public static Application__c getApplication(Id appyingTo, Id student, Id term) {
+        Application__c application = new Application__c(Applying_To__c = appyingTo, Applicant__c = student, Term__c = term);
+        return application;
+    }
 
     /*********************************************************************************************************
     * @description Creates fake Ids for given sObject.


### PR DESCRIPTION
# Critical Changes

# Changes

We've updated the functionality to prevent the deletion of Term records that have related Application or Course Offering records. This change is for internal-use only and is disabled at this time. You won't see any difference in functionality.
Note: We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI.

# Issues Closed
#1086 

# New Metadata

# Deleted Metadata

# Testing Notes
Scenario 1: “Prevent Term Deletion” checkbox is enabled and Course Offering record has related Term Grade, Course Offering, or Application records.
Check “Prevent Term Deletion” checkbox in Hierarchy Settings.
Create a Term record
Associate a Course Offering, Term Grade and Application record.
Delete the Term record.
You should receive a pop up error that you cannot delete this Course Offering. See https://salesforce.quip.com/x5xKAGcHko2L#fIEACAMe5GG for the error message.

Scenario 2: “Prevent Term Deletion” checkbox is enabled and Course Offering record does not have related Term Grade, Application, or Course Offering records.
Check “Prevent Term Deletion” checkbox in Hierarchy Settings.
Create a Term record
You should be able to delete the Term record.

Scenario 3: “Prevent Term Deletion” checkbox is disabled and Term Grade record has related Term, Course Connection, or Course Offering records.
Uncheck “Prevent Term Deletion” checkbox in Hierarchy Settings.
Create a Term record
Associate a Course Offering, Term Grade and Application record.
Delete the Term record
You should be able to delete the Term record

Scenario 4: “Prevent Term Deletion” checkbox is disabled and Term record does not have related Term Grade, Course Connection, or Course Offering Schedule records.
UnCheck “Prevent Term Deletion” checkbox in Hierarchy Settings.
Create a Term record
Delete the Term record
You should be able to delete the Term record


