### PR TITLE
[EDA] Update the API version number EDA wide

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -4,7 +4,7 @@ project:
     package:
         name: EDA
         namespace: hed
-        api_version: 45.0
+        api_version: 48.0
         install_class: STG_InstallScript
     git:
         prefix_release: rel/

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -6,5 +6,5 @@
     }
   ],
   "namespace": "hed",
-  "sourceApiVersion": "45.0"
+  "sourceApiVersion": "48.0"
 }

--- a/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp-meta.xml
+++ b/src/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Component for account(Admin and HH) name format settings</description>
 </AuraDefinitionBundle>

--- a/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp-meta.xml
+++ b/src/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/CMP_RecTypes/CMP_RecTypes.cmp-meta.xml
+++ b/src/aura/CMP_RecTypes/CMP_RecTypes.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>DESCRIPTION</description>
 </AuraDefinitionBundle>

--- a/src/aura/CMP_RecTypes_Dropdown/CMP_RecTypes_Dropdown.cmp-meta.xml
+++ b/src/aura/CMP_RecTypes_Dropdown/CMP_RecTypes_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>DESCRIPTION</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_App/STG_App.app-meta.xml
+++ b/src/aura/STG_App/STG_App.app-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp-meta.xml
+++ b/src/aura/STG_CMP_Addr/STG_CMP_Addr.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp-meta.xml
+++ b/src/aura/STG_CMP_Affl/STG_CMP_Affl.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Base/STG_CMP_Base.cmp-meta.xml
+++ b/src/aura/STG_CMP_Base/STG_CMP_Base.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Container/STG_CMP_Container.cmp-meta.xml
+++ b/src/aura/STG_CMP_Container/STG_CMP_Container.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Container for the settings components</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp-meta.xml
+++ b/src/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Course Connections Settings Component</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Courses/STG_CMP_Courses.cmp-meta.xml
+++ b/src/aura/STG_CMP_Courses/STG_CMP_Courses.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A settings component for Courses</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Header/STG_CMP_Header.cmp-meta.xml
+++ b/src/aura/STG_CMP_Header/STG_CMP_Header.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_ProgramPlans/STG_CMP_ProgramPlans.cmp-meta.xml
+++ b/src/aura/STG_CMP_ProgramPlans/STG_CMP_ProgramPlans.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>STG_CMP_ProgramPlans</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp-meta.xml
+++ b/src/aura/STG_CMP_Rel/STG_CMP_Rel.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp-meta.xml
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp-meta.xml
+++ b/src/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_EVT_Cancel/STG_EVT_Cancel.evt-meta.xml
+++ b/src/aura/STG_EVT_Cancel/STG_EVT_Cancel.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Edit Settings Event</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_EVT_Edit/STG_EVT_Edit.evt-meta.xml
+++ b/src/aura/STG_EVT_Edit/STG_EVT_Edit.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Edit Settings Event</description>
 </AuraDefinitionBundle>

--- a/src/aura/STG_EVT_Save/STG_EVT_Save.evt-meta.xml
+++ b/src/aura/STG_EVT_Save/STG_EVT_Save.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Save Settings Event</description>
 </AuraDefinitionBundle>

--- a/src/aura/autocomplete/autocomplete.cmp-meta.xml
+++ b/src/aura/autocomplete/autocomplete.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/autocompleteDataProvider/autocompleteDataProvider.cmp-meta.xml
+++ b/src/aura/autocompleteDataProvider/autocompleteDataProvider.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Provider for the Autocomplete</description>
 </AuraDefinitionBundle>

--- a/src/aura/autocompleteOption/autocompleteOption.cmp-meta.xml
+++ b/src/aura/autocompleteOption/autocompleteOption.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/autocompleteSelectListOption/autocompleteSelectListOption.evt-meta.xml
+++ b/src/aura/autocompleteSelectListOption/autocompleteSelectListOption.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/dataProviderInterface/dataProviderInterface.intf-meta.xml
+++ b/src/aura/dataProviderInterface/dataProviderInterface.intf-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/svgIcon/svgIcon.cmp-meta.xml
+++ b/src/aura/svgIcon/svgIcon.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/src/aura/svgIcon_EVT_Press/svgIcon_EVT_Press.evt-meta.xml
+++ b/src/aura/svgIcon_EVT_Press/svgIcon_EVT_Press.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <description>Icon Press Event</description>
 </AuraDefinitionBundle>

--- a/src/classes/ACCT_AdministrativeNameRefresh_BATCH.cls-meta.xml
+++ b/src/classes/ACCT_AdministrativeNameRefresh_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_AdministrativeNameRefresh_TEST.cls-meta.xml
+++ b/src/classes/ACCT_AdministrativeNameRefresh_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/ACCT_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_HouseholdNameRefresh_BATCH.cls-meta.xml
+++ b/src/classes/ACCT_HouseholdNameRefresh_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_HouseholdNameRefresh_TEST.cls-meta.xml
+++ b/src/classes/ACCT_HouseholdNameRefresh_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Account_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Account_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Addresses_UTIL.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_UTIL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_AdminAcc_TEST.cls-meta.xml
+++ b/src/classes/ADDR_AdminAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Contact_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Contact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Contact_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Contact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_HouseholdAcc_TEST.cls-meta.xml
+++ b/src/classes/ADDR_HouseholdAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_OtherAcc_TEST.cls-meta.xml
+++ b/src/classes/ADDR_OtherAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Seasonal_BATCH.cls-meta.xml
+++ b/src/classes/ADDR_Seasonal_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Seasonal_SCHED.cls-meta.xml
+++ b/src/classes/ADDR_Seasonal_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Seasonal_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Seasonal_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Seasonal_UTIL.cls-meta.xml
+++ b/src/classes/ADDR_Seasonal_UTIL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_AccChange_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_AccChange_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_AccRecordType_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_AccRecordType_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_AccRecordType_TEST.cls-meta.xml
+++ b/src/classes/AFFL_AccRecordType_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_ContactAccChange_TEST.cls-meta.xml
+++ b/src/classes/AFFL_ContactAccChange_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_ContactChange_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_ContactChange_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_MultiRecordTypeMapper.cls-meta.xml
+++ b/src/classes/AFFL_MultiRecordTypeMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_MultiRecordType_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_MultiRecordType_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_MultiRecordType_TEST.cls-meta.xml
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ATTD_CourseConnectionContact_TDTM.cls-meta.xml
+++ b/src/classes/ATTD_CourseConnectionContact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ATTD_CourseConnectionContact_TEST.cls-meta.xml
+++ b/src/classes/ATTD_CourseConnectionContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Advancement_Adapter.cls-meta.xml
+++ b/src/classes/Advancement_Adapter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Advancement_Adapter_TEST.cls-meta.xml
+++ b/src/classes/Advancement_Adapter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Advancement_Info.cls-meta.xml
+++ b/src/classes/Advancement_Info.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BEH_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/BEH_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BEH_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/BEH_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CASE_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/CASE_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CASE_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/CASE_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/CCON_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/CCON_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_ConnectionBackfill_BATCH.cls-meta.xml
+++ b/src/classes/CCON_ConnectionBackfill_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_ConnectionBackfill_TEST.cls-meta.xml
+++ b/src/classes/CCON_ConnectionBackfill_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_Faculty_TDTM.cls-meta.xml
+++ b/src/classes/CCON_Faculty_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_Faculty_TEST.cls-meta.xml
+++ b/src/classes/CCON_Faculty_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_PreventUpdate_TDTM.cls-meta.xml
+++ b/src/classes/CCON_PreventUpdate_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CCON_PreventUpdate_TEST.cls-meta.xml
+++ b/src/classes/CCON_PreventUpdate_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CENR_AcademicProgram_TDTM.cls-meta.xml
+++ b/src/classes/CENR_AcademicProgram_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CENR_AcademicProgram_TEST.cls-meta.xml
+++ b/src/classes/CENR_AcademicProgram_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CLAN_PrimaryLanguage_TDTM.cls-meta.xml
+++ b/src/classes/CLAN_PrimaryLanguage_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CLAN_PrimaryLanguage_TEST.cls-meta.xml
+++ b/src/classes/CLAN_PrimaryLanguage_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CMP_SettingsDataProvider.cls-meta.xml
+++ b/src/classes/CMP_SettingsDataProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CMP_SettingsDataProvider_TEST.cls-meta.xml
+++ b/src/classes/CMP_SettingsDataProvider_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COFF_Affiliation_TDTM.cls-meta.xml
+++ b/src/classes/COFF_Affiliation_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COFF_Affiliation_TEST.cls-meta.xml
+++ b/src/classes/COFF_Affiliation_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COFF_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/COFF_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COFF_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/COFF_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/CON_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/CON_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_DoNotContact_TDTM.cls-meta.xml
+++ b/src/classes/CON_DoNotContact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_DoNotContact_TEST.cls-meta.xml
+++ b/src/classes/CON_DoNotContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Email.cls-meta.xml
+++ b/src/classes/CON_Email.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Email_BATCH.cls-meta.xml
+++ b/src/classes/CON_Email_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Email_TEST.cls-meta.xml
+++ b/src/classes/CON_Email_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
+++ b/src/classes/CON_EthnicityRace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Phone.cls-meta.xml
+++ b/src/classes/CON_Phone.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PreferredPhone_TDTM.cls-meta.xml
+++ b/src/classes/CON_PreferredPhone_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PreferredPhone_TEST.cls-meta.xml
+++ b/src/classes/CON_PreferredPhone_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Preferred_TDTM.cls-meta.xml
+++ b/src/classes/CON_Preferred_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_Preferred_TEST.cls-meta.xml
+++ b/src/classes/CON_Preferred_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PrimaryAffls_TDTM.cls-meta.xml
+++ b/src/classes/CON_PrimaryAffls_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PrimaryAffls_TEST.cls-meta.xml
+++ b/src/classes/CON_PrimaryAffls_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
+++ b/src/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
+++ b/src/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COS_StartEndTime_TDTM.cls-meta.xml
+++ b/src/classes/COS_StartEndTime_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COS_StartEndTime_TEST.cls-meta.xml
+++ b/src/classes/COS_StartEndTime_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COUR_DescriptionCopy_BATCH.cls-meta.xml
+++ b/src/classes/COUR_DescriptionCopy_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/COUR_DescriptionCopy_TEST.cls-meta.xml
+++ b/src/classes/COUR_DescriptionCopy_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_AsyncErrors.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_AsyncErrors_SCHED.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_DeleteOutdated_BATCH.cls-meta.xml
+++ b/src/classes/ERR_DeleteOutdated_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_DeleteOutdated_SCHED.cls-meta.xml
+++ b/src/classes/ERR_DeleteOutdated_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_DeleteOutdated_TEST.cls-meta.xml
+++ b/src/classes/ERR_DeleteOutdated_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_ExceptionHandler.cls-meta.xml
+++ b/src/classes/ERR_ExceptionHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_ExceptionHandler_TEST.cls-meta.xml
+++ b/src/classes/ERR_ExceptionHandler_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_Handler.cls-meta.xml
+++ b/src/classes/ERR_Handler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_Handler_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_Notifier.cls-meta.xml
+++ b/src/classes/ERR_Notifier.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PPlan_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/PPlan_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PPlan_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/PPlan_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PPlan_Primary_TDTM.cls-meta.xml
+++ b/src/classes/PPlan_Primary_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PPlan_Primary_TEST.cls-meta.xml
+++ b/src/classes/PPlan_Primary_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREN_Affiliation_TDTM.cls-meta.xml
+++ b/src/classes/PREN_Affiliation_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREN_Affiliation_TEST.cls-meta.xml
+++ b/src/classes/PREN_Affiliation_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
+++ b/src/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREN_ProgramPlan_TEST.cls-meta.xml
+++ b/src/classes/PREN_ProgramPlan_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREQ_PreventPPlanParent_TDTM.cls-meta.xml
+++ b/src/classes/PREQ_PreventPPlanParent_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PREQ_PreventPPlanParent_TEST.cls-meta.xml
+++ b/src/classes/PREQ_PreventPPlanParent_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PReq_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/PReq_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PReq_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/PReq_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_Relationships_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_Relationships_TEST.cls-meta.xml
+++ b/src/classes/REL_Relationships_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_Utils.cls-meta.xml
+++ b/src/classes/REL_Utils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Base_CTRL.cls-meta.xml
+++ b/src/classes/STG_Base_CTRL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Base_CTRL_TEST.cls-meta.xml
+++ b/src/classes/STG_Base_CTRL_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_CourseConnections.cls-meta.xml
+++ b/src/classes/STG_CourseConnections.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_CourseConnections_TEST.cls-meta.xml
+++ b/src/classes/STG_CourseConnections_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Courses.cls-meta.xml
+++ b/src/classes/STG_Courses.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Courses_TEST.cls-meta.xml
+++ b/src/classes/STG_Courses_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_InstallScript.cls-meta.xml
+++ b/src/classes/STG_InstallScript.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TB_StartEndTime_TDTM.cls-meta.xml
+++ b/src/classes/TB_StartEndTime_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TB_StartEndTime_TEST.cls-meta.xml
+++ b/src/classes/TB_StartEndTime_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Config.cls-meta.xml
+++ b/src/classes/TDTM_Config.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
+++ b/src/classes/TDTM_DMLgt200_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls-meta.xml
+++ b/src/classes/TDTM_DefaultConfig.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Filter.cls-meta.xml
+++ b/src/classes/TDTM_Filter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Filter_TEST.cls-meta.xml
+++ b/src/classes/TDTM_Filter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Global_API.cls-meta.xml
+++ b/src/classes/TDTM_Global_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Manager.cls-meta.xml
+++ b/src/classes/TDTM_Manager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Manager_TEST.cls-meta.xml
+++ b/src/classes/TDTM_Manager_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_ProcessControl.cls-meta.xml
+++ b/src/classes/TDTM_ProcessControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Runnable.cls-meta.xml
+++ b/src/classes/TDTM_Runnable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_TriggerActionHelper.cls-meta.xml
+++ b/src/classes/TDTM_TriggerActionHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_TriggerHandler.cls-meta.xml
+++ b/src/classes/TDTM_TriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
+++ b/src/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TERM_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/TERM_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TERM_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/TERM_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TERM_CourseOff_TDTM.cls-meta.xml
+++ b/src/classes/TERM_CourseOff_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TERM_CourseOff_TEST.cls-meta.xml
+++ b/src/classes/TERM_CourseOff_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TGRD_TermGradeValidator.cls-meta.xml
+++ b/src/classes/TGRD_TermGradeValidator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TGRD_ValidateData_TDTM.cls-meta.xml
+++ b/src/classes/TGRD_ValidateData_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TGRD_ValidateData_TEST.cls-meta.xml
+++ b/src/classes/TGRD_ValidateData_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/THAN_ClearCache_TDTM.cls-meta.xml
+++ b/src/classes/THAN_ClearCache_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/THAN_ClearCache_TEST.cls-meta.xml
+++ b/src/classes/THAN_ClearCache_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/THAN_Filter_TDTM.cls-meta.xml
+++ b/src/classes/THAN_Filter_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/THAN_Filter_TEST.cls-meta.xml
+++ b/src/classes/THAN_Filter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_ACCT_Naming.cls-meta.xml
+++ b/src/classes/UTIL_ACCT_Naming.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_CustomSettingsFacade_TEST.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_CustomSettings_API.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettings_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Debug.cls-meta.xml
+++ b/src/classes/UTIL_Debug.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Describe.cls-meta.xml
+++ b/src/classes/UTIL_Describe.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Describe_API.cls-meta.xml
+++ b/src/classes/UTIL_Describe_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Describe_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Describe_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_FeatureManagement.cls-meta.xml
+++ b/src/classes/UTIL_FeatureManagement.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_FeatureManagement_TEST.cls-meta.xml
+++ b/src/classes/UTIL_FeatureManagement_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace.cls-meta.xml
+++ b/src/classes/UTIL_Namespace.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Namespace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_OrgTelemetry.cls-meta.xml
+++ b/src/classes/UTIL_OrgTelemetry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_OrgTelemetry_BATCH.cls-meta.xml
+++ b/src/classes/UTIL_OrgTelemetry_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls-meta.xml
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Profile.cls-meta.xml
+++ b/src/classes/UTIL_Profile.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Profile_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Profile_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_SortContact.cls-meta.xml
+++ b/src/classes/UTIL_SortContact.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_SortContact_TEST.cls-meta.xml
+++ b/src/classes/UTIL_SortContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_UnitTestData_API.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1165,5 +1165,5 @@
         <members>Relationship__c.Related_Contact_Do_Not_Change</members>
         <name>ValidationRule</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/src/pages/STG_Settings.page
+++ b/src/pages/STG_Settings.page
@@ -1,6 +1,6 @@
 <apex:page title="{!$Label.stgTitleHEDASettings}" showHeader="true" standardStylesheets="false" applyBodyTag="false" docType="html-5.0" controller="STG_Base_CTRL">
-    <script src="/soap/ajax/45.0/connection.js" type="text/javascript"></script>
-    <script src="/soap/ajax/45.0/apex.js" type="text/javascript"></script>
+    <script src="/soap/ajax/48.0/connection.js" type="text/javascript"></script>
+    <script src="/soap/ajax/48.0/apex.js" type="text/javascript"></script>
     <script src="/lightning/lightning.out.js" type="text/javascript"></script>
 
     <div class="slds">

--- a/src/pages/STG_Settings.page-meta.xml
+++ b/src/pages/STG_Settings.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>Settings</label>

--- a/src/tabs/Address__c.tab
+++ b/src/tabs/Address__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom24: Building</motif>
 </CustomTab>

--- a/src/tabs/Affiliation__c.tab
+++ b/src/tabs/Affiliation__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom37: Bridge</motif>
 </CustomTab>

--- a/src/tabs/Application__c.tab
+++ b/src/tabs/Application__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom27: Laptop</motif>
 </CustomTab>

--- a/src/tabs/Attendance_Event__c.tab
+++ b/src/tabs/Attendance_Event__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom53: Bell</motif>
 </CustomTab>

--- a/src/tabs/Attribute__c.tab
+++ b/src/tabs/Attribute__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom48: Trophy</motif>
 </CustomTab>

--- a/src/tabs/Behavior_Involvement__c.tab
+++ b/src/tabs/Behavior_Involvement__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom26: Flag</motif>
 </CustomTab>

--- a/src/tabs/Behavior_Response__c.tab
+++ b/src/tabs/Behavior_Response__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom90: Scales</motif>
 </CustomTab>

--- a/src/tabs/Contact_Language__c.tab
+++ b/src/tabs/Contact_Language__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom15: People</motif>
 </CustomTab>

--- a/src/tabs/Course_Enrollment__c.tab
+++ b/src/tabs/Course_Enrollment__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom47: Chess piece</motif>
 </CustomTab>

--- a/src/tabs/Course_Offering_Schedule__c.tab
+++ b/src/tabs/Course_Offering_Schedule__c.tab
@@ -2,6 +2,5 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
     <description>Create and View your Course Offering Schedules</description>
-    <mobileReady>false</mobileReady>
     <motif>Custom55: Books</motif>
 </CustomTab>

--- a/src/tabs/Course_Offering__c.tab
+++ b/src/tabs/Course_Offering__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom55: Books</motif>
 </CustomTab>

--- a/src/tabs/Course__c.tab
+++ b/src/tabs/Course__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom83: Pencil</motif>
 </CustomTab>

--- a/src/tabs/Facility__c.tab
+++ b/src/tabs/Facility__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom24: Building</motif>
 </CustomTab>

--- a/src/tabs/HEDA_Settings.tab
+++ b/src/tabs/HEDA_Settings.tab
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <label>EDA Settings</label>
-    <mobileReady>false</mobileReady>
     <motif>Custom64: Compass</motif>
     <page>STG_Settings</page>
 </CustomTab>

--- a/src/tabs/Language__c.tab
+++ b/src/tabs/Language__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom68: Globe</motif>
 </CustomTab>

--- a/src/tabs/Plan_Requirement__c.tab
+++ b/src/tabs/Plan_Requirement__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom82: Whistle</motif>
 </CustomTab>

--- a/src/tabs/Program_Enrollment__c.tab
+++ b/src/tabs/Program_Enrollment__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom18: Form</motif>
 </CustomTab>

--- a/src/tabs/Program_Plan__c.tab
+++ b/src/tabs/Program_Plan__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom21: Computer</motif>
 </CustomTab>

--- a/src/tabs/Relationship__c.tab
+++ b/src/tabs/Relationship__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom14: Hands</motif>
 </CustomTab>

--- a/src/tabs/Term_Grade__c.tab
+++ b/src/tabs/Term_Grade__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom48: Trophy</motif>
 </CustomTab>

--- a/src/tabs/Term__c.tab
+++ b/src/tabs/Term__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom25: Alarm clock</motif>
 </CustomTab>

--- a/src/tabs/Test_Score__c.tab
+++ b/src/tabs/Test_Score__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom23: Mail</motif>
 </CustomTab>

--- a/src/tabs/Test__c.tab
+++ b/src/tabs/Test__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom33: Desk</motif>
 </CustomTab>

--- a/src/tabs/Time_Block__c.tab
+++ b/src/tabs/Time_Block__c.tab
@@ -2,6 +2,5 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
     <description>Create and View your Time Blocks</description>
-    <mobileReady>false</mobileReady>
     <motif>Custom25: Alarm clock</motif>
 </CustomTab>

--- a/src/tabs/Trigger_Handler__c.tab
+++ b/src/tabs/Trigger_Handler__c.tab
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom67: Gears</motif>
 </CustomTab>

--- a/src/triggers/TDTM_Account.trigger-meta.xml
+++ b/src/triggers/TDTM_Account.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Address.trigger-meta.xml
+++ b/src/triggers/TDTM_Address.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Affiliation.trigger-meta.xml
+++ b/src/triggers/TDTM_Affiliation.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Application.trigger-meta.xml
+++ b/src/triggers/TDTM_Application.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_AttendanceEvent.trigger-meta.xml
+++ b/src/triggers/TDTM_AttendanceEvent.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Attribute.trigger-meta.xml
+++ b/src/triggers/TDTM_Attribute.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Behavior_Involvement.trigger-meta.xml
+++ b/src/triggers/TDTM_Behavior_Involvement.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Behavior_Response.trigger-meta.xml
+++ b/src/triggers/TDTM_Behavior_Response.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Campaign.trigger-meta.xml
+++ b/src/triggers/TDTM_Campaign.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_CampaignMember.trigger-meta.xml
+++ b/src/triggers/TDTM_CampaignMember.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Case.trigger-meta.xml
+++ b/src/triggers/TDTM_Case.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Contact.trigger-meta.xml
+++ b/src/triggers/TDTM_Contact.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_ContactLanguage.trigger-meta.xml
+++ b/src/triggers/TDTM_ContactLanguage.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Course.trigger-meta.xml
+++ b/src/triggers/TDTM_Course.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_CourseEnrollment.trigger-meta.xml
+++ b/src/triggers/TDTM_CourseEnrollment.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_CourseOffering.trigger-meta.xml
+++ b/src/triggers/TDTM_CourseOffering.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_CourseOfferingSchedule.trigger-meta.xml
+++ b/src/triggers/TDTM_CourseOfferingSchedule.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Facility.trigger-meta.xml
+++ b/src/triggers/TDTM_Facility.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Language.trigger-meta.xml
+++ b/src/triggers/TDTM_Language.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Opportunity.trigger-meta.xml
+++ b/src/triggers/TDTM_Opportunity.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_PlanRequirement.trigger-meta.xml
+++ b/src/triggers/TDTM_PlanRequirement.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_ProgramEnrollment.trigger-meta.xml
+++ b/src/triggers/TDTM_ProgramEnrollment.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_ProgramPlan.trigger-meta.xml
+++ b/src/triggers/TDTM_ProgramPlan.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Relationship.trigger-meta.xml
+++ b/src/triggers/TDTM_Relationship.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Term.trigger-meta.xml
+++ b/src/triggers/TDTM_Term.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_TermGrade.trigger-meta.xml
+++ b/src/triggers/TDTM_TermGrade.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Test.trigger-meta.xml
+++ b/src/triggers/TDTM_Test.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Test_Score.trigger-meta.xml
+++ b/src/triggers/TDTM_Test_Score.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_TimeBlock.trigger-meta.xml
+++ b/src/triggers/TDTM_TimeBlock.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_TriggerHandler.trigger-meta.xml
+++ b/src/triggers/TDTM_TriggerHandler.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/tasks/legacy_update_profile.py
+++ b/tasks/legacy_update_profile.py
@@ -24,7 +24,7 @@ DEFAULT_XML = """<Package xmlns="http://soap.sforce.com/2006/04/metadata">
         <members>Admin</members>
         <name>Profile</name>
     </types>
-    <version>39.0</version>
+    <version>48.0</version>
 </Package>"""
 
 
@@ -212,7 +212,7 @@ class UpdateProfile(Deploy):
 
     def _get_deploy_package_xml_content(self):
         return f"""<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata">
-        <types><members>{self.profile_name}</members><name>Profile</name></types><version>39.0</version></Package>
+        <types><members>{self.profile_name}</members><name>Profile</name></types><version>48.0</version></Package>
         """
 
     def _deploy_metadata(self):

--- a/unpackaged/config/analytics/package.xml
+++ b/unpackaged/config/analytics/package.xml
@@ -4,5 +4,5 @@
         <members>*</members>
         <name>WaveTemplateBundle</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/analytics/package.xml
+++ b/unpackaged/config/analytics/package.xml
@@ -4,5 +4,5 @@
         <members>*</members>
         <name>WaveTemplateBundle</name>
     </types>
-    <version>48.0</version>
+    <version>45.0</version>
 </Package>

--- a/unpackaged/config/analytics/waveTemplates/RA_Program_Enrollment/template-info.json
+++ b/unpackaged/config/analytics/waveTemplates/RA_Program_Enrollment/template-info.json
@@ -3,7 +3,7 @@
   "label" : "Education Cloud: Recruiting",
   "name" : "RA_Program_Enrollment",
   "description" : "The Recruiting and Admissions template allows you to quickly create insightful dashboards to help you better understand your recruiting and admissions data. Requires EDA.",
-  "assetVersion" : 48.0,
+  "assetVersion" : 46.0,
   "variableDefinition" : "variables.json",
   "uiDefinition" : "ui.json",
   "rules" : [

--- a/unpackaged/config/analytics/waveTemplates/RA_Program_Enrollment/template-info.json
+++ b/unpackaged/config/analytics/waveTemplates/RA_Program_Enrollment/template-info.json
@@ -3,7 +3,7 @@
   "label" : "Education Cloud: Recruiting",
   "name" : "RA_Program_Enrollment",
   "description" : "The Recruiting and Admissions template allows you to quickly create insightful dashboards to help you better understand your recruiting and admissions data. Requires EDA.",
-  "assetVersion" : 46.0,
+  "assetVersion" : 48.0,
   "variableDefinition" : "variables.json",
   "uiDefinition" : "ui.json",
   "rules" : [

--- a/unpackaged/config/dev/package.xml
+++ b/unpackaged/config/dev/package.xml
@@ -16,5 +16,5 @@
         <members>Admin</members>
         <name>Profile</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/dev_delete/destructiveChanges.xml
+++ b/unpackaged/config/dev_delete/destructiveChanges.xml
@@ -13,5 +13,5 @@
         <members>Opportunity-Opportunity Layout.layout</members>
         <name>Layout</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/dev_delete/package.xml
+++ b/unpackaged/config/dev_delete/package.xml
@@ -12,5 +12,5 @@
         <members>*</members>
         <name>CompactLayout</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -28,5 +28,5 @@
         <members>*</members>
         <name>Profile</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/qa/tabs/___NAMESPACE___Error__c.tab
+++ b/unpackaged/config/qa/tabs/___NAMESPACE___Error__c.tab
@@ -2,6 +2,5 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
     <description>Error Tab</description>
-    <mobileReady>false</mobileReady>
     <motif>Custom53: Bell</motif>
 </CustomTab>

--- a/unpackaged/config/spe/package.xml
+++ b/unpackaged/config/spe/package.xml
@@ -4,5 +4,5 @@
         <members>Encryption</members>
         <name>PermissionSet</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/post/case_behavior_record_types/package.xml
+++ b/unpackaged/post/case_behavior_record_types/package.xml
@@ -16,5 +16,5 @@
         <members>Case-fr</members>
         <name>CustomObjectTranslation</name>
     </types>
-  	<version>45.0</version>
+  	<version>48.0</version>
 </Package>

--- a/unpackaged/post/course_connection_record_types/package.xml
+++ b/unpackaged/post/course_connection_record_types/package.xml
@@ -20,5 +20,5 @@
     <members>%%%NAMESPACE%%%Course_Enrollment__c-fr</members>
     <name>CustomObjectTranslation</name>
   </types>
-  <version>45.0</version>
+  <version>48.0</version>
 </Package>

--- a/unpackaged/post/facility_display_name/package.xml
+++ b/unpackaged/post/facility_display_name/package.xml
@@ -12,5 +12,5 @@
     <members>%%%NAMESPACE%%%Facility__c-fr</members>
     <name>CustomObjectTranslation</name>
   </types>
-  <version>45.0</version>
+  <version>48.0</version>
 </Package>

--- a/unpackaged/pre/acc_record_types/package.xml
+++ b/unpackaged/pre/acc_record_types/package.xml
@@ -12,5 +12,5 @@
     <members>Account-fr</members>
     <name>CustomObjectTranslation</name>
   </types>
-  <version>45.0</version>
+  <version>48.0</version>
 </Package>

--- a/unpackaged/pre/contact_key_affl_fields/package.xml
+++ b/unpackaged/pre/contact_key_affl_fields/package.xml
@@ -12,5 +12,5 @@
     <members>Contact-fr</members>
     <name>CustomObjectTranslation</name>
   </types>
-  <version>45.0</version>
+  <version>48.0</version>
 </Package>


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated EDA to use API Version v48.0 to align with the most current version of the API. Additionally, we have removed all references to the deprecated mobileReady field from all customTab object files. You'll see no change to your org as a result of this update.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
