### PR TITLE
[Robot] Validate the dropdown fields are disabled by default in edit mode 

### DIFF
--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -402,6 +402,7 @@ class EDA(BaseEDAPage):
         """
         for field,expected_value in kwargs.items():
             locator = eda_lex_locators["eda_settings_cc"]["dropdown_field"].format(field)
+            self.selenium.page_should_contain_element(locator)
             self.selenium.wait_until_element_is_visible(locator,
                                                 error= "Element is not displayed for the user")
             actual_value = self.selenium.get_webelement(locator).get_attribute("disabled")

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -408,4 +408,4 @@ class EDA(BaseEDAPage):
             actual_value = self.selenium.get_webelement(locator).get_attribute(expected_value)
             expected_value = bool(expected_value == "disabled")
             if not str(expected_value).lower() == str(actual_value).lower() :
-                raise Exception (f"Drop down field '{field}' status is '{actual_value}'")
+                raise Exception (f"Drop down field {field} status is {actual_value} instead of {expected_value}")

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -397,14 +397,15 @@ class EDA(BaseEDAPage):
 
     def verify_dropdown_field_status(self, **kwargs):
         """ Verify the drop down field is disabled/enabled for the user
-            we have to pass the name of the field and the status of the field 
-            True = disabled and False = enabled
+            we have to pass the name of the field and the expected status
+            of the field as either enabled or disabled
         """
         for field,expected_value in kwargs.items():
             locator = eda_lex_locators["eda_settings"]["dropdown_field"].format(field)
             self.selenium.page_should_contain_element(locator)
             self.selenium.wait_until_element_is_visible(locator,
                                                 error= f"Element '{field}' is not displayed for the user")
-            actual_value = self.selenium.get_webelement(locator).get_attribute("disabled")
+            actual_value = self.selenium.get_webelement(locator).get_attribute(expected_value)
+            expected_value = bool(expected_value == "disabled")
             if not str(expected_value).lower() == str(actual_value).lower() :
                 raise Exception (f"Drop down field '{field}' status is '{actual_value}'")

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -394,3 +394,16 @@ class EDA(BaseEDAPage):
             actual_value = self.selenium.get_webelement(locator).text
             if not str(value).lower() == str(actual_value).lower() :
                 raise Exception (f"Drop down value in '{field}' is not updated and the value is '{actual_value}'")
+
+    def verify_dropdown_field_status(self, **kwargs):
+        """ Verify the drop down field is disabled/enabled for the user
+            we have to pass the name of the field and the status of the field 
+            True = disabled and False = enabled
+        """
+        for field,expected_value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_cc"]["dropdown_field"].format(field)
+            self.selenium.wait_until_element_is_visible(locator,
+                                                error= "Element is not displayed for the user")
+            actual_value = self.selenium.get_webelement(locator).get_attribute("disabled")
+            if not str(expected_value).lower() == str(actual_value).lower() :
+                raise Exception (f"Drop down field '{field}' status is '{actual_value}'")

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -401,10 +401,10 @@ class EDA(BaseEDAPage):
             True = disabled and False = enabled
         """
         for field,expected_value in kwargs.items():
-            locator = eda_lex_locators["eda_settings_cc"]["dropdown_field"].format(field)
+            locator = eda_lex_locators["eda_settings"]["dropdown_field"].format(field)
             self.selenium.page_should_contain_element(locator)
             self.selenium.wait_until_element_is_visible(locator,
-                                                error= "Element is not displayed for the user")
+                                                error= f"Element '{field}' is not displayed for the user")
             actual_value = self.selenium.get_webelement(locator).get_attribute("disabled")
             if not str(expected_value).lower() == str(actual_value).lower() :
                 raise Exception (f"Drop down field '{field}' status is '{actual_value}'")

--- a/robot/EDA/resources/locators_49.py
+++ b/robot/EDA/resources/locators_49.py
@@ -102,6 +102,7 @@ eda_lex_locators = {
     },
      "eda_settings_cc": {
         "default_cc_checkbox": "//div[text()='Enable Course Connections']/following-sibling::div/descendant::img",
+        "dropdown_field": "//div[text()='{}']/following-sibling::div/select",
         "dropdown_values": "//div[text()='{}']/following-sibling::div/select/option[text()='{}']",
         "dropdown_values_count": "//div[text()='{}']/following-sibling::div/select/option",
         "enable_cc_checkbox": "//div[text()='Enable Course Connections']/following-sibling::div[1]/descendant::span",

--- a/robot/EDA/resources/locators_49.py
+++ b/robot/EDA/resources/locators_49.py
@@ -99,10 +99,10 @@ eda_lex_locators = {
         "affl_mappings_tab": "//a[contains(text(),'Affiliation Mappings')]",
         "default_checkbox": "//div[text()='{}']/following-sibling::div/descendant::img",
         "enable_checkbox": "(//div[text()='{}']/following-sibling::div/descendant::span)[1]",
+        "dropdown_field": "//div[text()='{}']/following-sibling::div/select",
     },
      "eda_settings_cc": {
         "default_cc_checkbox": "//div[text()='Enable Course Connections']/following-sibling::div/descendant::img",
-        "dropdown_field": "//div[text()='{}']/following-sibling::div/select",
         "dropdown_values": "//div[text()='{}']/following-sibling::div/select/option[text()='{}']",
         "dropdown_values_count": "//div[text()='{}']/following-sibling::div/select/option",
         "enable_cc_checkbox": "//div[text()='Enable Course Connections']/following-sibling::div[1]/descendant::span",

--- a/robot/EDA/tests/browser/settings/course_connections.robot
+++ b/robot/EDA/tests/browser/settings/course_connections.robot
@@ -44,3 +44,15 @@ Validate Edit Mode For Course Connections, Settings
     Verify selected dropdown value
     ...                                         Default Active Student Record Type=Student
     ...                                         Default Faculty Record Type=Faculty
+
+Validate drop down values appear when checkbox is unchecked
+    [Documentation]         Checks for the warning message when the Enable Course Connections is unchecked.
+    ...                     Checks the dropdown field is disabled for Default Active Student Record Type
+    ...                     and Default Faculty Record Type. The value of the dropdown field status is True
+    ...                     when disbaled and False when enabled.
+    [tags]                                      unstable        W-041782
+    Click action button on EDA settings page    Edit
+    Verify enable course connections warning    true
+    Verify dropdown field status           
+    ...                                         Default Active Student Record Type=true
+    ...                                         Default Faculty Record Type=true   

--- a/robot/EDA/tests/browser/settings/course_connections.robot
+++ b/robot/EDA/tests/browser/settings/course_connections.robot
@@ -21,8 +21,8 @@ Validate drop down values appear when checkbox is unchecked
     Click action button on EDA settings page    Edit
     Verify enable course connections warning    true
     Verify dropdown field status           
-    ...                                         Default Active Student Record Type=true
-    ...                                         Default Faculty Record Type=true 
+    ...                                         Default Active Student Record Type=disabled
+    ...                                         Default Faculty Record Type=disabled 
 
 Validate Edit Mode For Course Connections, Settings
     [Documentation]         Check for the warning message when the Enable Course Connections is unchecked

--- a/robot/EDA/tests/browser/settings/course_connections.robot
+++ b/robot/EDA/tests/browser/settings/course_connections.robot
@@ -12,6 +12,18 @@ Test Setup      Run keywords
 ...             Update enable cc to default
 
 *** Test Cases ***
+Validate drop down values appear when checkbox is unchecked
+    [Documentation]         Checks for the warning message when the Enable Course Connections is unchecked.
+    ...                     Checks the dropdown field is disabled for Default Active Student Record Type
+    ...                     and Default Faculty Record Type. The value of the dropdown field status is True
+    ...                     when disbaled and False when enabled.
+    [tags]                                      unstable        W-041782
+    Click action button on EDA settings page    Edit
+    Verify enable course connections warning    true
+    Verify dropdown field status           
+    ...                                         Default Active Student Record Type=true
+    ...                                         Default Faculty Record Type=true 
+
 Validate Edit Mode For Course Connections, Settings
     [Documentation]         Check for the warning message when the Enable Course Connections is unchecked
     ...                     Check the warning message disappears when the Enable Course Connections is checked
@@ -44,15 +56,3 @@ Validate Edit Mode For Course Connections, Settings
     Verify selected dropdown value
     ...                                         Default Active Student Record Type=Student
     ...                                         Default Faculty Record Type=Faculty
-
-Validate drop down values appear when checkbox is unchecked
-    [Documentation]         Checks for the warning message when the Enable Course Connections is unchecked.
-    ...                     Checks the dropdown field is disabled for Default Active Student Record Type
-    ...                     and Default Faculty Record Type. The value of the dropdown field status is True
-    ...                     when disbaled and False when enabled.
-    [tags]                                      unstable        W-041782
-    Click action button on EDA settings page    Edit
-    Verify enable course connections warning    true
-    Verify dropdown field status           
-    ...                                         Default Active Student Record Type=true
-    ...                                         Default Faculty Record Type=true   


### PR DESCRIPTION
Validate the drop down fields (Default Active Student Record Type, Default Faculty Record Type) are disabled when the course connections, settings tab is in edit mode.

Robot WI: W-041782

To run the test case, run this from your CCI:
cci task run robot -o suites robot/EDA/tests/browser/settings/course_connections.robot

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
