### PR TITLE
[EDA] Prevent Deletion of Program Enrollment Record if There are Associated Child Records

### DIFF
--- a/src/classes/PREN_CannotDelete_TDTM.cls
+++ b/src/classes/PREN_CannotDelete_TDTM.cls
@@ -1,0 +1,86 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Program Enrollment
+* @group-content ../../ApexDocContent/ProgramEnrollment.htm
+* @description Stops a Program Enrollment from being deleted if it has any Course Connection child records.
+*/
+public with sharing class PREN_CannotDelete_TDTM extends TDTM_Runnable {
+    /*******************************************************************************************************
+    * @description Get the setting of preventing Program Enrollment deletion
+    */
+    private static Boolean enabledPreventProgramEnrollmentDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Program_Enrollment_Deletion__c;
+    
+    /*******************************************************************************************************
+    * @description Stops a Program Enrollment from being deleted if it has any Course Connection 
+    * or Plan Requirement child records.
+    * @param listNew the list of Program Enrollment from trigger new.
+    * @param listOld the list of Program Enrollment from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Program Enrollment
+    * @return dmlWrapper.
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+        
+        if (!PREN_CannotDelete_TDTM.enabledPreventProgramEnrollmentDeletion) {
+            return new DmlWrapper(); 
+        }
+
+        Map<Id, Program_Enrollment__c> oldMap = new Map<Id, Program_Enrollment__c>((List<Program_Enrollment__c>)oldList);
+
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            for (Program_Enrollment__c programEnrollment : [SELECT ID,
+                                                            (SELECT ID FROM Program_Enrollment__c.Course_Enrollments__r LIMIT 1)
+                                                            FROM Program_Enrollment__c
+                                                            WHERE ID IN :oldlist])
+            {
+                if (this.hasChildRecords(programEnrollment)) {
+                    Program_Enrollment__c programEnrollmentInContext = oldmap.get(programEnrollment.ID);
+                    programEnrollmentInContext.addError(Label.CannotDelete);
+                }
+            }
+        }
+
+        return new DmlWrapper();
+    }
+
+    /*******************************************************************************************************
+     * @description Evaluates whether the Program Enrollment has any child related records.
+     * @param programEnrollment is the current Program Enrollment record.
+     * @return Boolean.
+     ********************************************************************************************************/
+    @testVisible
+    private Boolean hasChildRecords(Program_Enrollment__c programEnrollment) {
+        return (!programEnrollment.Course_Enrollments__r.isEmpty());
+    }
+}

--- a/src/classes/PREN_CannotDelete_TDTM.cls
+++ b/src/classes/PREN_CannotDelete_TDTM.cls
@@ -75,10 +75,10 @@ public with sharing class PREN_CannotDelete_TDTM extends TDTM_Runnable {
     }
 
     /*******************************************************************************************************
-     * @description Evaluates whether the Program Enrollment has any child related records.
-     * @param programEnrollment is the current Program Enrollment record.
-     * @return Boolean.
-     ********************************************************************************************************/
+    * @description Evaluates whether the Program Enrollment has any child related records.
+    * @param programEnrollment is the current Program Enrollment record.
+    * @return Boolean.
+    ********************************************************************************************************/
     @testVisible
     private Boolean hasChildRecords(Program_Enrollment__c programEnrollment) {
         return (!programEnrollment.Course_Enrollments__r.isEmpty());

--- a/src/classes/PREN_CannotDelete_TDTM.cls
+++ b/src/classes/PREN_CannotDelete_TDTM.cls
@@ -42,7 +42,7 @@ public with sharing class PREN_CannotDelete_TDTM extends TDTM_Runnable {
     
     /*******************************************************************************************************
     * @description Stops a Program Enrollment from being deleted if it has any Course Connection 
-    * or Plan Requirement child records.
+    * child records.
     * @param listNew the list of Program Enrollment from trigger new.
     * @param listOld the list of Program Enrollment from trigger old.
     * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).

--- a/src/classes/PREN_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/PREN_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/PREN_CannotDelete_TEST.cls
+++ b/src/classes/PREN_CannotDelete_TEST.cls
@@ -50,7 +50,7 @@ private class PREN_CannotDelete_TEST {
     * @description Test method to test if Prevent_Program_Enrollment_Deletion__c is enabled in Hierarchy Settings, and
     * Program Enrollment has a Course Connection record associated to it, then it cannot be deleted.
     */
-	@isTest
+    @isTest
     public static void cannotDeleteProgramEnrollmentWithCourseConn(){
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                         (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
@@ -98,7 +98,7 @@ private class PREN_CannotDelete_TEST {
     * @description Test method to test if Prevent_Program_Enrollment_Deletion__c is disabled in Hierarchy Settings, and
     * Program Enrollment has a Course Connection record associated to it, then it can be deleted.
     */
-	@isTest
+    @isTest
     public static void canDeleteProgramEnrollmentWithCourseConn(){
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                         (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
@@ -144,7 +144,7 @@ private class PREN_CannotDelete_TEST {
     /*********************************************************************************************************
     * @description Tests the hasChildRecords method that the Program Enrollment record has child records. 
     */
-	@isTest
+    @isTest
     public static void testProgramEnrollmentHasChildRecords(){
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                         (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
@@ -191,7 +191,7 @@ private class PREN_CannotDelete_TEST {
     /*********************************************************************************************************
     * @description Tests the hasChildRecords method that the Program Enrollment record has no child records. 
     */
-	@isTest
+    @isTest
     public static void testProgramEnrollmentHasNoChildRecords(){
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                         (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,

--- a/src/classes/PREN_CannotDelete_TEST.cls
+++ b/src/classes/PREN_CannotDelete_TEST.cls
@@ -1,0 +1,221 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Program Enrollment
+* @group-content ../../ApexDocContent/ProgramEnrollment.htm
+* @description Tests for PREN_CannotDelete_TDTM
+*/
+@isTest
+private class PREN_CannotDelete_TEST {
+    /*********************************************************************************************************
+    * @description Retrieves the Administrative record type Id. 
+    */
+    public static String adminAccRecTypeId = UTIL_Describe.getAdminAccRecTypeID(); 
+    
+    /*********************************************************************************************************
+    * @description Retrieves the Academic Program record type Id. 
+    */
+    public static String academicAccRecTypeId = UTIL_Describe.getAcademicAccRecTypeID(); 
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Program_Enrollment_Deletion__c is enabled in Hierarchy Settings, and
+    * Program Enrollment has a Course Connection record associated to it, then it cannot be deleted.
+    */
+	@isTest
+    public static void cannotDeleteProgramEnrollmentWithCourseConn(){
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Program_Enrollment_Deletion__c = True));
+        
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, PREN_CannotDelete_TEST.academicAccRecTypeId); 
+        insert accounts; 
+        
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        insert contacts; 
+        
+        List<Program_Enrollment__c> programEnrollments = UTIL_UnitTestData_TEST.getMultipleTestProgramEnrollments(2, accounts[0].Id); 
+        programEnrollments[0].Contact__c = contacts[0].Id; 
+        programEnrollments[1].Contact__c = contacts[1].Id; 
+        insert programEnrollments; 
+        
+        Course__c course = new Course__c(Name = 'Intro to Neuroscience', Account__c = accounts[0].Id); 
+        insert course; 
+        
+        Term__c term = UTIL_UnitTestData_TEST.getTerm(accounts[0].Id, 'Fall'); 
+        insert term; 
+
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id);
+        
+        Course_Enrollment__c courseConnection1 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[0].Id, courseOffering1.Id); 
+        Course_Enrollment__c courseConnection2 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[1].Id, courseOffering2.Id);
+        courseConnection1.Program_Enrollment__c = programEnrollments[0].Id; 
+        courseConnection2.Program_Enrollment__c = programEnrollments[1].Id; 
+        insert courseConnection1;
+        insert courseConnection2; 
+        
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(programEnrollments, false);
+        Test.stopTest();
+
+        List<Program_Enrollment__c> returnProgramEnrollments = [SELECT Id
+                                                                FROM Program_Enrollment__c
+                                                                WHERE Id IN :programEnrollments]; 
+        System.assertEquals(2, returnProgramEnrollments.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);  
+    }
+    
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Program_Enrollment_Deletion__c is disabled in Hierarchy Settings, and
+    * Program Enrollment has a Course Connection record associated to it, then it can be deleted.
+    */
+	@isTest
+    public static void canDeleteProgramEnrollmentWithCourseConn(){
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Program_Enrollment_Deletion__c = False));
+
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, PREN_CannotDelete_TEST.academicAccRecTypeId); 
+        insert accounts; 
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        insert contacts; 
+
+        List<Program_Enrollment__c> programEnrollments = UTIL_UnitTestData_TEST.getMultipleTestProgramEnrollments(2, accounts[0].Id); 
+        programEnrollments[0].Contact__c = contacts[0].Id; 
+        programEnrollments[1].Contact__c = contacts[1].Id; 
+        insert programEnrollments; 
+
+        Course__c course = new Course__c(Name = 'Intro to Neuroscience', Account__c = accounts[0].Id); 
+        insert course; 
+
+        Term__c term = UTIL_UnitTestData_TEST.getTerm(accounts[0].Id, 'Fall'); 
+        insert term; 
+
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id);
+
+        Course_Enrollment__c courseConnection1 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[0].Id, courseOffering1.Id); 
+        Course_Enrollment__c courseConnection2 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[1].Id, courseOffering2.Id);
+        courseConnection1.Program_Enrollment__c = programEnrollments[0].Id; 
+        courseConnection2.Program_Enrollment__c = programEnrollments[1].Id; 
+        insert courseConnection1;
+        insert courseConnection2; 
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(programEnrollments, false);
+        Test.stopTest();
+
+        List<Program_Enrollment__c> returnProgramEnrollments = [SELECT Id
+                                                                FROM Program_Enrollment__c
+                                                                WHERE Id IN :programEnrollments]; 
+        System.assertEquals(0, returnProgramEnrollments.size());
+    }
+    
+    /*********************************************************************************************************
+    * @description Tests the hasChildRecords method that the Program Enrollment record has child records. 
+    */
+	@isTest
+    public static void testProgramEnrollmentHasChildRecords(){
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Program_Enrollment_Deletion__c = True));
+        
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, PREN_CannotDelete_TEST.academicAccRecTypeId); 
+        insert accounts; 
+        
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        insert contacts; 
+        
+        List<Program_Enrollment__c> programEnrollments = UTIL_UnitTestData_TEST.getMultipleTestProgramEnrollments(2, accounts[0].Id); 
+        programEnrollments[0].Contact__c = contacts[0].Id; 
+        programEnrollments[1].Contact__c = contacts[1].Id; 
+        insert programEnrollments; 
+        
+        Course__c course = new Course__c(Name = 'Intro to Neuroscience', Account__c = accounts[0].Id); 
+        insert course; 
+        
+        Term__c term = UTIL_UnitTestData_TEST.getTerm(accounts[0].Id, 'Fall'); 
+        insert term; 
+
+        Course_Offering__c courseOffering1 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id); 
+        Course_Offering__c courseOffering2 = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id);
+        
+        Course_Enrollment__c courseConnection1 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[0].Id, courseOffering1.Id); 
+        Course_Enrollment__c courseConnection2 = UTIL_UnitTestData_TEST.getCourseConnection(contacts[1].Id, courseOffering2.Id);
+        courseConnection1.Program_Enrollment__c = programEnrollments[0].Id; 
+        courseConnection2.Program_Enrollment__c = programEnrollments[1].Id; 
+        insert courseConnection1;
+        insert courseConnection2; 
+        
+        List<Program_Enrollment__c> returnProgramEnrollments = [SELECT Id,
+                                                                (SELECT Id FROM Program_Enrollment__c.Course_Enrollments__r LIMIT 1)
+                                                                FROM Program_Enrollment__c
+                                                                WHERE Id IN :programEnrollments]; 
+        
+        PREN_CannotDelete_TDTM myClass = new PREN_CannotDelete_TDTM(); 
+        for (Program_Enrollment__c programEnroll: returnProgramEnrollments) {
+            System.assertEquals(True, myClass.hasChildRecords(programEnroll)); 
+        }
+    }
+    
+    /*********************************************************************************************************
+    * @description Tests the hasChildRecords method that the Program Enrollment record has no child records. 
+    */
+	@isTest
+    public static void testProgramEnrollmentHasNoChildRecords(){
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                        (Account_Processor__c = PREN_CannotDelete_TEST.adminAccRecTypeId,
+                                                        Prevent_Program_Enrollment_Deletion__c = True));
+        
+        List<Account> accounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, PREN_CannotDelete_TEST.academicAccRecTypeId); 
+        insert accounts; 
+        
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        insert contacts; 
+        
+        List<Program_Enrollment__c> programEnrollments = UTIL_UnitTestData_TEST.getMultipleTestProgramEnrollments(2, accounts[0].Id); 
+        programEnrollments[0].Contact__c = contacts[0].Id; 
+        programEnrollments[1].Contact__c = contacts[1].Id; 
+        insert programEnrollments; 
+
+        List<Program_Enrollment__c> returnProgramEnrollments = [SELECT Id,
+                                                                (SELECT Id FROM Program_Enrollment__c.Course_Enrollments__r LIMIT 1)
+                                                                FROM Program_Enrollment__c
+                                                                WHERE Id IN :programEnrollments]; 
+        
+        PREN_CannotDelete_TDTM myClass = new PREN_CannotDelete_TDTM(); 
+        for (Program_Enrollment__c programEnroll: returnProgramEnrollments) {
+            System.assertEquals(False, myClass.hasChildRecords(programEnroll)); 
+        }
+    }
+}

--- a/src/classes/PREN_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/PREN_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -252,6 +252,7 @@ public without sharing class TDTM_DefaultConfig {
         // Prevents deletion of Program Enrollment when the records have associated child records
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PREN_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Program_Enrollment__c',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
                 
         // Prevents deletion of Course when the records have associated child records
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -248,6 +248,11 @@ public without sharing class TDTM_DefaultConfig {
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'BEH_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Behavior_Involvement__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
+        
+        // Prevents deletion of Behavior Involvement when the records have associated child records
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'PREN_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Program_Enrollment__c',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
 
         return handlers;
         

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -169,6 +169,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Account_Deletion__c = mySettings.Prevent_Account_Deletion__c;
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
+        settings.Prevent_Program_Enrollment_Deletion__c = mySettings.Prevent_Program_Enrollment_Deletion__c;
         orgSettings = settings;
         return settings;
     }

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -419,6 +419,15 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Prevent_Program_Enrollment_Deletion__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Reserved for future use.</description>
+        <externalId>false</externalId>
+        <label>Prevent Program Plan Deletion</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Prevent_Program_Plan_Deletion__c</fullName>
         <defaultValue>false</defaultValue>
         <description>Reserved for future use.</description>

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -423,7 +423,7 @@
         <defaultValue>false</defaultValue>
         <description>Reserved for future use.</description>
         <externalId>false</externalId>
-        <label>Prevent Program Plan Deletion</label>
+        <label>Prevent Program Enrollment Deletion</label>
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>
     </fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -96,6 +96,8 @@
         <members>PPlan_Primary_TEST</members>
         <members>PREN_Affiliation_TDTM</members>
         <members>PREN_Affiliation_TEST</members>
+        <members>PREN_CannotDelete_TDTM</members>
+        <members>PREN_CannotDelete_TEST</members>
         <members>PREN_ProgramPlan_TDTM</members>
         <members>PREN_ProgramPlan_TEST</members>
         <members>PREQ_PreventPPlanParent_TDTM</members>
@@ -461,6 +463,7 @@
         <members>Hierarchy_Settings__c.Prevent_Course_Connection_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Course_Offering_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Plan_Requirement_Deletion__c</members>
+        <members>Hierarchy_Settings__c.Prevent_Program_Enrollment_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Program_Plan_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Term_Deletion__c</members>
         <members>Hierarchy_Settings__c.Reciprocal_Method__c</members>


### PR DESCRIPTION
# Critical Changes

# Changes
We've added functionality to prevent the deletion of Program Enrollment records with related Course Connection records.

These changes are for internal-use only and are disabled at this time. You won't see any difference in functionality.

**Note:**We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI, which will be provided in an upcoming release. However, if you do enable any of these settings, note the following:

If you have disabled the related PREN_CannotDelete_TDTM classes for the object, the settings will remain disabled even though you've enabled them in Hierarchy Custom Settings.
If you enable any of these settings, be sure to disable them before merging records or deleting duplicate records.
# Issues Closed
Closes #1167
# New Metadata
Checkbox Field on Hierarchy Settings:
- Prevent_Program_Enrollment_Deletion__c

Apex Classes:
- PREN_CannotDelete_TDTM
- PREN_CannotDelete_TEST

# Deleted Metadata

# Testing Notes
https://salesforce.quip.com/2uBfA1GvDlQ7#SEGACA9eO5k