### PR TITLE
[EDA] Prevent Deletion of a Case when there is a Related Behavior Involvement Record

### DIFF
--- a/src/classes/CASE_CannotDelete_TDTM.cls
+++ b/src/classes/CASE_CannotDelete_TDTM.cls
@@ -1,0 +1,73 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Cases
+* @group-content ../../ApexDocContent/Case.htm
+* @description This class prevents Case records from being deleted if
+* it has any Behavior Involvement associations.
+*/
+public with sharing class CASE_CannotDelete_TDTM extends TDTM_Runnable {
+    /*******************************************************************************************************
+    * @description Get the setting of preventing Case deletion
+    */
+    private static Boolean enabledPreventCaseDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Case_Deletion__c;
+
+    /*******************************************************************************************************
+    * @description Prevents Case records from being deleted if it has any Behavior Involvement associations.
+    * @param newList the list of Case from trigger new.
+    * @param oldList the list of Case from trigger old.
+    * @param triggerAction which trigger event (BeforeDelete).
+    * @param objResult the describe for Case.
+    * @return dmlWrapper.
+    ********************************************************************************************************/
+     public override DmlWrapper run(List<SObject> newList, List<SObject> oldList,
+     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+        if (!enabledPreventCaseDeletion) {
+            return new DmlWrapper();
+        }
+
+        Map<ID, Case> oldmap = new Map<ID, Case>((List<Case>)oldlist);
+
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            for (Case caseRecord : [SELECT Id,
+                                        (SELECT Id FROM Behavior_Involvements__r LIMIT 1)
+                                    FROM Case
+                                    WHERE Id IN :oldlist]) {
+                if (caseRecord.Behavior_Involvements__r.size() > 0) {
+                    Case caseInContext = oldmap.get(caseRecord.Id);
+                    caseInContext.addError(Label.CannotDelete);
+                }
+            }
+        }
+        return new DmlWrapper();
+    }
+}

--- a/src/classes/CASE_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/CASE_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CASE_CannotDelete_TEST.cls
+++ b/src/classes/CASE_CannotDelete_TEST.cls
@@ -82,7 +82,7 @@ private class CASE_CannotDelete_TEST {
 
         Test.startTest();
             List<Case> casesToDelete = [SELECT Id FROM Case];
-            Database.DeleteResult[] results = Database.delete(casesToDelete, false);
+            Database.DeleteResult[] results = Database.delete(casesToDelete, FALSE);
         Test.stopTest();
 
         // Ensure no Cases are deleted
@@ -95,11 +95,11 @@ private class CASE_CannotDelete_TEST {
     */
     @isTest
     static void testCaseDeleteSettingOff() {
-        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Case_Deletion__c = False));
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Case_Deletion__c = FALSE));
 
         Test.startTest();
             List<Case> casesToDelete = [SELECT Id FROM Case];
-            Database.DeleteResult[] results = Database.delete(casesToDelete, false);
+            Database.DeleteResult[] results = Database.delete(casesToDelete, FALSE);
         Test.stopTest();
 
         // Ensure all Cases are deleted

--- a/src/classes/CASE_CannotDelete_TEST.cls
+++ b/src/classes/CASE_CannotDelete_TEST.cls
@@ -1,0 +1,109 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Cases
+* @group-content ../../ApexDocContent/Case.htm
+* @description Unit tests for CASE_CannotDelete_TDTM. These tests
+* make sure Cases cannot be deleted when they have Behavior Involvement Associations.
+*/
+
+@isTest
+private class CASE_CannotDelete_TEST {
+
+    @testSetup
+    static void dataSetup() {
+        
+        // Insert Contacts
+        List<Contact> students = new List<Contact>();
+        
+        Contact student1 = UTIL_UnitTestData_TEST.getContact();
+        Contact student2 = UTIL_UnitTestData_TEST.getContact();
+        
+        students.add(student1);
+        students.add(student2);
+
+        insert students;
+
+        // Insert Cases
+        List<Case> cases = new List<Case>();
+        Case case1 = UTIL_UnitTestData_TEST.getCase(student1.Id, 'School Violation', 'New');
+        Case case2 = UTIL_UnitTestData_TEST.getCase(student2.Id, 'School Violation', 'New');
+
+        cases.add(case1);
+        cases.add(case2);
+
+        insert cases;
+
+        // Insert Behavior Involvement records
+        List<Behavior_Involvement__c> behaviorRecords = new List<Behavior_Involvement__c>();
+
+        Behavior_Involvement__c behavInvolRec1 = UTIL_UnitTestData_TEST.getBehaviorInvolvementRecord(student1.Id, case1.Id, 'Victim');
+        Behavior_Involvement__c behavInvolRec2 = UTIL_UnitTestData_TEST.getBehaviorInvolvementRecord(student2.Id, case2.Id, 'Witness');
+
+        behaviorRecords.add(behavInvolRec1);
+        behaviorRecords.add(behavInvolRec2);
+
+        insert behaviorRecords;
+    }
+
+
+    /*************************************************************************************************************
+    * @description Test deletion of Cases with Behavior Involvement and preventing deletion setting is turned On
+    */
+    @isTest
+    static void testCaseDeleteSettingOn() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Case_Deletion__c = TRUE));
+
+        Test.startTest();
+            List<Case> casesToDelete = [SELECT Id FROM Case];
+            Database.DeleteResult[] results = Database.delete(casesToDelete, false);
+        Test.stopTest();
+
+        // Ensure no Cases are deleted
+        List<Case> casesAfterDelete = [SELECT Id FROM Case];
+        System.assertEquals(2, casesAfterDelete.size());
+    }
+
+    /*************************************************************************************************************
+    * @description Test deletion of Cases with Behavior Involvement and preventing deletion setting is turned Off
+    */
+    @isTest
+    static void testCaseDeleteSettingOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Prevent_Case_Deletion__c = False));
+
+        Test.startTest();
+            List<Case> casesToDelete = [SELECT Id FROM Case];
+            Database.DeleteResult[] results = Database.delete(casesToDelete, false);
+        Test.stopTest();
+
+        // Ensure all Cases are deleted
+        List<Case> casesAfterDelete = [SELECT Id FROM Case];
+        System.assertEquals(0, casesAfterDelete.size());
+    }
+}

--- a/src/classes/CASE_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/CASE_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -239,6 +239,11 @@ public without sharing class TDTM_DefaultConfig {
                 Class__c = 'CCON_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Course_Enrollment__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
 
+        // Prevents deletion of Case when the records have associated child records
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'CASE_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Case',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
+
         return handlers;
 
     }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -162,6 +162,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Contact_Deletion__c = mySettings.Prevent_Contact_Deletion__c;
         settings.Prevent_Course_Offering_Deletion__c = mySettings.Prevent_Course_Offering_Deletion__c;
         settings.Prevent_Course_Connection_Deletion__c = mySettings.Prevent_Course_Connection_Deletion__c;
+        settings.Prevent_Case_Deletion__c = mySettings.Prevent_Case_Deletion__c;
         orgSettings = settings;
         return settings;
     }

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -617,6 +617,35 @@ public class UTIL_UnitTestData_TEST {
         Facility__c facility = new Facility__c(Name = 'Test Facility ' + Datetime.now().getTime());
         return facility;
     }
+    
+    /*********************************************************************************************************
+    * @description Gets a Case record for testing based on the parameter
+    * @param student The Contact record to associate the Case with
+    * @param category The case Category
+    * @Param status The status of the Case
+    * @return The Case record
+    **********************************************************************************************************/
+
+    public static Case getCase(Id student, String category, String status) {
+    	Case caseRecord =  new Case(ContactId = student, Occurrence_Date__c = Date.today(),
+    	                             Category__c = category, Status = status);
+        return caseRecord;
+    }
+    
+    /*********************************************************************************************************
+    * @description Gets a Behavior Involvement record for testing based on the parameter
+    * @param student The Contact record to associate the Beahvior Involvement with
+    * @param caseId The Case record to assocaite the Beahvior Involvement with
+    * @param role The role of the Student involved
+    * @return The Behavior Involvement record
+    **********************************************************************************************************/
+
+    public static Behavior_Involvement__c getBehaviorInvolvementRecord(Id student, Id caseId, String role) {
+    	Behavior_Involvement__c behavInvolvement =  new Behavior_Involvement__c(Contact__c = student,
+                                                                                Case__c = caseId,
+                                                                                Role__c = role);
+        return behavInvolvement;
+    }
 
     /*********************************************************************************************************
     * @description Creates fake Ids for given sObject.

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -645,6 +645,9 @@ public class UTIL_UnitTestData_TEST {
                                                                                 Case__c = caseId,
                                                                                 Role__c = role);
         return behavInvolvement;
+    }
+    
+    /**********************************************************************************************************    
     * @description Gets an Application for testing.
     * @Params appyingTo The Id of the Account 
     * @params student The Id of the Contact

--- a/src/package.xml
+++ b/src/package.xml
@@ -31,6 +31,8 @@
         <members>Advancement_Adapter</members>
         <members>Advancement_Adapter_TEST</members>
         <members>Advancement_Info</members>
+        <members>CASE_CannotDelete_TDTM</members>
+        <members>CASE_CannotDelete_TEST</members>
         <members>CCON_CannotDelete_TDTM</members>
         <members>CCON_CannotDelete_TEST</members>
         <members>CCON_ConnectionBackfill_BATCH</members>


### PR DESCRIPTION
# Critical Changes

# Changes
We've added functionality to prevent the deletion of Case records that have related Behavior Involvement records. This change is for internal-use only and is disabled at this time. You won't see any difference in functionality.
**Note:** We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI.

# Issues Closed
Closes #1091 

# New Metadata

# Deleted Metadata

# Testing Notes

Scenario 1: “Prevent Case Deletion” checkbox is enabled and Case record has related Behavior Involvement records.
Check “Prevent Case Deletion” checkbox in Hierarchy Settings.
Create a Case record
Associate a Behavior Involvement record.
Delete the Case record.
You should receive a pop up error that you cannot delete this Course Offering. See https://salesforce.quip.com/xZuIAOMoQoJD#PPOACAn2eHJ for the error message.

Scenario 2: “Prevent Case Deletion” checkbox is enabled and Case record has no related child records.
Check “Prevent Case Deletion” checkbox in Hierarchy Settings.
Create a Case record
Do not associate any child records
Delete the Case record.
You should be able to delete the record

Scenario 3: “Prevent Case Deletion” checkbox is disabled and Case record has Behavior Involvement record child records.
UnCheck “Prevent Case Deletion” checkbox in Hierarchy Settings.
Create a Case record
Associate a Behavior Involvement record.
Delete the Case record.
You should be able to delete the record

Scenario 4: “Prevent Case Deletion” checkbox is disabled and Case record has no related child records.
UnCheck “Prevent Case Deletion” checkbox in Hierarchy Settings.
Create a Case record
Delete the Case record.
You should be able to delete the record
