### PR TITLE
[EDA] Field Encryption Is Failing on ACCT_IndividualsAccount_TEST

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -269,7 +269,7 @@ private class ACCT_IndividualAccounts_TEST {
      @isTest
      public static void deleteContactNoOpps() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
-                    									Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
+                                                        Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         String newContactMailingStreet = '123 Elm St';
 
@@ -304,7 +304,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void deleteContactWithOppAdm() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
-                                    					Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
+                                                        Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         String newContactMailingStreet = '123 Elm St';
 
@@ -345,7 +345,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void deleteContactNormalAccount() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
-                                    					Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
+                                                        Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         List<Account> orgAccounts = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID());
         insert orgAccounts[0];
@@ -410,7 +410,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactNewHHAcc() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
@@ -431,7 +431,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHAcc() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -469,7 +469,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHAccSameLastNameWithParenthesis() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!LastName} ({!FirstName}) Household',
+                                                        Household_Account_Naming_Format__c = '{!LastName} ({!FirstName}) Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -505,7 +505,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHAccSameLastName() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -542,7 +542,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void updateContactExistingHHAcc() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -589,7 +589,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHAccNotAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = false));
 
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
@@ -623,7 +623,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHAccExcludedFromNaming() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -666,7 +666,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void updateContactExistingHHAccNotAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = false));
 
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
@@ -711,7 +711,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void deleteContactFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -756,7 +756,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void disconnectContactFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -804,7 +804,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void deleteAllContactsFromHHAccAutomatic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                        Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
@@ -977,7 +977,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHNewConEmptyString() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-               											Household_Account_Naming_Format__c = Label.acctNamingOther,
+                                                           Household_Account_Naming_Format__c = Label.acctNamingOther,
                                                         Household_Other_Name_Setting__c = '{!Salutation} {!FirstName} Family',
                                                         Automatic_Household_Naming__c = true));
 
@@ -1015,7 +1015,7 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void newContactExistingHHExistingConEmptyString() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                										Household_Account_Naming_Format__c = Label.acctNamingOther,
+                                                        Household_Account_Naming_Format__c = Label.acctNamingOther,
                                                         Household_Other_Name_Setting__c = '{!Salutation} {!FirstName} Family',
                                                         Automatic_Household_Naming__c = true));
 
@@ -1199,8 +1199,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void testHandleInsertWrapperLogic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                       	Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
-                                                       	Automatic_Household_Naming__c = true));
+                                                           Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                           Automatic_Household_Naming__c = true));
 
         List<Account> accts = UTIL_UnitTestData_API.getMultipleTestAccounts(2, UTIL_Describe_API.getHhAccRecTypeID());
         insert accts;
@@ -1233,8 +1233,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void testHandleUpdateWrapperLogic() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
-                                                       	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                           Automatic_Household_Naming__c = true));
         List<Contact> cons = UTIL_UnitTestData_API.getMultipleTestContacts(2);
         insert cons;
 
@@ -1281,8 +1281,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void testBulkUpdateContactNames() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                       	Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
-                                                      	Automatic_Household_Naming__c = true));
+                                                           Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                          Automatic_Household_Naming__c = true));
         List<Contact> cons = UTIL_UnitTestData_API.getMultipleTestContacts(2);
         insert cons;
         List<Account> hhAccounts = [SELECT Id, Name FROM Account];
@@ -1325,8 +1325,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void testHandlesAfterDelete() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                       	Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
-                                                       	Automatic_Household_Naming__c = true));
+                                                           Household_Account_Naming_Format__c = '{!FirstName} {!LastName} Household',
+                                                           Automatic_Household_Naming__c = true));
         Contact con = UTIL_UnitTestData_API.getContact();
         insert con;
 
@@ -1353,8 +1353,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsFirstLastNames() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!{!FirstName}} {!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!{!FirstName}} {!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
@@ -1408,8 +1408,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsLastFirstNames() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} ({!{!FirstName}}) Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} ({!{!FirstName}}) Household',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
@@ -1464,8 +1464,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsLastNameOnly() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
@@ -1505,8 +1505,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsWithoutFirstNames() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!{!FirstName}} {!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!{!FirstName}} {!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
@@ -1546,12 +1546,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsWithCustomFormat() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!{!FirstName} {!LastName}} House',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!{!FirstName} {!LastName}} House',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
-		Contact con = UTIL_UnitTestData_API.getContact();
+        Contact con = UTIL_UnitTestData_API.getContact();
         con.FirstName = 'Marvin';
         con.LastName = 'Johnston';
         insert con;
@@ -1576,7 +1576,7 @@ private class ACCT_IndividualAccounts_TEST {
         insert con3;
 
         Account requeryFinalAccount = [SELECT Id, Name
-                                  	   FROM Account
+                                         FROM Account
                                        WHERE Id = :requeryInsertedCon.AccountId];
         System.assertEquals(con.FirstName + ' ' + con.LastName + ', ' +
                             con2.FirstName + ' ' + con2.LastName + ' ' +
@@ -1592,12 +1592,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void sortContactsWithCustomFormat2() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!Salutation} {!{!FirstName}} {!LastName} Family',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!Salutation} {!{!FirstName}} {!LastName} Family',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
-		Contact con = UTIL_UnitTestData_API.getContact();
+        Contact con = UTIL_UnitTestData_API.getContact();
         con.Salutation = 'Ms.';
         con.FirstName = 'Betty';
         con.LastName = 'White';
@@ -1623,7 +1623,7 @@ private class ACCT_IndividualAccounts_TEST {
         insert con3;
 
         Account requeryFinalAccount = [SELECT Id, Name
-                                  	   FROM Account
+                                         FROM Account
                                        WHERE Id = :requeryInsertedCon.AccountId];
         System.assertEquals(con.Salutation + ' ' + con.FirstName + ', ' + con2.FirstName + ' ' + andConnector + ' ' +
                             con3.FirstName + ' ' + con3.LastName + ' ' + 'Family',requeryFinalAccount.Name);
@@ -1636,8 +1636,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void contactMarkedDeceased() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
@@ -1682,7 +1682,7 @@ private class ACCT_IndividualAccounts_TEST {
         List<Contact> newContacts = UTIL_UnitTestData_API.getMultipleTestContacts(5);
         for (Integer i = 0; i<newContacts.size(); i++) {
             for (Contact c : newContacts) {
-            	c.FirstName = 'ConFirstName ' + i;
+                c.FirstName = 'ConFirstName ' + i;
                 c.LastName = 'ConLastName ' + i;
             }
         }
@@ -1725,8 +1725,8 @@ private class ACCT_IndividualAccounts_TEST {
         insert addThirdContacts;
 
         List<Contact> returnSecondContacts = [SELECT Id, FirstName, Deceased__c
-                                             FROM Contact
-                                             WHERE FirstName LIKE 'ConSecondName%'];
+                                                FROM Contact
+                                                WHERE Id IN :addSecondContacts];
         for (Contact con : returnSecondContacts) {
             con.Deceased__c = true;
         }
@@ -1745,13 +1745,13 @@ private class ACCT_IndividualAccounts_TEST {
                 String FirstName3= 'ConThirdName ' + i;
                 String LastName = 'ConLastName ' + i;
 
-            	System.assertEquals(LastName + ' (' + FirstName1 + ' and ' +
-                					FirstName3 + ') ' + ' Household', returnAccounts[i].Name);
+                System.assertEquals(LastName + ' (' + FirstName1 + ' and ' +
+                                    FirstName3 + ') ' + ' Household', returnAccounts[i].Name);
         }
 
         List<Contact> returnThirdContacts = [SELECT Id, FirstName, Deceased__c
                                              FROM Contact
-                                             WHERE FirstName LIKE 'ConThirdName%'];
+                                             WHERE Id IN :addThirdContacts];
 
         for (Contact conThree : returnThirdContacts) {
             conThree.Deceased__c = true;
@@ -1767,7 +1767,7 @@ private class ACCT_IndividualAccounts_TEST {
                 String FirstName1= 'ConFirstName ' + i;
                 String LastName = 'ConLastName ' + i;
 
-            	System.assertEquals(LastName + ' (' + FirstName1 + ') ' + ' Household', returnAccounts[i].Name);
+                System.assertEquals(LastName + ' (' + FirstName1 + ') ' + ' Household', returnAccounts[i].Name);
         }
     }
 
@@ -1790,8 +1790,8 @@ private class ACCT_IndividualAccounts_TEST {
         insert newContacts;
 
         List<Contact> requeryInsertedCon = [SELECT Id, FirstName, LastName, AccountId, Account.Name
-                                      		FROM Contact
-                                      		WHERE Id IN :newContacts];
+                                              FROM Contact
+                                              WHERE Id IN :newContacts];
 
         requeryInsertedCon[0].Deceased__c = true;
         requeryInsertedCon[1].FirstName = 'Betty';
@@ -1818,12 +1818,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void deceasedContacts() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
-		insert con;
+        insert con;
 
         Contact requeryInsertedCon = [SELECT Id, AccountId, Account.Name
                                       FROM Contact
@@ -1859,12 +1859,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void contactMarkedExcludedFromHHNaming() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
-		insert con;
+        insert con;
 
         Contact requeryInsertedCon = [SELECT Id, AccountId, Account.Name
                                       FROM Contact
@@ -1897,12 +1897,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void allContactsMarkedExcludedFromHHNaming() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
-		insert con;
+        insert con;
 
         Contact requeryInsertedCon = [SELECT Id, AccountId, Account.Name
                                       FROM Contact
@@ -1937,12 +1937,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void lastContactIsDeleted() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
-		insert con;
+        insert con;
 
         Contact requeryInsertedCon = [SELECT Id, AccountId, Account.Name
                                       FROM Contact
@@ -1978,12 +1978,12 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     public static void contactDeleted() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = '{!LastName} Household',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = '{!LastName} Household',
+                                                         Automatic_Household_Naming__c = true));
 
         Contact con = UTIL_UnitTestData_API.getContact();
         con.LastName = 'Thomas';
-		insert con;
+        insert con;
 
         Contact requeryInsertedCon = [SELECT Id, AccountId, Account.Name
                                       FROM Contact
@@ -2038,8 +2038,8 @@ private class ACCT_IndividualAccounts_TEST {
     @isTest
     private static void testBulkPrefix(){
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID(),
-                                                     	Household_Account_Naming_Format__c = 'Foyer {!LastName} ({!{!FirstName}})',
-                                                     	Automatic_Household_Naming__c = true));
+                                                         Household_Account_Naming_Format__c = 'Foyer {!LastName} ({!{!FirstName}})',
+                                                         Automatic_Household_Naming__c = true));
 
         String andConnector = Label.defaultNamingConnector;
 
@@ -2055,7 +2055,7 @@ private class ACCT_IndividualAccounts_TEST {
         newCons[0].LastName = 'Pens';
         newCons[1].FirstName = 'Betty';
         newCons[1].LastName = 'Jones';
-       	insert newCons;
+           insert newCons;
 
         List<Id> accountIds = new List<Id>();
         List<Contact> queryContacts = [SELECT Id, AccountId, Account.Name,
@@ -2077,8 +2077,8 @@ private class ACCT_IndividualAccounts_TEST {
         Test.stopTest();
 
         List<Account> returnAccounts = [SELECT Id, Name
-                                       	FROM Account
-                                       	WHERE Id IN :accountIds];
+                                           FROM Account
+                                           WHERE Id IN :accountIds];
         System.assertEquals('Foyer Pens ' + '(Jane ' + andConnector + ' John)', returnAccounts[0].Name);
         System.assertEquals('Foyer Jones ' + '(Betty ' + andConnector + ' Tommy)', returnAccounts[1].Name);
 

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -1310,13 +1310,19 @@ private class ACCT_IndividualAccounts_TEST {
         update cons;
         Test.stopTest();
 
-        //Account name should now be named for the contact that belongs to it
-        List<Account> johnsonAccount = [SELECT Id, Name FROM Account WHERE Name = 'Jenny Johnson Household'];
-        System.assertEquals(1, johnsonAccount.size(), 'number of accounts after name update does not match expected value of 1');
-        System.assertEquals('Jenny Johnson Household', johnsonAccount[0].Name, 'account name does not match expected name');
-        List<Account> smithAccount = [SELECT Id, Name FROM Account WHERE Name = 'Samantha Smith Household'];
-        System.assertEquals(1, smithAccount.size(), 'number of accounts after name update does not match expected value of 1');
-        System.assertEquals('Samantha Smith Household', smithAccount[0].Name, 'account name does not match expected name');
+        List<Contact> returnContacts = [SELECT Id, AccountId, Account.Name, LastName
+                                        FROM Contact
+                                        WHERE Id IN :cons];
+        System.assertEquals(2, returnContacts.size()); 
+        
+        Map<String, String> lastNameByAccountName = new Map<String, String>(); 
+        for (Contact c : returnContacts) {
+            if (c.AccountId != NULL) {
+                lastNameByAccountName.put(c.LastName, c.Account.Name); 
+            }
+        }
+		System.assertEquals('Jenny Johnson Household', lastNameByAccountName.get('Johnson')); 
+		System.assertEquals('Samantha Smith Household', lastNameByAccountName.get('Smith')); 
     }
 
     /*********************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes
We've made an update that enables customers who encrypted the Name field on the Contact object to successfully install EDA release 1.92.

# Issues Closed
Closes #1105

# New Metadata

# Deleted Metadata

# Testing Notes
Pre-requisite: 
- Enable encryption
- Set "Name" encrypted on Contact

Scenario 1: Bulk test: Update x amount of Contacts from different Accounts and mark the "Deceased" or "Exclude From Household Naming" checkboxes true.
Steps:

Create multiple Contacts and Accounts
Ensure you have multiple Contacts on the same Account
Ensure you have multiple Accounts
Update 1 Contact from each Account by marking either "Deceased" or "Exclude From Household Naming".
All Account names should be updated with just the Contacts left on the Account that are not marked Deceased or Excluded from Household Naming.
Scenario 2: Bulk test: Update x amount of Contacts from different Accounts and mark some of the Contacts "Deceased" or "Exclude From Household Naming" checkboxes true, and some Contacts update their FirstName or LastName but do not mark them as "Deceased" or "Exclude From Household Naming"
Steps:

Create multiple Contacts and Accounts
Ensure you have multiple Contacts on the same Account
Ensure you have multiple Accounts
Update 1 Contact from each Account by marking either "Deceased" or "Exclude From Household Naming" or updating their FirstName or LastName.
All Account names should be updated with just the Contacts left on the Account that are not marked "Deceased" or "Excluded from Household Naming" and the Contacts that were updated but nor marked "Deceased" or "Excluded from Household Naming" should still reflect on the Account name.
Scenario 3: Non bulk: Update 1 Contact from an Account and marked it "Deceased" or "Exclude From Household Naming".
Steps:

Create an Account with multiple Contacts
Update 1 Contact and marked "Deceased" or "Exclude From Household Naming"
Account name should be updated with just the Contacts left on the Account that are not marked "Deceased" or "Exclude From Household Naming"