### PR TITLE
[EDA] Prevent Deletion of Time Block Record  if There are Associated Course Records

### DIFF
--- a/src/classes/TB_CannotDelete_TDTM.cls
+++ b/src/classes/TB_CannotDelete_TDTM.cls
@@ -30,10 +30,10 @@
 /**
 * @author Salesforce.org
 * @date 2020
-* @group Time Block
+* @group Time Blocks
 * @group-content ../../ApexDocContent/TimeBlocks.htm
-* @description Stops a Time Block from being deleted if it has any Course Offering or 
-* Course Offering Schedule child records. 
+* @description Stops a Time Block from being deleted if it associated with
+* any Course Offering or Course Offering Schedule child records. 
 */
 
 public with sharing class TB_CannotDelete_TDTM extends TDTM_runnable {

--- a/src/classes/TB_CannotDelete_TDTM.cls
+++ b/src/classes/TB_CannotDelete_TDTM.cls
@@ -62,13 +62,11 @@ public with sharing class TB_CannotDelete_TDTM extends TDTM_runnable {
         Map<Id, Time_Block__c> oldmap = new Map<Id, Time_Block__c>((List<Time_Block__c>)oldList);
         
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
-            for (Time_Block__c tb : [
-                                    SELECT Id, 
+            for (Time_Block__c tb : [ SELECT Id, 
                                         (SELECT Id FROM Time_Block__c.Time_Blocks__r LIMIT 1),
                                         (SELECT Id FROM Time_Block__c.Course_Offering_Schedules__r LIMIT 1)
-                                    FROM Time_Block__c WHERE Id IN :oldlist
-                                    
-                                ]) {
+                                      FROM Time_Block__c WHERE Id IN :oldlist
+                                    ]) {
                 
                 if (this.hasChildRecords(tb)) {
                     Time_Block__c timeBlockInContext = oldMap.get(tb.ID);
@@ -76,7 +74,7 @@ public with sharing class TB_CannotDelete_TDTM extends TDTM_runnable {
                 }
             }     
         }
-
+        
         return new DmlWrapper();
     }
     
@@ -88,8 +86,6 @@ public with sharing class TB_CannotDelete_TDTM extends TDTM_runnable {
      ********************************************************************************************************/
     @testVisible
     private Boolean hasChildRecords(Time_Block__c tb) {
-        
         return ( tb.Time_Blocks__r.isEmpty() == FALSE || tb.Course_Offering_Schedules__r.isEmpty() == FALSE ); 
-    
     }
 }

--- a/src/classes/TB_CannotDelete_TDTM.cls
+++ b/src/classes/TB_CannotDelete_TDTM.cls
@@ -1,5 +1,95 @@
-public with sharing class TB_CannotDelete_TDTM {
-    public TB_CannotDelete_TDTM() {
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Time Block
+* @group-content ../../ApexDocContent/TimeBlocks.htm
+* @description Stops a Time Block from being deleted if it has any Course Offering or 
+* Course Offering Schedule child records. 
+*/
 
+public with sharing class TB_CannotDelete_TDTM extends TDTM_runnable {
+
+    /*******************************************************************************************************
+    * @description Get the setting for Prevent Time Block Deletion
+    */
+    private static Boolean enabledPreventTimeBlockDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Time_Block_Deletion__c;
+    
+    /*******************************************************************************************************
+    * @description Stops a Time Block from being deleted if it has any Course Offering or 
+    * Course Offering Schedule child records. 
+    * @param newlist the list of Tests from trigger new. 
+    * @param oldlist the list of Tests from trigger old. 
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
+    * @param objResult the describe for Time Blocks. 
+    * @return DmlWrapper.  
+    ********************************************************************************************************/
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+        
+        if (TB_CannotDelete_TDTM.enabledPreventTimeBlockDeletion == FALSE) {
+            return new DmlWrapper(); 
+        }
+        
+        Map<Id, Time_Block__c> oldmap = new Map<Id, Time_Block__c>((List<Time_Block__c>)oldList);
+        
+        if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
+            for (Time_Block__c tb : [
+                                    SELECT Id, 
+                                        (SELECT Id FROM Time_Block__c.Time_Blocks__r LIMIT 1),
+                                        (SELECT Id FROM Time_Block__c.Course_Offering_Schedules__r LIMIT 1)
+                                    FROM Time_Block__c WHERE Id IN :oldlist
+                                    
+                                ]) {
+                
+                if (this.hasChildRecords(tb)) {
+                    Time_Block__c timeBlockInContext = oldMap.get(tb.ID);
+                    timeBlockInContext.addError(Label.CannotDelete);
+                }
+            }     
+        }
+
+        return new DmlWrapper();
+    }
+    
+    /*******************************************************************************************************
+     * @description Evaluates whether the Time Block has any child (Course Offering or 
+     * Course Offering Schedule) related records.
+     * @param tb is the current Time Block record.
+     * @return Boolean.
+     ********************************************************************************************************/
+    @testVisible
+    private Boolean hasChildRecords(Time_Block__c tb) {
+        
+        return ( tb.Time_Blocks__r.isEmpty() == FALSE || tb.Course_Offering_Schedules__r.isEmpty() == FALSE ); 
+    
     }
 }

--- a/src/classes/TB_CannotDelete_TDTM.cls
+++ b/src/classes/TB_CannotDelete_TDTM.cls
@@ -1,0 +1,5 @@
+public with sharing class TB_CannotDelete_TDTM {
+    public TB_CannotDelete_TDTM() {
+
+    }
+}

--- a/src/classes/TB_CannotDelete_TDTM.cls-meta.xml
+++ b/src/classes/TB_CannotDelete_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TB_CannotDelete_TEST.cls
+++ b/src/classes/TB_CannotDelete_TEST.cls
@@ -488,6 +488,46 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasCourseOfferingChildRecordsIsTrue() {
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id, 
+                (SELECT Id FROM Time_Block__c.Time_Blocks__r)
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        TB_CannotDelete_TDTM tbCannotDeleteClass = new TB_CannotDelete_TDTM();
+
+        for (Time_Block__c tb : returnTimeBlocks) {
+            System.assertEquals(TRUE, tbCannotDeleteClass.hasChildRecords(tb));
+        }
     }
 
     /*********************************************************************************************************
@@ -496,6 +536,53 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasCourseOfferingScheduleChildRecordsIsTrue() {
+        
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id, 
+                (SELECT Id FROM Time_Block__c.Course_Offering_Schedules__r)
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        TB_CannotDelete_TDTM tbCannotDeleteClass = new TB_CannotDelete_TDTM();
+
+        for (Time_Block__c tb : returnTimeBlocks) {
+            System.assertEquals(TRUE, tbCannotDeleteClass.hasChildRecords(tb));
+        }
     }
 
     /*********************************************************************************************************
@@ -504,6 +591,58 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasCourseOfferingAndScheduleChildRecordsIsTrue() {
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id, 
+                (SELECT Id FROM Time_Block__c.Time_Blocks__r),
+                (SELECT Id FROM Time_Block__c.Course_Offering_Schedules__r)
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        TB_CannotDelete_TDTM tbCannotDeleteClass = new TB_CannotDelete_TDTM();
+
+        for (Time_Block__c tb : returnTimeBlocks) {
+            System.assertEquals(TRUE, tbCannotDeleteClass.hasChildRecords(tb));
+        }
     }
 
     /*********************************************************************************************************
@@ -512,6 +651,32 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasChildRecordsIsFalse() {
-    }
 
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id, 
+                (SELECT Id FROM Time_Block__c.Time_Blocks__r),
+                (SELECT Id FROM Time_Block__c.Course_Offering_Schedules__r)
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        TB_CannotDelete_TDTM tbCannotDeleteClass = new TB_CannotDelete_TDTM();
+
+        for (Time_Block__c tb : returnTimeBlocks) {
+            System.assertEquals(FALSE, tbCannotDeleteClass.hasChildRecords(tb));
+        }
+    }
 }

--- a/src/classes/TB_CannotDelete_TEST.cls
+++ b/src/classes/TB_CannotDelete_TEST.cls
@@ -1,0 +1,5 @@
+public with sharing class TB_CannotDelete_TEST {
+    public TB_CannotDelete_TEST() {
+
+    }
+}

--- a/src/classes/TB_CannotDelete_TEST.cls
+++ b/src/classes/TB_CannotDelete_TEST.cls
@@ -40,12 +40,64 @@
 private class TB_CannotDelete_TEST {
 
     /*********************************************************************************************************
+    * @description Retrieves the record type Ids for Household and Administrator Accounts. 
+    */
+    public static String deptAccRecordTypeID = UTIL_Describe.getDepAccRecTypeID(); 
+
+    /*********************************************************************************************************
     * @description Test method to test that when Prevent_Time_Block_Deletion__c is enabled in Hierarchy 
     * Settings and Time Block has a child Course Offering record associated with it, the Time Block 
     * record cannot be deleted.
     */
     @isTest 
     private static void cannotDeleteWithChildCourseOfferingPreventDeleteOn() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = TRUE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(timeBlocks.size(), returnTimeBlocks.size());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(Label.CannotDelete, result.errors[0].message);
+        }
     }
 
     /*********************************************************************************************************
@@ -55,6 +107,59 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void cannotDeleteWithChildCourseOfferingSchedulePreventDeleteOn() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = TRUE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(timeBlocks.size(), returnTimeBlocks.size());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(Label.CannotDelete, result.errors[0].message);
+        }
     }
 
     /*********************************************************************************************************
@@ -64,6 +169,64 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void cannotDeleteWithChildCourseOfferingAndScheduleRecordsPreventDeleteOn() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = TRUE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(timeBlocks.size(), returnTimeBlocks.size());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(Label.CannotDelete, result.errors[0].message);
+        }
     }
 
     /*********************************************************************************************************
@@ -72,6 +235,33 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithoutChildRecordsPreventDeleteOn() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = TRUE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(TRUE, returnTimeBlocks.isEmpty());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.isSuccess());
+        }
     }
 
     /*********************************************************************************************************
@@ -81,6 +271,53 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithChildCourseOfferingPreventDeleteOff() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = FALSE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(TRUE, returnTimeBlocks.isEmpty());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.isSuccess());
+        }
     }
 
     /*********************************************************************************************************
@@ -90,6 +327,58 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithChildCourseOfferingSchedulePreventDeleteOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = FALSE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(TRUE, returnTimeBlocks.isEmpty());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.isSuccess());
+        }
     }
 
     /*********************************************************************************************************
@@ -99,6 +388,63 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithChildCourseOfferingAndSchedulePreventDeleteOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = FALSE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        List<Account> departmentAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, TB_CannotDelete_TEST.deptAccRecordTypeID);
+        insert departmentAccounts;
+
+        Term__c testTerm = UTIL_UnitTestData_TEST.getTerm(departmentAccounts[0].Id, 'Test Term');
+        insert testTerm;
+
+        Course__c testCourse = new Course__c(Name = 'Test Course', Account__c = departmentAccounts[0].Id);
+        insert testCourse;
+
+        List<Course_Offering__c> courseOfferings = new List<Course_Offering__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings.add(UTIL_UnitTestData_TEST.createCourseOffering(testCourse.Id, testTerm.Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferings[index].Time_Block__c = timeBlocks[index].Id;
+        }
+        update courseOfferings;
+
+        List<Course_Offering_Schedule__c> courseOfferingSchedules = new List<Course_Offering_Schedule__c>();
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules.add(UTIL_UnitTestData_TEST.createCourseOfferingSchedule(courseOfferings[index].Id));
+        }
+
+        for (Integer index = 0; index < 5; index++){
+            courseOfferingSchedules[index].Time_Block__c = timeBlocks[index].Id;
+        }
+
+        insert courseOfferingSchedules;
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(TRUE, returnTimeBlocks.isEmpty());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.isSuccess());
+        }
     }
 
     /*********************************************************************************************************
@@ -107,6 +453,33 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithoutChildRecordsPreventDeleteOff() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Prevent_Time_Block_Deletion__c = FALSE));
+
+        Time startTime = Time.newInstance(8, 0, 0, 0);
+        Time stopTime = Time.newInstance(10, 0, 0, 0);
+
+        List<Time_Block__c> timeBlocks = new List<Time_Block__c>();
+
+        for (Integer index = 0; index < 5; index++){
+            timeBlocks.add(UTIL_UnitTestData_TEST.createTimeBlock(startTime, stopTime));
+        }
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(timeBlocks, FALSE);
+        Test.stopTest();
+
+        List<Time_Block__c> returnTimeBlocks = [
+            SELECT Id
+            FROM Time_Block__c
+            WHERE Id IN :timeBlocks
+        ];
+
+        System.assertEquals(TRUE, returnTimeBlocks.isEmpty());
+        
+        for (Database.DeleteResult result : results) {
+            System.assertEquals(TRUE, result.isSuccess());
+        }
     }
 
     /*********************************************************************************************************

--- a/src/classes/TB_CannotDelete_TEST.cls
+++ b/src/classes/TB_CannotDelete_TEST.cls
@@ -35,7 +35,6 @@
 * @description Tests for TB_CannotDelete_TDTM.
 */
 
-
 @isTest
 private class TB_CannotDelete_TEST {
 
@@ -235,6 +234,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithoutChildRecordsPreventDeleteOn() {
+        
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Time_Block_Deletion__c = TRUE));
 
@@ -327,6 +327,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithChildCourseOfferingSchedulePreventDeleteOff() {
+        
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Time_Block_Deletion__c = FALSE));
 
@@ -388,6 +389,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithChildCourseOfferingAndSchedulePreventDeleteOff() {
+        
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Time_Block_Deletion__c = FALSE));
 
@@ -453,6 +455,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void canDeleteWithoutChildRecordsPreventDeleteOff() {
+        
         UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
                                                             (Prevent_Time_Block_Deletion__c = FALSE));
 
@@ -488,6 +491,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasCourseOfferingChildRecordsIsTrue() {
+        
         Time startTime = Time.newInstance(8, 0, 0, 0);
         Time stopTime = Time.newInstance(10, 0, 0, 0);
 
@@ -591,6 +595,7 @@ private class TB_CannotDelete_TEST {
     */
     @isTest 
     private static void hasCourseOfferingAndScheduleChildRecordsIsTrue() {
+        
         Time startTime = Time.newInstance(8, 0, 0, 0);
         Time stopTime = Time.newInstance(10, 0, 0, 0);
 

--- a/src/classes/TB_CannotDelete_TEST.cls
+++ b/src/classes/TB_CannotDelete_TEST.cls
@@ -1,5 +1,144 @@
-public with sharing class TB_CannotDelete_TEST {
-    public TB_CannotDelete_TEST() {
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER s
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Time Blocks
+* @group-content ../../ApexDocContent/TimeBlocks.htm
+* @description Tests for TB_CannotDelete_TDTM.
+*/
 
+
+@isTest
+private class TB_CannotDelete_TEST {
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is enabled in Hierarchy 
+    * Settings and Time Block has a child Course Offering record associated with it, the Time Block 
+    * record cannot be deleted.
+    */
+    @isTest 
+    private static void cannotDeleteWithChildCourseOfferingPreventDeleteOn() {
     }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is enabled in Hierarchy 
+    * Settings and Time Block has a child Course Offering Schedule record associated with it, the Time Block 
+    * record cannot be deleted.
+    */
+    @isTest 
+    private static void cannotDeleteWithChildCourseOfferingSchedulePreventDeleteOn() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is enabled in Hierarchy 
+    * Settings and Time Block has both Course Offering and Course Offering Schedule child records associated 
+    * with it, the Time Block record cannot be deleted.
+    */
+    @isTest 
+    private static void cannotDeleteWithChildCourseOfferingAndScheduleRecordsPreventDeleteOn() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is enabled in Hierarchy 
+    * Settings and Time Block has no associated child records, the Time Block record can be deleted.
+    */
+    @isTest 
+    private static void canDeleteWithoutChildRecordsPreventDeleteOn() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is disabled in Hierarchy 
+    * Settings and Time Block has a child Course Offering record associated with it, the Time Block 
+    * record can be deleted.
+    */
+    @isTest 
+    private static void canDeleteWithChildCourseOfferingPreventDeleteOff() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is disabled in Hierarchy 
+    * Settings and Time Block has a child Course Offering Schedule record associated with it, the Time Block 
+    * record can be deleted.
+    */
+    @isTest 
+    private static void canDeleteWithChildCourseOfferingSchedulePreventDeleteOff() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is disabled in Hierarchy 
+    * Settings and Time Block has both Course Offering and Course Offering Schedule child records associated 
+    * with it, the Time Block record can be deleted.
+    */
+    @isTest 
+    private static void canDeleteWithChildCourseOfferingAndSchedulePreventDeleteOff() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test that when Prevent_Time_Block_Deletion__c is disabled in Hierarchy 
+    * Settings and Time Block has no associated child records, the Time Block record can be deleted.
+    */
+    @isTest 
+    private static void canDeleteWithoutChildRecordsPreventDeleteOff() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TB_CannotDelete_TDTM to test that TRUE
+    * is returned for a Time Block record with Course Offering child records.
+    */
+    @isTest 
+    private static void hasCourseOfferingChildRecordsIsTrue() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TB_CannotDelete_TDTM to test that TRUE
+    * is returned for a Time Block record with Course Offering Schedule child records.
+    */
+    @isTest 
+    private static void hasCourseOfferingScheduleChildRecordsIsTrue() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TB_CannotDelete_TDTM to test that TRUE
+    * is returned for a Time Block record with both Course Offering and Course Offering Schedule child records.
+    */
+    @isTest 
+    private static void hasCourseOfferingAndScheduleChildRecordsIsTrue() {
+    }
+
+    /*********************************************************************************************************
+    * @description Test method for the hasChildRecords() method in TB_CannotDelete_TDTM to test that FALSE
+    * is returned for a Time Block record no associated child records.
+    */
+    @isTest 
+    private static void hasChildRecordsIsFalse() {
+    }
+
 }

--- a/src/classes/TB_CannotDelete_TEST.cls-meta.xml
+++ b/src/classes/TB_CannotDelete_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TB_StartEndTime_TDTM.cls
+++ b/src/classes/TB_StartEndTime_TDTM.cls
@@ -27,8 +27,8 @@
 /**
 * @author Salesforce.org
 * @date 2019
-* @group Course Offering
-* @group-content ../../ApexDocContent/CourseOfferings.htm
+* @group Time Blocks
+* @group-content ../../ApexDocContent/TimeBlocks.htm
 * @description Updates associated Course Offering Schedules' Start Time and End Time fields when the Start Time
 * and/or End Time fields are updated on the Time Block.
 */

--- a/src/classes/TB_StartEndTime_TEST.cls
+++ b/src/classes/TB_StartEndTime_TEST.cls
@@ -27,8 +27,8 @@
 /**
 * @author Salesforce.org
 * @date 2019
-* @group Course Offering
-* @group-content ../../ApexDocContent/CourseOfferings.htm
+* @group Time Blocks
+* @group-content ../../ApexDocContent/TimeBlocks.htm
 * @description Tests specific to testing the TB_StartEndTime_TDTM logic around updating the Start Time 
 * and End Time on associated Course Offering Schedule records when the Time Block Start Time and/or
 * End Time is updated.

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -249,7 +249,11 @@ public without sharing class TDTM_DefaultConfig {
                 Class__c = 'BEH_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Behavior_Involvement__c',
                 Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
 
+        // Prevents deletion of Time Block when the records have associated child records
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+                Class__c = 'TB_CannotDelete_TDTM', Load_Order__c = 1, Object__c = 'Time_Block__c',
+                Owned_by_Namespace__c = 'hed', Trigger_Action__c = 'BeforeDelete'));
+
         return handlers;
-        
     }
 }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -165,11 +165,8 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Course_Offering_Deletion__c = mySettings.Prevent_Course_Offering_Deletion__c;
         settings.Prevent_Facility_Deletion__c = mySettings.Prevent_Facility_Deletion__c;
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
-<<<<<<< HEAD
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
         settings.Prevent_Time_Block_Deletion__c = mySettings.Prevent_Time_Block_Deletion__c;
-=======
->>>>>>> master
         settings.Prevent_Program_Enrollment_Deletion__c = mySettings.Prevent_Program_Enrollment_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
         settings.Prevent_Term_Deletion__c = mySettings.Prevent_Term_Deletion__c;

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -169,6 +169,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         settings.Prevent_Account_Deletion__c = mySettings.Prevent_Account_Deletion__c;
         settings.Prevent_Plan_Requirement_Deletion__c = mySettings.Prevent_Plan_Requirement_Deletion__c;
         settings.Prevent_Program_Plan_Deletion__c = mySettings.Prevent_Program_Plan_Deletion__c;
+        settings.Prevent_Time_Block_Deletion__c = mySettings.Prevent_Time_Block_Deletion__c;
         orgSettings = settings;
         return settings;
     }

--- a/src/objects/Hierarchy_Settings__c.object
+++ b/src/objects/Hierarchy_Settings__c.object
@@ -437,6 +437,15 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Prevent_Time_Block_Deletion__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Reserved for future use.</description>
+        <externalId>false</externalId>
+        <label>Prevent Time Block Deletion</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Reciprocal_Method__c</fullName>
         <description>Determines method used to generate the reciprocal relationship.  Either List Setting which uses custom settings by gender, or Value Inversion, which inverts the type if appropriate (&quot;Parent-Child&quot; to &quot;Child-Parent&quot;)</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -465,13 +465,13 @@
         <members>Hierarchy_Settings__c.Prevent_Plan_Requirement_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Program_Plan_Deletion__c</members>
         <members>Hierarchy_Settings__c.Prevent_Term_Deletion__c</members>
+        <members>Hierarchy_Settings__c.Prevent_Time_Block_Deletion__c</members>
         <members>Hierarchy_Settings__c.Reciprocal_Method__c</members>
         <members>Hierarchy_Settings__c.Relationship_Name_Field_Id__c</members>
         <members>Hierarchy_Settings__c.Relationship_Name_Id_Field_Id__c</members>
         <members>Hierarchy_Settings__c.Simple_Address_Change_Treated_as_Update__c</members>
         <members>Hierarchy_Settings__c.Store_Errors_On__c</members>
         <members>Hierarchy_Settings__c.Student_RecType__c</members>
-        <members>Hierarchy_Settings__c.Prevent_Time_Block_Deletion__c</members>
         <members>Hierarchy_Settings__c.Validate_Program_Plan_for_Nested_PR__c</members>
         <members>Plan_Requirement__c.Category__c</members>
         <members>Plan_Requirement__c.Course__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -115,6 +115,8 @@
         <members>STG_Courses_TEST</members>
         <members>STG_InstallScript</members>
         <members>STG_InstallScript_TEST</members>
+        <members>TB_CannotDelete_TDTM</members>
+        <members>TB_CannotDelete_TEST</members>
         <members>TB_StartEndTime_TDTM</members>
         <members>TB_StartEndTime_TEST</members>
         <members>TDTM_Config</members>
@@ -469,6 +471,7 @@
         <members>Hierarchy_Settings__c.Simple_Address_Change_Treated_as_Update__c</members>
         <members>Hierarchy_Settings__c.Store_Errors_On__c</members>
         <members>Hierarchy_Settings__c.Student_RecType__c</members>
+        <members>Hierarchy_Settings__c.Prevent_Time_Block_Deletion__c</members>
         <members>Hierarchy_Settings__c.Validate_Program_Plan_for_Nested_PR__c</members>
         <members>Plan_Requirement__c.Category__c</members>
         <members>Plan_Requirement__c.Course__c</members>


### PR DESCRIPTION
# Critical Changes

# Changes
### Updates to Ensure Data Integrity
We've added functionality to prevent the deletion of Time Block records with related Course Offering or Course Offering Schedule records.

These changes are for internal-use only and are disabled at this time. You won't see any difference in functionality.

**Note:** We strongly recommend that EDA Admins don't manage Hierarchy Custom Settings directly and, instead, use the EDA Settings UI, which will be provided in an upcoming release. However, if you do enable any of these settings, note the following:

- If you have disabled the related TB_CannotDelete_TDTM classes for the object, the settings will remain disabled even though you've enabled them in Hierarchy Custom Settings.

- If you enable any of these settings, be sure to disable them before merging records or deleting duplicate records.

# Issues Closed
Closes Issue #1174 

# New Metadata
Checkbox Field on Hierarchy Settings:

- Prevent_Time_Block_Deletion__c

Apex Classes:

- TB_CannotDelete_TDTM

- TB_CannotDelete_TEST

# Deleted Metadata

# Testing Notes
https://salesforce.quip.com/tocpA7KiYHWk#HNYACA6cKr0