### PR TITLE
[EDA] Prevent Deletion of Course Record  if There are Associated Course Records

### DIFF
--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -59,14 +59,14 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
       	Map<Id, Course__c> oldMap = new Map<Id, Course__c>((List<Course__c>)oldList);
       
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
-            for (Course__c c : [SELECT ID,
+            for (Course__c course : [SELECT ID,
                                 (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
                                 (SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
                                 FROM Course__c
                                 WHERE ID IN :oldlist])
             {
-                if (hasChildRecords(c)) {
-                    Course__c courseInContext = oldmap.get(c.ID);
+                if (hasChildRecords(course)) {
+                    Course__c courseInContext = oldmap.get(course.ID);
                     courseInContext.addError(Label.CannotDelete);
                 }
             }
@@ -77,10 +77,11 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
 
    /*******************************************************************************************************
    * @description Evaluates whether the Course has any child related records.
-   * @param c is the current Course record.
+   * @param course is the current Course record.
    * @return Boolean.
    ********************************************************************************************************/
-   private static Boolean hasChildRecords(Course__c c) {
-        return (!c.Course_Offerings__r.isEmpty() || !c.Plan_Requirements__r.isEmpty());
+   @testVisible
+   private Boolean hasChildRecords(Course__c course) {
+        return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());
    }
 }

--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -1,0 +1,86 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Course
+* @group-content ../../ApexDocContent/Course.htm
+* @description Stops a Course from being deleted if it has any Course Offering or Plan Requirement child records.
+*/
+public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
+    /*******************************************************************************************************
+    * @description Get the setting of preventing Course deletion
+    */
+    private static Boolean enabledPreventCourseDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Course_Deletion__c;
+    
+    /*******************************************************************************************************
+    * @description Stops a Course from being deleted if it has any Course Offering 
+    * or Plan Requirement child records.
+    * @param listNew the list of Courses from trigger new.
+    * @param listOld the list of Courses from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Courses
+    * @return dmlWrapper.
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+		
+        if (!enabledPreventCourseDeletion) {
+            return new DmlWrapper(); 
+        }
+        
+      	Map<Id, Course__c> oldMap = new Map<Id, Course__c>((List<Course__c>)oldList);
+      
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            for (Course__c c : [SELECT ID,
+                            (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
+                     		(SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
+                            FROM Course__c
+                            WHERE ID IN :oldlist])
+            {
+                if (hasChildRecords(c)) {
+                    Course__c courseInContext = oldmap.get(c.ID);
+                    courseInContext.addError(Label.CannotDelete);
+                }
+            }
+        }
+
+      return new DmlWrapper();
+   }
+
+   /*******************************************************************************************************
+   * @description Evaluates whether the Course has any child related records.
+   * @param c is the current Course record.
+   * @return Boolean.
+   ********************************************************************************************************/
+   private static Boolean hasChildRecords(Course__c c) {
+        return (!c.Course_Offerings__r.isEmpty() || !c.Plan_Requirements__r.isEmpty());
+   }
+}

--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -75,11 +75,11 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
     return new DmlWrapper();
     }
 
-   /*******************************************************************************************************
-   * @description Evaluates whether the Course has any child related records.
-   * @param course is the current Course record.
-   * @return Boolean.
-   ********************************************************************************************************/
+    /*******************************************************************************************************
+    * @description Evaluates whether the Course has any child related records.
+    * @param course is the current Course record.
+    * @return Boolean.
+    ********************************************************************************************************/
     @testVisible
     private Boolean hasChildRecords(Course__c course) {
         return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());

--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -51,19 +51,19 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
     ********************************************************************************************************/
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-		
+
         if (!COUR_CannotDelete_TDTM.enabledPreventCourseDeletion) {
             return new DmlWrapper(); 
         }
-        
-      	Map<Id, Course__c> oldMap = new Map<Id, Course__c>((List<Course__c>)oldList);
-      
+
+        Map<Id, Course__c> oldMap = new Map<Id, Course__c>((List<Course__c>)oldList);
+
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
             for (Course__c course : [SELECT ID,
-                            (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
-                     		(SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
-                            FROM Course__c
-                            WHERE ID IN :oldlist])
+                        (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
+                        (SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
+                        FROM Course__c
+                        WHERE ID IN :oldlist])
             {
                 if (this.hasChildRecords(course)) {
                     Course__c courseInContext = oldmap.get(course.ID);
@@ -72,16 +72,16 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
             }
         }
 
-      return new DmlWrapper();
-   }
+    return new DmlWrapper();
+    }
 
    /*******************************************************************************************************
    * @description Evaluates whether the Course has any child related records.
    * @param course is the current Course record.
    * @return Boolean.
    ********************************************************************************************************/
-   @testVisible
-   private Boolean hasChildRecords(Course__c course) {
-   		return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());
-   }
+    @testVisible
+    private Boolean hasChildRecords(Course__c course) {
+        return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());
+    }
 }

--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -60,10 +60,10 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
       
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
             for (Course__c c : [SELECT ID,
-                            (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
-                     		(SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
-                            FROM Course__c
-                            WHERE ID IN :oldlist])
+                                (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
+                                (SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
+                                FROM Course__c
+                                WHERE ID IN :oldlist])
             {
                 if (hasChildRecords(c)) {
                     Course__c courseInContext = oldmap.get(c.ID);

--- a/src/classes/COUR_CannotDelete_TDTM.cls
+++ b/src/classes/COUR_CannotDelete_TDTM.cls
@@ -52,7 +52,7 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 		
-        if (!enabledPreventCourseDeletion) {
+        if (!COUR_CannotDelete_TDTM.enabledPreventCourseDeletion) {
             return new DmlWrapper(); 
         }
         
@@ -60,12 +60,12 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
       
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
             for (Course__c course : [SELECT ID,
-                                (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
-                                (SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
-                                FROM Course__c
-                                WHERE ID IN :oldlist])
+                            (SELECT ID FROM Course__c.Course_Offerings__r LIMIT 1),
+                     		(SELECT ID FROM Course__c.Plan_Requirements__r LIMIT 1)
+                            FROM Course__c
+                            WHERE ID IN :oldlist])
             {
-                if (hasChildRecords(course)) {
+                if (this.hasChildRecords(course)) {
                     Course__c courseInContext = oldmap.get(course.ID);
                     courseInContext.addError(Label.CannotDelete);
                 }
@@ -82,6 +82,6 @@ public with sharing class COUR_CannotDelete_TDTM extends TDTM_Runnable {
    ********************************************************************************************************/
    @testVisible
    private Boolean hasChildRecords(Course__c course) {
-        return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());
+   		return (!course.Course_Offerings__r.isEmpty() || !course.Plan_Requirements__r.isEmpty());
    }
 }

--- a/src/classes/COUR_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/COUR_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -1,0 +1,390 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Course
+* @group-content ../../ApexDocContent/Course.htm
+* @description Tests for COUR_CannotDelete_TDTM
+*/
+@isTest
+public class COUR_CannotDelete_TEST {
+    /*********************************************************************************************************
+    * @description Retrieves the Administrative record type Id. 
+    */
+    public static String adminAccRecTypeId = UTIL_Describe.getAdminAccRecTypeID(); 
+    
+	/*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
+    * Course has a Course Offering record associated to it, then it cannot be deleted.
+    */
+    @isTest
+    public static void courCannotDeleteWithCourOffering() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id);
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+		System.assertEquals(2, returnCourses.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
+    * Course has a Plan Requirement record associated to it, then it cannot be deleted.
+    */
+    @isTest
+    public static void courCannotDeleteWithPlanReq() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
+        planReqs[0].Course__c = courses[0].Id;
+        planReqs[1].Course__c = courses[1].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(2, returnCourses.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
+    * Courses have a Course Offering and Plan Requirement record associated to it, then it cannot be deleted.
+    */
+    @isTest
+    public static void courCannotDeleteWithChildRecords() {
+    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id); 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
+        planReqs[0].Course__c = courses[0].Id;
+        planReqs[1].Course__c = courses[1].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(2, returnCourses.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
+    * Course has a Course Offering and Plan Requirement record associated to it, then it cannot be deleted.
+    */
+    @isTest
+    public static void courCannotDeleteWithSomeChildRecords() {
+    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(1); 
+        planReqs[0].Course__c = courses[0].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(1, returnCourses.size());
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is disabled in Hierarchy Settings, and
+    * Course has a Course Offering record associated to it, then it can be deleted.
+    */
+    @isTest
+    public static void courCanDeleteWithCourOffering() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = False));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id);
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(0, returnCourses.size());
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is disabled in Hierarchy Settings, and
+    * Course has a Plan Requirement record associated to it, then it can be deleted.
+    */
+    @isTest
+    public static void courCanDeleteWithPlanReq() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = False));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
+        planReqs[0].Course__c = courses[0].Id;
+        planReqs[1].Course__c = courses[1].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(0, returnCourses.size());
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is disabled in Hierarchy Settings, and
+    * Courses have a Course Offering and Plan Requirement record associated to it, then it can be deleted.
+    */
+    @isTest
+    public static void courCanDeleteWithChildRecords() {
+    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = False));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id); 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
+        planReqs[0].Course__c = courses[0].Id;
+        planReqs[1].Course__c = courses[1].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(0, returnCourses.size());
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Course_Deletion__c is disabled in Hierarchy Settings, and
+    * Course has a Course Offering and Plan Requirement record associated to it, then it can be deleted.
+    */
+    @isTest
+    public static void courCanDeleteWithSomeChildRecords() {
+    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = False));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(1); 
+        planReqs[0].Course__c = courses[0].Id;
+        insert planReqs; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(courses, false);
+        Test.stopTest();
+        
+        List<Course__c> returnCourses = [SELECT Id
+                                  FROM Course__c
+                                  WHERE Id IN :courses]; 
+        System.assertEquals(0, returnCourses.size());
+    }
+}

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -48,39 +48,39 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void cannotDeleteCourseWithCourseOffering() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
-        
+                                                (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                Prevent_Course_Deletion__c = True));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
-        List<Course__c> courses = new List<Course__c>{
+
+        List<Course__c> courses = new List<Course__c> {
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
-        List<Term__c> terms = new List<Term__c>{
+
+        List<Term__c> terms = new List<Term__c> {
             new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
             new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
         }; 
         insert terms; 
-        
+
         Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
         Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id);
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
-		System.assertEquals(2, returnCourses.size());
+        System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
     }
     
@@ -91,79 +91,79 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void cannotDeleteCourseWithPlanRequirements() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
-        
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = True));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
-        List<Course__c> courses = new List<Course__c>{
+
+        List<Course__c> courses = new List<Course__c> {
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
         planReqs[0].Course__c = courses[0].Id;
         planReqs[1].Course__c = courses[1].Id;
         insert planReqs; 
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
         System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
     }
-    
+
     /*********************************************************************************************************
     * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
     * Courses have a Course Offering and Plan Requirement record associated to it, then it cannot be deleted.
     */
     @isTest
     public static void cannotDeleteCourseWithChildRecords() {
-    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
-        
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = True));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
+
         List<Course__c> courses = new List<Course__c>{
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Term__c> terms = new List<Term__c>{
             new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
             new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
         }; 
         insert terms; 
-        
+
         Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
         Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id); 
-        
+
         List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
         planReqs[0].Course__c = courses[0].Id;
         planReqs[1].Course__c = courses[1].Id;
         insert planReqs; 
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
@@ -177,39 +177,39 @@ private class COUR_CannotDelete_TEST {
     */
     @isTest
     public static void cannotDeleteCourseWithSomeChildRecords() {
-    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
-        
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = True));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
+
         List<Course__c> courses = new List<Course__c>{
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Term__c> terms = new List<Term__c>{
             new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
             new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
         }; 
         insert terms; 
-        
+
         Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
-        
+
         List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(1); 
         planReqs[0].Course__c = courses[0].Id;
         insert planReqs; 
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
@@ -223,35 +223,35 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void canDeleteCourseWithCourseOffering() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = False));
-        
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = False));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
+
         List<Course__c> courses = new List<Course__c>{
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Term__c> terms = new List<Term__c>{
             new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
             new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
         }; 
         insert terms; 
-        
+
         Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
         Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id);
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
@@ -265,34 +265,34 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void canDeleteCourseWithPlanRequirements() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = False));
-        
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = False));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
+
         List<Course__c> courses = new List<Course__c>{
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
         planReqs[0].Course__c = courses[0].Id;
         planReqs[1].Course__c = courses[1].Id;
         insert planReqs; 
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(0, returnCourses.size());
     }
     
@@ -302,41 +302,41 @@ private class COUR_CannotDelete_TEST {
     */
     @isTest
     public static void canDeleteCourseWithChildRecords() {
-    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = False));
-        
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = False));
+
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
         List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
-        
+
         List<Course__c> courses = new List<Course__c>{
             new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
-        
+
         List<Term__c> terms = new List<Term__c>{
             new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
             new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
         }; 
         insert terms; 
-        
+
         Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
         Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id); 
-        
+
         List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
         planReqs[0].Course__c = courses[0].Id;
         planReqs[1].Course__c = courses[1].Id;
         insert planReqs; 
-        
+
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(courses, false);
         Test.stopTest();
-        
+
         List<Course__c> returnCourses = [SELECT Id
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
@@ -349,10 +349,10 @@ private class COUR_CannotDelete_TEST {
     */
     @isTest
     public static void canDeleteCourseWithSomeChildRecords() {
-    	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = False));
-        
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = False));
+            
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
@@ -394,8 +394,8 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void testCourseHasChildRecords() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
@@ -425,17 +425,17 @@ private class COUR_CannotDelete_TEST {
         insert planReqs; 
         
         List<Course__c> returnCourses = [SELECT Id,
-                                        (SELECT ID, Name FROM Course_Offerings__r LIMIT 1),
-                     				    (SELECT ID, Name FROM Plan_Requirements__r LIMIT 1)
+                                        (SELECT Id, Name FROM Course_Offerings__r LIMIT 1),
+                                        (SELECT Id, Name FROM Plan_Requirements__r LIMIT 1)
                                         FROM Course__c
-                                        WHERE ID IN :courses]; 
+                                        WHERE Id IN :courses]; 
         
         Boolean checkRelatedRecords; 
         COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
         
         for (Course__c cour : returnCourses) {
-             checkRelatedRecords = myClass.hasChildRecords(cour); 
-             System.assertEquals(True, checkRelatedRecords); 
+            checkRelatedRecords = myClass.hasChildRecords(cour); 
+            System.assertEquals(True, checkRelatedRecords); 
         }
     }
 	
@@ -445,8 +445,8 @@ private class COUR_CannotDelete_TEST {
     @isTest
     public static void testCourseHasNoChildRecords() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
-                                                            Prevent_Course_Deletion__c = True));
+                                                        (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
@@ -461,17 +461,17 @@ private class COUR_CannotDelete_TEST {
         };        
         insert courses; 
         List<Course__c> returnCourses = [SELECT Id,
-                                        (SELECT ID, Name FROM Course_Offerings__r LIMIT 1),
-                     				    (SELECT ID, Name FROM Plan_Requirements__r LIMIT 1)
+                                        (SELECT Id, Name FROM Course_Offerings__r LIMIT 1),
+                                        (SELECT Id, Name FROM Plan_Requirements__r LIMIT 1)
                                         FROM Course__c
-                                        WHERE ID IN :courses]; 
+                                        WHERE Id IN :courses]; 
         
         Boolean checkRelatedRecords; 
         COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
         
         for (Course__c cour : returnCourses) {
-             checkRelatedRecords = myClass.hasChildRecords(cour); 
-             System.assertEquals(False, checkRelatedRecords); 
+            checkRelatedRecords = myClass.hasChildRecords(cour); 
+            System.assertEquals(False, checkRelatedRecords); 
         }
     }
 }

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -41,7 +41,7 @@ private class COUR_CannotDelete_TEST {
     */
     public static String adminAccRecTypeId = UTIL_Describe.getAdminAccRecTypeID(); 
     
-	/*********************************************************************************************************
+    /*********************************************************************************************************
     * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
     * Course has a Course Offering record associated to it, then it cannot be deleted.
     */
@@ -388,7 +388,7 @@ private class COUR_CannotDelete_TEST {
         System.assertEquals(0, returnCourses.size());
     }
     
-	/*********************************************************************************************************
+    /*********************************************************************************************************
     * @description Tests the hasChildRecords method that the Course record has child records. 
     */
     @isTest

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -35,27 +35,27 @@
 * @description Tests for COUR_CannotDelete_TDTM
 */
 @isTest
-public class COUR_CannotDelete_TEST {
+private class COUR_CannotDelete_TEST {
     /*********************************************************************************************************
     * @description Retrieves the Administrative record type Id. 
     */
     public static String adminAccRecTypeId = UTIL_Describe.getAdminAccRecTypeID(); 
     
-    /*********************************************************************************************************
+	/*********************************************************************************************************
     * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
     * Course has a Course Offering record associated to it, then it cannot be deleted.
     */
     @isTest
-    public static void courCannotDeleteWithCourOffering() {
+    public static void cannotDeleteCourseWithCourseOffering() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -78,9 +78,9 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
-        System.assertEquals(2, returnCourses.size());
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
+		System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
     }
     
@@ -89,16 +89,16 @@ public class COUR_CannotDelete_TEST {
     * Course has a Plan Requirement record associated to it, then it cannot be deleted.
     */
     @isTest
-    public static void courCannotDeleteWithPlanReq() {
+    public static void cannotDeleteCourseWithPlanRequirements() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -117,8 +117,8 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
     }
@@ -128,16 +128,16 @@ public class COUR_CannotDelete_TEST {
     * Courses have a Course Offering and Plan Requirement record associated to it, then it cannot be deleted.
     */
     @isTest
-    public static void courCannotDeleteWithChildRecords() {
+    public static void cannotDeleteCourseWithChildRecords() {
     	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -165,8 +165,8 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
     }
@@ -176,16 +176,16 @@ public class COUR_CannotDelete_TEST {
     * Course has a Course Offering and Plan Requirement record associated to it, then it cannot be deleted.
     */
     @isTest
-    public static void courCannotDeleteWithSomeChildRecords() {
+    public static void cannotDeleteCourseWithSomeChildRecords() {
     	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = True));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -211,8 +211,8 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(1, returnCourses.size());
     }
     
@@ -221,16 +221,16 @@ public class COUR_CannotDelete_TEST {
     * Course has a Course Offering record associated to it, then it can be deleted.
     */
     @isTest
-    public static void courCanDeleteWithCourOffering() {
+    public static void canDeleteCourseWithCourseOffering() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = False));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -253,8 +253,8 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(0, returnCourses.size());
     }
     
@@ -263,16 +263,16 @@ public class COUR_CannotDelete_TEST {
     * Course has a Plan Requirement record associated to it, then it can be deleted.
     */
     @isTest
-    public static void courCanDeleteWithPlanReq() {
+    public static void canDeleteCourseWithPlanRequirements() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = False));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -301,16 +301,16 @@ public class COUR_CannotDelete_TEST {
     * Courses have a Course Offering and Plan Requirement record associated to it, then it can be deleted.
     */
     @isTest
-    public static void courCanDeleteWithChildRecords() {
+    public static void canDeleteCourseWithChildRecords() {
     	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = False));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -338,8 +338,8 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(0, returnCourses.size());
     }
     
@@ -348,16 +348,16 @@ public class COUR_CannotDelete_TEST {
     * Course has a Course Offering and Plan Requirement record associated to it, then it can be deleted.
     */
     @isTest
-    public static void courCanDeleteWithSomeChildRecords() {
+    public static void canDeleteCourseWithSomeChildRecords() {
     	UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
-                                                            (Account_Processor__c = adminAccRecTypeId,
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
                                                             Prevent_Course_Deletion__c = False));
         
         //We're using "Administrative" record type for this new Account since
         //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
         //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
         //record type in UTIL_Describe. 
-        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, adminAccRecTypeId); 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
         insert accounts; 
         
         List<Course__c> courses = new List<Course__c>{
@@ -383,8 +383,95 @@ public class COUR_CannotDelete_TEST {
         Test.stopTest();
         
         List<Course__c> returnCourses = [SELECT Id
-                                  FROM Course__c
-                                  WHERE Id IN :courses]; 
+                                        FROM Course__c
+                                        WHERE Id IN :courses]; 
         System.assertEquals(0, returnCourses.size());
+    }
+    
+	/*********************************************************************************************************
+    * @description Tests the hasChildRecords method that the Course record has child records. 
+    */
+    @isTest
+    public static void testCourseHasChildRecords() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        
+        List<Term__c> terms = new List<Term__c>{
+            new Term__c(Name = 'Fall', Account__c = accounts[0].Id),
+            new Term__c(Name = 'Spring', Account__c = accounts[0].Id)  
+        }; 
+        insert terms; 
+        
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(courses[0].Id, terms[0].Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(courses[1].Id, terms[1].Id); 
+        
+        List<Plan_Requirement__c> planReqs = UTIL_UnitTestData_TEST.getMultipleTestPlanRequirements(2); 
+        planReqs[0].Course__c = courses[0].Id;
+        planReqs[1].Course__c = courses[1].Id;
+        insert planReqs; 
+        
+        List<Course__c> returnCourses = [SELECT Id,
+                                        (SELECT ID, Name FROM Course_Offerings__r LIMIT 1),
+                     				    (SELECT ID, Name FROM Plan_Requirements__r LIMIT 1)
+                                        FROM Course__c
+                                        WHERE ID IN :courses]; 
+        
+        Boolean checkRelatedRecords; 
+        COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
+        
+        for (Course__c cour : returnCourses) {
+             checkRelatedRecords = myClass.hasChildRecords(cour); 
+             System.assertEquals(True, checkRelatedRecords); 
+        }
+    }
+	
+    /*********************************************************************************************************
+    * @description Tests the hasChildRecords method that the Course record has no child records. 
+    */
+    @isTest
+    public static void testCourseHasNoChildRecords() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = COUR_CannotDelete_TEST.adminAccRecTypeId,
+                                                            Prevent_Course_Deletion__c = True));
+        
+        //We're using "Administrative" record type for this new Account since
+        //we're not ready (we need to determine how best to handle retrieving recordTypeIds that are not
+        //in EDA Settings) to create a new method to retrieve the Universtiy_Department Account
+        //record type in UTIL_Describe. 
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, COUR_CannotDelete_TEST.adminAccRecTypeId); 
+        insert accounts; 
+        
+        List<Course__c> courses = new List<Course__c>{
+            new Course__c (Name = 'Course1', Account__c  = accounts[0].Id),
+            new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
+        };        
+        insert courses; 
+        List<Course__c> returnCourses = [SELECT Id,
+                                        (SELECT ID, Name FROM Course_Offerings__r LIMIT 1),
+                     				    (SELECT ID, Name FROM Plan_Requirements__r LIMIT 1)
+                                        FROM Course__c
+                                        WHERE ID IN :courses]; 
+        
+        Boolean checkRelatedRecords; 
+        COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
+        
+        for (Course__c cour : returnCourses) {
+             checkRelatedRecords = myClass.hasChildRecords(cour); 
+             System.assertEquals(False, checkRelatedRecords); 
+        }
     }
 }

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -41,7 +41,7 @@ public class COUR_CannotDelete_TEST {
     */
     public static String adminAccRecTypeId = UTIL_Describe.getAdminAccRecTypeID(); 
     
-	/*********************************************************************************************************
+    /*********************************************************************************************************
     * @description Test method to test if Prevent_Course_Deletion__c is enabled in Hierarchy Settings, and
     * Course has a Course Offering record associated to it, then it cannot be deleted.
     */
@@ -80,7 +80,7 @@ public class COUR_CannotDelete_TEST {
         List<Course__c> returnCourses = [SELECT Id
                                   FROM Course__c
                                   WHERE Id IN :courses]; 
-		System.assertEquals(2, returnCourses.size());
+        System.assertEquals(2, returnCourses.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
     }
     

--- a/src/classes/COUR_CannotDelete_TEST.cls
+++ b/src/classes/COUR_CannotDelete_TEST.cls
@@ -430,12 +430,9 @@ private class COUR_CannotDelete_TEST {
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
         
-        Boolean checkRelatedRecords; 
         COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
-        
-        for (Course__c cour : returnCourses) {
-            checkRelatedRecords = myClass.hasChildRecords(cour); 
-            System.assertEquals(True, checkRelatedRecords); 
+        for (Course__c cour : returnCourses) { 
+            System.assertEquals(True, myClass.hasChildRecords(cour)); 
         }
     }
 	
@@ -460,18 +457,16 @@ private class COUR_CannotDelete_TEST {
             new Course__c (Name = 'Course2', Account__c  = accounts[0].Id)
         };        
         insert courses; 
+        
         List<Course__c> returnCourses = [SELECT Id,
                                         (SELECT Id, Name FROM Course_Offerings__r LIMIT 1),
                                         (SELECT Id, Name FROM Plan_Requirements__r LIMIT 1)
                                         FROM Course__c
                                         WHERE Id IN :courses]; 
         
-        Boolean checkRelatedRecords; 
         COUR_CannotDelete_TDTM myClass = new COUR_CannotDelete_TDTM();
-        
         for (Course__c cour : returnCourses) {
-            checkRelatedRecords = myClass.hasChildRecords(cour); 
-            System.assertEquals(False, checkRelatedRecords); 
+            System.assertEquals(False, myClass.hasChildRecords(cour)); 
         }
     }
 }

--- a/src/classes/COUR_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/COUR_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -248,6 +248,11 @@ public without sharing class TDTM_DefaultConfig {
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'BEH_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Behavior_Involvement__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
+        
+        // Prevents deletion of Course when the records have associated child records
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'COUR_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Course__c',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
 
         return handlers;
         

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -169,6 +169,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Account_Deletion__c = mySettings.Prevent_Account_Deletion__c;
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
+        settings.Prevent_Course_Deletion__c = mySettings.Prevent_Course_Deletion__c; 
         orgSettings = settings;
         return settings;
     }

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -392,6 +392,15 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Prevent_Course_Deletion__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Reserved for future use.</description>
+        <externalId>false</externalId>
+        <label>Prevent Course Deletion</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Prevent_Course_Connection_Deletion__c</fullName>
         <defaultValue>false</defaultValue>
         <description>Reserved for future use.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -460,6 +460,7 @@
         <members>Hierarchy_Settings__c.Prevent_Behavior_Involvement_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Case_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Contact_Deletion__c</members>
+        <members>Hierarchy_Settings__c.Prevent_Course_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Course_Connection_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Course_Offering_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Plan_Requirement_Deletion__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -77,6 +77,8 @@
         <members>CON_PrimaryLanguage_TEST</members>
         <members>COS_StartEndTime_TDTM</members>
         <members>COS_StartEndTime_TEST</members>
+        <members>COUR_CannotDelete_TDTM</members>
+        <members>COUR_CannotDelete_TEST</members>
         <members>COUR_DescriptionCopy_BATCH</members>
         <members>COUR_DescriptionCopy_TEST</members>
         <members>ERR_AsyncErrors</members>


### PR DESCRIPTION
# Critical Changes

# Changes
## Updates to Ensure Data Integrity
We've added functionality to prevent the deletion of Course records with related Course Offering or Plan Requirement records. 

These changes are for internal-use only and are disabled at this time. You won't see any difference in functionality.

**Note:** We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI, which will be provided in an upcoming release. However, if you do enable any of these settings, note the following:

- If you have disabled the related COUR_CannotDelete_TDTM classes for the object, the settings will remain disabled even though you've enabled them in Hierarchy Custom Settings.
- If you enable any of these settings, be sure to disable them before merging records or deleting duplicate records.
# Issues Closed
Closes #1164
# New Metadata
Checkbox Field on Hierarchy Settings:
- Prevent_Course_Deletion__c

Apex Classes: 
- COUR_CannotDelete_TDTM
- COUR_CannotDelete_TEST
# Deleted Metadata

# Testing Notes
https://salesforce.quip.com/tpgtAkYA9bi9#KLfACAC3QG7