### PR TITLE
[Robot] Validate the warning message displayed in backfill course connections settings

### DIFF
--- a/robot/EDA/resources/CourseConnectionsSettingsPageObject.py
+++ b/robot/EDA/resources/CourseConnectionsSettingsPageObject.py
@@ -98,3 +98,50 @@ class CourseConnectionsSettingsPage(BaseEDAPage, BasePage):
         actual_value = self.selenium.get_element_attribute(locator_default, "alt")
         if not str(expectedCheckboxValue).lower() == str(actual_value).lower():
             raise Exception(f"Value of 'Enable course connections' is not '{expectedCheckboxValue}' as expected")
+
+    def select_course_connections_subtab(self, tabName):
+        """ This method will select the sub tabs available under course connections
+            The name of the sub tab to be selected is passed as an argument from the test
+        """
+        locator = eda_lex_locators["eda_settings_cc"]["cc_sub_tabs"].format(tabName)
+        self.selenium.page_should_contain_element(locator)
+        self.selenium.click_element(locator)
+
+    def verify_backfill_warning(self, is_displayed):
+        """ Verify the warning message is displayed
+            this message gets displayed when the 'Enable Course Connections' field is unchecked
+            and if the user selects backfill subtab
+        """
+        locator_enabled = eda_lex_locators["eda_settings_cc"]["backfill_warning_enabled"]
+        locator_disabled = eda_lex_locators["eda_settings_cc"]["backfill_warning_disabled"]
+        if str(is_displayed).lower() == "true":
+            self.selenium.wait_until_page_contains_element(locator_enabled,
+                                                           error="Backfill warning is not displayed")
+        else:
+            time.sleep(1)
+            self.selenium.wait_until_page_contains_element(
+                locator_disabled, error="Backfill warning is displayed")
+
+    def verify_button_status(self, **kwargs):
+        """ Verify the button is disabled/enabled for the user
+            we have to pass the name of the button and the expected status
+            of the button as either enabled or disabled
+        """
+        for button,expected_value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_cc"]["backfill_button_status"].format(button)
+            self.selenium.page_should_contain_element(locator)
+            self.selenium.wait_until_element_is_visible(locator,
+                                                error= f"Element '{button}' button is not displayed for the user")
+            actual_value = self.selenium.get_webelement(locator).get_attribute(expected_value)
+            expected_value = bool(expected_value == "disabled")
+            if not str(expected_value).lower() == str(actual_value).lower() :
+                raise Exception (f"Element {button} button status is {actual_value} instead of {expected_value}")
+
+    def verify_backfill_checkbox_value(self, expectedCheckboxValue):
+        """ This method will verify the 'I understand and am ready to run Backfill.' checkbox is set to the value passed in the arg """
+        locator = eda_lex_locators["eda_settings_cc"]["backfill_checkbox_status"]
+        time.sleep(1)
+        self.selenium.wait_until_element_is_visible(locator)
+        actual_value = self.selenium.get_element_attribute(locator, "data-qa-checkbox-state")
+        if not str(expectedCheckboxValue).lower() == str(actual_value).lower():
+            raise Exception(f"Value of 'I understand and am ready to run Backfill.' is not {expectedCheckboxValue} as expected")

--- a/robot/EDA/resources/locators_49.py
+++ b/robot/EDA/resources/locators_49.py
@@ -109,6 +109,11 @@ eda_lex_locators = {
         "enable_cc_warning_disabled": "//span[contains(@class, 'slds-hide')]/descendant::div[contains(@class, 'slds-notify') and @role='alert']/descendant::*[@data-key='warning']/../../following-sibling::span[text()='You must enable Course Connections before editing record types.']",
         "updated_dropdown_value": "//div[text()='{}']/following-sibling::div/descendant::span[text()='{}']",
         "settings_tab": "//div[contains(@class, 'CourseConnections')]/descendant::a[text()='Settings']",
+        "backfill_warning_enabled": "//div[contains(@class, 'slds-notify--alert')]/descendant::span[text()='You must enable Course Connections before running the Course Connections Backfill.']",
+        "backfill_warning_disabled": "//span[contains(@class, 'slds-hide')]/descendant::span[text()='You must enable Course Connections before running the Course Connections Backfill.']",
+        "cc_sub_tabs": "//div[contains(@class, 'CourseConnections')]/descendant::a[text()='{}']",
+        "backfill_button_status": "//span[text()='{}']/parent::button",
+        "backfill_checkbox_status": "//input[contains(@class, 'backfill')]/following-sibling::span[contains(@class, 'checkbox')]",
     },
     "account_types": {
         "administrative": "//span[contains(text(),'Administrative')]/parent::*",

--- a/robot/EDA/tests/browser/settings/course_connections_backfill.robot
+++ b/robot/EDA/tests/browser/settings/course_connections_backfill.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+...             robot/EDA/resources/CourseConnectionsSettingsPageObject.py
+
+Suite Setup     Open Test Browser
+Suite Teardown  Capture screenshot and delete records and close browser
+
+Test Setup      Run keywords
+...             Go to EDA settings tab          Course Connections      AND
+...             Update enable cc to default
+
+*** Test Cases ***
+Verify backfill settings error message when course connections is unchecked
+    [Documentation]         Checks enable course connection is disabled and then verifies the warning message 
+    ...                     banner is displayed in the backfill tab. Verifies the checkbox "I understand and
+    ...                     am ready to run backfill" is not checked. Checks the button "Run Backfill" is not
+    ...                     active.
+    [tags]                                      unstable        W-041785
+    Verify enable course connections            false
+    Select course connections subtab            Backfill
+    Verify backfill warning                     true
+    Verify backfill checkbox value              false
+    Verify button status
+    ...                                         Run Backfill=disabled

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -27,14 +27,3 @@ Verify standard field values
     ...                                         Error Notification Recipients=All Sys Admins
     ...                                         Administrative Account Name Format={!LastName} Administrative Account
     ...                                         Household Account Name Format={!LastName} Household
-
-# Verify values are retained after save
-#     [Documentation]         Checks for the default account model value as Administrative and checks store errors
-#     ...                     checkbox is checked and send error notification checkbox is unchecked and error
-#     ...                     notification recipient dropdown is set to All Sys Admins and checkboxes for disable
-#     ...                     error handling and automatic household naming are unchecked and administrative 
-#     ...                     account name format is set to {!LastName} Administrative and household account
-#     ...                     name format dropdown is set to {!LastName} Household.
-#     [tags]                                      unstable        W-041788
-#     Go to EDA settings tab                      System
-#     Click action button on EDA settings page    Edit

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+...             robot/EDA/resources/SystemSettingsPageObject.py
+
+Suite Setup     Open Test Browser
+Suite Teardown  Capture screenshot and delete records and close browser
+
+*** Test Cases ***
+Verify standard field values
+    [Documentation]         Checks for the default account model value as Administrative and checks store errors
+    ...                     checkbox is checked and send error notification checkbox is unchecked and error
+    ...                     notification recipient dropdown is set to All Sys Admins and checkboxes for disable
+    ...                     error handling and automatic household naming are unchecked and administrative 
+    ...                     account name format is set to {!LastName} Administrative and household account
+    ...                     name format dropdown is set to {!LastName} Household.
+    [tags]                                      unstable        W-041787
+    Go to EDA settings tab                      System
+    Verify default checkbox value
+    ...                                         Store Errors=true
+    ...                                         Send Error Notifications=false
+    ...                                         Disable Error Handling=false
+    ...                                         Automatically Rename Household Accounts=false                                         
+    Verify default dropdown value              
+    ...                                         Default Account Model=Administrative
+    ...                                         Error Notification Recipients=All Sys Admins
+    ...                                         Administrative Account Name Format={!LastName} Administrative Account
+    ...                                         Household Account Name Format={!LastName} Household
+
+Verify values are retained after save
+    [Documentation]         Checks for the default account model value as Administrative and checks store errors
+    ...                     checkbox is checked and send error notification checkbox is unchecked and error
+    ...                     notification recipient dropdown is set to All Sys Admins and checkboxes for disable
+    ...                     error handling and automatic household naming are unchecked and administrative 
+    ...                     account name format is set to {!LastName} Administrative and household account
+    ...                     name format dropdown is set to {!LastName} Household.
+    [tags]                                      unstable        W-041788
+    Go to EDA settings tab                      System
+    Click action button on EDA settings page    Edit

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -28,13 +28,13 @@ Verify standard field values
     ...                                         Administrative Account Name Format={!LastName} Administrative Account
     ...                                         Household Account Name Format={!LastName} Household
 
-Verify values are retained after save
-    [Documentation]         Checks for the default account model value as Administrative and checks store errors
-    ...                     checkbox is checked and send error notification checkbox is unchecked and error
-    ...                     notification recipient dropdown is set to All Sys Admins and checkboxes for disable
-    ...                     error handling and automatic household naming are unchecked and administrative 
-    ...                     account name format is set to {!LastName} Administrative and household account
-    ...                     name format dropdown is set to {!LastName} Household.
-    [tags]                                      unstable        W-041788
-    Go to EDA settings tab                      System
-    Click action button on EDA settings page    Edit
+# Verify values are retained after save
+#     [Documentation]         Checks for the default account model value as Administrative and checks store errors
+#     ...                     checkbox is checked and send error notification checkbox is unchecked and error
+#     ...                     notification recipient dropdown is set to All Sys Admins and checkboxes for disable
+#     ...                     error handling and automatic household naming are unchecked and administrative 
+#     ...                     account name format is set to {!LastName} Administrative and household account
+#     ...                     name format dropdown is set to {!LastName} Household.
+#     [tags]                                      unstable        W-041788
+#     Go to EDA settings tab                      System
+#     Click action button on EDA settings page    Edit


### PR DESCRIPTION
Validate the warning message, back fill checkbox status and run back fill button status when enable course connection is unchecked.

Robot WI: W-041785

New/Existing Test - This is a new test

To run the test case, run this from your CCI:
cci task run robot -o suites robot/EDA/tests/browser/settings/course_connections_backfill.robot -o vars BROWSER:headlesschrome


# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
