### PR TITLE
[EDA] Prevent Deletion of Test Record  if There are Associated Test Score Records

### DIFF
--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -224,6 +224,11 @@ public without sharing class TDTM_DefaultConfig {
                 Class__c = 'TERM_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Term__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
 
+        // Prevents deletion of Tests when the records are associated with Test Scores
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'TST_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Test__c',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
+
         // Prevents changes to a Contact or Course Offering on a Course Connection when a Term Grade or an Attendance Event is present on the Course Connection.
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'CCON_PreventUpdate_TDTM', Load_Order__c = 1, Object__c = 'Course_Enrollment__c',

--- a/src/classes/TST_CannotDelete_TDTM.cls
+++ b/src/classes/TST_CannotDelete_TDTM.cls
@@ -1,0 +1,5 @@
+public with sharing class TST_CannotDelete_TDTM {
+    public TST_CannotDelete_TDTM() {
+
+    }
+}

--- a/src/classes/TST_CannotDelete_TDTM.cls
+++ b/src/classes/TST_CannotDelete_TDTM.cls
@@ -1,5 +1,91 @@
-public with sharing class TST_CannotDelete_TDTM {
-    public TST_CannotDelete_TDTM() {
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Tests
+* @group-content ../../ApexDocContent/Tests.htm
+* @description Stops a Test from being deleted if it has any Test Score child records. 
+*/
+public with sharing class TST_CannotDelete_TDTM extends TDTM_runnable {
 
+    /*******************************************************************************************************
+    * @description Get the setting for Prevent Test Deletion
+    */
+    private static Boolean enabledPreventTestDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Test_Deletion__c;
+
+    /*******************************************************************************************************
+    * @description Stops a Test from being deleted if it has any Test Score child records. 
+    * @param newlist the list of Tests from trigger new. 
+    * @param oldlist the list of Tests from trigger old. 
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
+    * @param objResult the describe for Tests 
+    * @return DmlWrapper.  
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+        
+        if (TST_CannotDelete_TDTM.enabledPreventTestDeletion == FALSE) {
+            return new DmlWrapper(); 
+        }
+        
+        Map<Id, Test__c> oldmap = new Map<Id, Test__c>((List<Test__c>)oldList);
+        
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            for (Test__c tst : [
+                                    SELECT Id, 
+                                        (SELECT Id FROM Test__c.Test_Scores__r LIMIT 1)
+                                    FROM Test__c WHERE Id IN :oldlist
+                                    
+                                ]) {
+                
+                if (this.hasChildRecords(tst)) {
+                    Test__c testInContext = oldMap.get(tst.ID);
+                    testInContext.addError(Label.CannotDelete);
+                }
+            }     
+        }
+
+        return new DmlWrapper();
     }
+    
+    /*******************************************************************************************************
+     * @description Evaluates whether the Test has any child (Test Score) related records.
+     * @param tst is the current Test record.
+     * @return Boolean.
+     ********************************************************************************************************/
+    @testVisible
+    private Boolean hasChildRecords(Test__c tst) {
+        
+        return ( tst.Test_Scores__r.isEmpty() == FALSE ); 
+    
+    }
+
 }

--- a/src/classes/TST_CannotDelete_TDTM.cls
+++ b/src/classes/TST_CannotDelete_TDTM.cls
@@ -51,7 +51,7 @@ public with sharing class TST_CannotDelete_TDTM extends TDTM_runnable {
     ********************************************************************************************************/
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-        
+    
         if (TST_CannotDelete_TDTM.enabledPreventTestDeletion == FALSE) {
             return new DmlWrapper(); 
         }
@@ -59,20 +59,17 @@ public with sharing class TST_CannotDelete_TDTM extends TDTM_runnable {
         Map<Id, Test__c> oldmap = new Map<Id, Test__c>((List<Test__c>)oldList);
         
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
-            for (Test__c tst : [
-                                    SELECT Id, 
-                                        (SELECT Id FROM Test__c.Test_Scores__r LIMIT 1)
-                                    FROM Test__c WHERE Id IN :oldlist
-                                    
-                                ]) {
+            for (Test__c tst : [ SELECT Id, 
+                                (SELECT Id FROM Test__c.Test_Scores__r LIMIT 1)
+                                FROM Test__c WHERE Id IN :oldlist
+                               ]) {
                 
                 if (this.hasChildRecords(tst)) {
                     Test__c testInContext = oldMap.get(tst.ID);
                     testInContext.addError(Label.CannotDelete);
                 }
-            }     
+            }
         }
-
         return new DmlWrapper();
     }
     
@@ -83,9 +80,6 @@ public with sharing class TST_CannotDelete_TDTM extends TDTM_runnable {
      ********************************************************************************************************/
     @testVisible
     private Boolean hasChildRecords(Test__c tst) {
-        
         return ( tst.Test_Scores__r.isEmpty() == FALSE ); 
-    
     }
-
 }

--- a/src/classes/TST_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/TST_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TST_CannotDelete_TEST.cls
+++ b/src/classes/TST_CannotDelete_TEST.cls
@@ -1,0 +1,268 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Tests
+* @group-content ../../ApexDocContent/Tests.htm
+* @description Tests for TST_CannotDelete_TDTM.
+*/
+
+
+@isTest
+private class TST_CannotDelete_TEST {
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings, and
+    * Test has a child Test Score record associated to it, the Test record cannot be deleted.
+    */
+    @isTest 
+    private static void tstCannotDeleteWithChildPreventOn() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Test_Deletion__c = TRUE));
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        List<Test_Score__c> testScores = new List<Test_Score__c>();
+        for (Test__c tst : tests) {
+            Test_Score__c tstScr = new Test_Score__c(Test__c = tst.Id, Subject_Area__c = 'Language');
+            testScores.add(tstScr);
+        }
+        insert testScores;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(tests, FALSE);
+        Test.stopTest();
+
+        List<Test__c> returnTests = [
+            SELECT Id
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        System.assertEquals(tests.size(), returnTests.size());
+
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(Label.Cannotdelete, result.errors[0].message);
+        }
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings, and
+    * Test is not associated with any child Test Score records, the Test record can be deleted.
+    */
+    @isTest 
+    private static void tstCanDeleteWithoutChildPreventOn() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Test_Deletion__c = TRUE));
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(tests, FALSE);
+        Test.stopTest();
+
+        List<Test__c> returnTests = [
+            SELECT Id
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        System.assertEquals(TRUE, returnTests.isEmpty());
+
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.success);
+        }
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings, and
+    * Test has a child Test Score record associated to it, the Test record can be deleted.
+    */
+    @isTest 
+    private static void tstCanDeleteWithChildPreventOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Test_Deletion__c = FALSE));
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        List<Test_Score__c> testScores = new List<Test_Score__c>();
+        for (Test__c tst : tests) {
+            Test_Score__c tstScr = new Test_Score__c(Test__c = tst.Id, Subject_Area__c = 'Language');
+            testScores.add(tstScr);
+        }
+        insert testScores;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(tests, FALSE);
+        Test.stopTest();
+
+        List<Test__c> returnTests = [
+            SELECT Id
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        System.assertEquals(TRUE, returnTests.isEmpty());
+
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.success);
+        }
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings, and
+    * Test is not associated with any child Test Score records, the Test record can be deleted.
+    */
+    @isTest 
+    private static void tstCanDeleteWithoutChildPreventOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Test_Deletion__c = FALSE));
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(tests, FALSE);
+        Test.stopTest();
+
+        List<Test__c> returnTests = [
+            SELECT Id
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        System.assertEquals(TRUE, returnTests.isEmpty());
+
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.success);
+        }
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TST_CannotDelete_TDTM to test that TRUE
+    * is returned for a Test record with Test Score child records.
+    */
+    @isTest
+    private static void testTstHasChildRecordsIsTrue() {
+        
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        List<Test_Score__c> testScores = new List<Test_Score__c>();
+        for (Test__c tst : tests) {
+            Test_Score__c tstScr = new Test_Score__c(Test__c = tst.Id, Subject_Area__c = 'Language');
+            testScores.add(tstScr);
+        }
+        insert testScores;
+
+        List<Test__c> returnTests = [
+            SELECT Id, 
+                (SELECT Id FROM Test__c.Test_Scores__r)
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        TST_CannotDelete_TDTM tstCannotDeleteClass = new TST_CannotDelete_TDTM();
+
+        for (Test__c tst : returnTests) {
+            System.assertEquals(TRUE, tstCannotDeleteClass.hasChildRecords(tst));
+        }
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TST_CannotDelete_TDTM to test that FALSE
+    * is returned for a Test record with no child records.
+    */
+    @isTest
+    private static void testTstHasChildRecordsIsFalse() {
+        
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
+        insert contacts;
+
+        List<Test__c> tests = new List<Test__c>();
+        for (Contact contact : contacts) {
+            Test__c tst = new Test__c(Contact__c = contact.Id, Test_Type__c = 'SAT', Test_Date__c = System.today() - 30);
+            tests.add(tst);
+        }
+        insert tests;
+
+        List<Test__c> returnTests = [
+            SELECT Id, 
+                (SELECT Id FROM Test__c.Test_Scores__r)
+            FROM Test__c
+            WHERE Id IN :tests
+        ];
+
+        TST_CannotDelete_TDTM tstCannotDeleteClass = new TST_CannotDelete_TDTM();
+
+        for (Test__c tst : returnTests) {
+            System.assertEquals(FALSE, tstCannotDeleteClass.hasChildRecords(tst));
+        }
+    }
+}

--- a/src/classes/TST_CannotDelete_TEST.cls
+++ b/src/classes/TST_CannotDelete_TEST.cls
@@ -40,11 +40,11 @@
 private class TST_CannotDelete_TEST {
 
     /*********************************************************************************************************
-    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings, and
-    * Test has a child Test Score record associated to it, the Test record cannot be deleted.
+    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings and
+    * Test has a child Test Score record associated with it, the Test record cannot be deleted.
     */
     @isTest 
-    private static void tstCannotDeleteWithChildPreventOn() {
+    private static void cannotDeleteWithChildPreventDeleteOn() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Test_Deletion__c = TRUE));
 
@@ -83,11 +83,11 @@ private class TST_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings, and
+    * @description Test method to test that when Prevent_Test_Deletion__c is enabled in Hierarchy Settings and
     * Test is not associated with any child Test Score records, the Test record can be deleted.
     */
     @isTest 
-    private static void tstCanDeleteWithoutChildPreventOn() {
+    private static void canDeleteWithoutChildPreventDeleteOn() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Test_Deletion__c = TRUE));
 
@@ -119,11 +119,11 @@ private class TST_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings, and
+    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings and
     * Test has a child Test Score record associated to it, the Test record can be deleted.
     */
     @isTest 
-    private static void tstCanDeleteWithChildPreventOff() {
+    private static void canDeleteWithChildPreventDeleteOff() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Test_Deletion__c = FALSE));
 
@@ -162,11 +162,11 @@ private class TST_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings, and
+    * @description Test method to test that when Prevent_Test_Deletion__c is disabled in Hierarchy Settings and
     * Test is not associated with any child Test Score records, the Test record can be deleted.
     */
     @isTest 
-    private static void tstCanDeleteWithoutChildPreventOff() {
+    private static void canDeleteWithoutChildPreventDeleteOff() {
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Test_Deletion__c = FALSE));
 
@@ -202,7 +202,7 @@ private class TST_CannotDelete_TEST {
     * is returned for a Test record with Test Score child records.
     */
     @isTest
-    private static void testTstHasChildRecordsIsTrue() {
+    private static void hasChildRecordsIsTrue() {
         
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
         insert contacts;
@@ -240,7 +240,7 @@ private class TST_CannotDelete_TEST {
     * is returned for a Test record with no child records.
     */
     @isTest
-    private static void testTstHasChildRecordsIsFalse() {
+    private static void hasChildRecordsIsFalse() {
         
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(5);
         insert contacts;

--- a/src/classes/TST_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/TST_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -169,6 +169,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Account_Deletion__c = mySettings.Prevent_Account_Deletion__c;
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
+        settings.Prevent_Test_Deletion__c = mySettings.Prevent_Test_Deletion__c;
         orgSettings = settings;
         return settings;
     }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -168,6 +168,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Program_Enrollment_Deletion__c = mySettings.Prevent_Program_Enrollment_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
         settings.Prevent_Term_Deletion__c = mySettings.Prevent_Term_Deletion__c;
+        settings.Prevent_Test_Deletion__c = mySettings.Prevent_Test_Deletion__c;
         settings.Reciprocal_Method__c = mySettings.Reciprocal_Method__c;
         settings.Simple_Address_Change_Treated_as_Update__c = mySettings.Simple_Address_Change_Treated_as_Update__c;
         settings.Store_Errors_On__c = mySettings.Store_Errors_On__c;

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -167,17 +167,12 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
         settings.Prevent_Program_Enrollment_Deletion__c = mySettings.Prevent_Program_Enrollment_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
-<<<<<<< HEAD
-        settings.Prevent_Test_Deletion__c = mySettings.Prevent_Test_Deletion__c;
-        settings.Prevent_Course_Deletion__c = mySettings.Prevent_Course_Deletion__c; 
-=======
         settings.Prevent_Term_Deletion__c = mySettings.Prevent_Term_Deletion__c;
         settings.Reciprocal_Method__c = mySettings.Reciprocal_Method__c;
         settings.Simple_Address_Change_Treated_as_Update__c = mySettings.Simple_Address_Change_Treated_as_Update__c;
         settings.Store_Errors_On__c = mySettings.Store_Errors_On__c;
         settings.Student_RecType__c = mySettings.Student_RecType__c;
         settings.Validate_Program_Plan_for_Nested_PR__c = mySettings.Validate_Program_Plan_for_Nested_PR__c; 
->>>>>>> master
         orgSettings = settings;
         return settings;
     }

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -437,6 +437,15 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Prevent_Test_Deletion__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Reserved for future use.</description>
+        <externalId>false</externalId>
+        <label>Prevent Test Deletion</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Reciprocal_Method__c</fullName>
         <description>Determines method used to generate the reciprocal relationship.  Either List Setting which uses custom settings by gender, or Value Inversion, which inverts the type if appropriate (&quot;Parent-Child&quot; to &quot;Child-Parent&quot;)</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -142,6 +142,7 @@
         <members>THAN_ClearCache_TEST</members>
         <members>THAN_Filter_TDTM</members>
         <members>THAN_Filter_TEST</members>
+        <members>TST_CannotDelete_TDTM</members>
         <members>UTIL_ACCT_Naming</members>
         <members>UTIL_CustomSettingsFacade</members>
         <members>UTIL_CustomSettingsFacade_TEST</members>
@@ -463,6 +464,7 @@
         <members>Hierarchy_Settings__c.Prevent_Plan_Requirement_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Program_Plan_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Term_Deletion__c</members>
+        <members>Hierarchy_Settings__c.Prevent_Test_Deletion__c</members>
         <members>Hierarchy_Settings__c.Reciprocal_Method__c</members>
         <members>Hierarchy_Settings__c.Relationship_Name_Field_Id__c</members>
         <members>Hierarchy_Settings__c.Relationship_Name_Id_Field_Id__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -143,6 +143,7 @@
         <members>THAN_Filter_TDTM</members>
         <members>THAN_Filter_TEST</members>
         <members>TST_CannotDelete_TDTM</members>
+        <members>TST_CannotDelete_TEST</members>
         <members>UTIL_ACCT_Naming</members>
         <members>UTIL_CustomSettingsFacade</members>
         <members>UTIL_CustomSettingsFacade_TEST</members>


### PR DESCRIPTION
# Critical Changes

# Changes
### Updates to Ensure Data Integrity
We've added functionality to prevent the deletion of Test records with related Test Score records.

These changes are for internal-use only and are disabled at this time. You won't see any difference in functionality.

**Note:** We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI, which will be provided in an upcoming release. However, if you do enable any of these settings, note the following:

- If you have disabled the related TST_CannotDelete_TDTM classes for the object, the settings will remain disabled even though you've enabled them in Hierarchy Custom Settings.

- If you enable any of these settings, be sure to disable them before merging records or deleting duplicate records.

# Issues Closed
Closes Issue #1170 

# New Metadata
Checkbox Field on Hierarchy Settings:

- Prevent_Test_Deletion__c

Apex Classes:

- TST_CannotDelete_TDTM

- TST_CannotDelete_TEST

# Deleted Metadata

# Testing Notes
https://salesforce.quip.com/tu19APFVFuvF#OGIACAhkxdd