### PR TITLE
Feature/vbeck/stringupdates

### DIFF
--- a/src/objects/Address__c.object
+++ b/src/objects/Address__c.object
@@ -115,8 +115,8 @@
     <fields>
         <fullName>Formula_MailingAddress__c</fullName>
         <externalId>false</externalId>
-        <description>The full mailing address, including mailing street 2 and country values, if not blank (read-only).</description>
-         <inlineHelpText>The full mailing address, including mailing street 2 and country values, if not blank (read-only).</inlineHelpText>
+        <description>The full mailing address, including Mailing Street 2 and Mailing Country values, if not blank (read-only).</description>
+         <inlineHelpText>The full mailing address, including Mailing Street 2 and Mailing Country values, if not blank (read-only).</inlineHelpText>
         <formula>MailingStreet__c &amp;
 BR() &amp; 
 IF(ISBLANK(MailingStreet2__c), &quot;&quot;, MailingStreet2__c &amp; BR()) &amp; 

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -4854,7 +4854,7 @@
     <fields>
         <fullName>Social_Security_Number__c</fullName>
         <externalId>false</externalId>
-        <description>Social Security Number. Encrypted for confidentiality. Only users with the View Encrypted Data permission  can see the unencrypted value.</description>
+        <description>Social Security Number. Encrypted for confidentiality. Only users with the View Encrypted Data permission can see the unencrypted value.</description>
         <label>Social Security Number</label>
         <length>12</length>
         <maskChar>X</maskChar>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -4854,6 +4854,7 @@
     <fields>
         <fullName>Social_Security_Number__c</fullName>
         <externalId>false</externalId>
+        <description>Social Security Number. Encrypted for confidentiality. Only users with the View Encrypted Data permission  can see the unencrypted value.</description>
         <label>Social Security Number</label>
         <length>12</length>
         <maskChar>X</maskChar>

--- a/src/objects/Course_Offering__c.object
+++ b/src/objects/Course_Offering__c.object
@@ -52,7 +52,7 @@
         <label>HEDA Course Offering Compact Layout</label>
     </compactLayouts>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Joins Courses and Terms to contain information related to a single occurrence of a course.</description>
+    <description>Joins Courses and Terms to contain information related to a single occurrence of a Course.</description>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>

--- a/src/objects/Course__c.object
+++ b/src/objects/Course__c.object
@@ -68,6 +68,7 @@
         <fullName>Account__c</fullName>
         <externalId>false</externalId>
         <inlineHelpText>The department (Account record) that offers this Course.</inlineHelpText>
+        <description>The department (Account record) that offers this Course.</description>
         <label>Department</label>
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Courses</relationshipLabel>
@@ -82,6 +83,7 @@
         <fullName>Course_ID__c</fullName>
         <externalId>false</externalId>
         <inlineHelpText>The Course alphanumeric ID., for example, English 101.</inlineHelpText>
+        <description>The Course alphanumeric ID., for example, English 101.</description>
         <label>Course ID</label>
         <length>255</length>
         <required>false</required>
@@ -104,6 +106,7 @@
         <fullName>Description__c</fullName>
         <externalId>false</externalId>
         <inlineHelpText>This field has been replaced by the Extended Description field, which accomodates longer descriptions. Your admin can migrate text from the Description to the Extended Description field in EDA Settings | Courses.</inlineHelpText>
+        <description>This field has been replaced by the Extended Description field, which accomodates longer descriptions. Your admin can migrate text from the Description to the Extended Description field in EDA Settings | Courses.</description>
         <label>Description</label>
         <required>false</required>
         <trackTrending>false</trackTrending>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -156,9 +156,9 @@
     </fields>
     <fields>
         <fullName>Version__c</fullName>
-        <description>Helps identify this version of the Program Plan, for example, "Spring 2020."</description>
+        <description>Helps identify this version of the Program Plan, for example, &quot;Spring 2020.&quot;</description>
         <externalId>false</externalId>
-        <inlineHelpText>Helps identify this version of the Program Plan, for example, "Spring 2020."</inlineHelpText>
+        <inlineHelpText>Helps identify this version of the Program Plan, for example, &quot;Spring 2020.&quot;</inlineHelpText>
         <label>Version</label>
         <length>25</length>
         <required>false</required>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -156,9 +156,9 @@
     </fields>
     <fields>
         <fullName>Version__c</fullName>
-        <description>Helps identify which version of the Program Plan this is for this Academic Program, for example, "Spring 2020."</description>
+        <description>Helps identify this version of the Program Plan, for example, "Spring 2020."</description>
         <externalId>false</externalId>
-        <inlineHelpText>Helps identify which version of the Program Plan this is for this Academic Program, for example, "Spring 2020."</inlineHelpText>
+        <inlineHelpText>Helps identify this version of the Program Plan, for example, "Spring 2020."</inlineHelpText>
         <label>Version</label>
         <length>25</length>
         <required>false</required>

--- a/src/objects/Program_Plan__c.object
+++ b/src/objects/Program_Plan__c.object
@@ -156,9 +156,9 @@
     </fields>
     <fields>
         <fullName>Version__c</fullName>
-        <description>Helps identify this version of the Program Plan, for example, &quot;Spring 2020.&quot;</description>
+        <description>The version of the Program Plan, for example, Spring 2020.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Helps identify this version of the Program Plan, for example, &quot;Spring 2020.&quot;</inlineHelpText>
+        <inlineHelpText>The version of the Program Plan, for example, Spring 2020.</inlineHelpText>
         <label>Version</label>
         <length>25</length>
         <required>false</required>

--- a/src/objects/Term__c.object
+++ b/src/objects/Term__c.object
@@ -91,8 +91,8 @@
     </fields>
     <fields>
         <fullName>Grading_Period_Sequence__c</fullName>
-        <description>Indicates which Term this is. For example, enter "1"  for the first quarter or semester, "2" for the second quarter or semester, etc.</description>
-        <inlineHelpText>Indicates which Term this is. For example, enter "1"  for the first quarter or semester, "2" for the second quarter or semester, etc.</inlineHelpText>
+        <description>Indicates which Term this is. For example, enter &quot;1&quot; for the first quarter or semester, &quot;2&quot; for the second quarter or semester, etc.</description>
+        <inlineHelpText>Indicates which Term this is. For example, enter &quot;1&quot; for the first quarter or semester, &quot;2&quot; for the second quarter or semester, etc.</inlineHelpText>
         <externalId>false</externalId>
         <label>Grading Period Sequence</label>
         <precision>18</precision>

--- a/unpackaged/post/facility_display_name/objects/___NAMESPACE___Facility__c.object
+++ b/unpackaged/post/facility_display_name/objects/___NAMESPACE___Facility__c.object
@@ -2,7 +2,7 @@
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
         <fullName>Display_Name__c</fullName>
-        <description>The full name of the Facility. For example, &quot;Thomas Edison Building - Room 201.&quot;</description>
+        <description>A name that combines Parent Name (Thurgood Marshall Tower) and Facility Name (Room 400), for example, Thurgood Marshall Tower - Room 400. If no Parent Facility, Account value is used. If also no Account, Facility Name and Display Name are the same.</description>
         <externalId>false</externalId>
         <formula>IF(
     NOT(ISBLANK(%%%NAMESPACE%%%Parent_Facility__c)), %%%NAMESPACE%%%Parent_Facility__r.Name + &apos; - &apos; + Name,
@@ -12,7 +12,7 @@
     )
 )</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
-        <inlineHelpText>The full name of the Facility. For example, &quot;Thomas Edison Building - Room 201.&quot;</inlineHelpText>
+        <inlineHelpText>A name that combines Parent Name (Thurgood Marshall Tower) and Facility Name (Room 400), for example, Thurgood Marshall Tower - Room 400. If no Parent Facility, Account value is used. If also no Account, Facility Name and Display Name are the same.</inlineHelpText>
         <label>Display Name</label>
         <required>false</required>
         <trackTrending>false</trackTrending>


### PR DESCRIPTION
# Critical Changes

# Changes
## Updated UI Text Strings
We've made the following changes to EDA's UI text strings:
- Descriptions added to Social Security Number on Contact and to Department, Course ID, and Description on Course.
- Corrected casing of "Course" in the object description for Course Offering.
- Updated descriptions to Version on Program Plan, Grading Period Sequence on Term, and Display Name on Facility.

For information about the UI text string updates we announced in EDA 1.100 see [this post](https://github.com/SalesforceFoundation/EDA/releases/tag/rel%2F1.100).

_Note:_ If you've created packages that redeploy EDA object and field metadata with descriptions, update your existing descriptions to match the updated strings.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
