### PR TITLE
[EDA] - Summer '20, Add Lightning Component Controllers to Admin Profile

### DIFF
--- a/unpackaged/config/dev/profiles/Admin.profile
+++ b/unpackaged/config/dev/profiles/Admin.profile
@@ -166,4 +166,24 @@
         <tab>standard-Contact</tab>
         <visibility>DefaultOn</visibility>
     </tabVisibilities>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%CMP_SettingsDataProvider</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Base_CTRL</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_CourseConnections</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Courses</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%UTIL_Describe</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
 </Profile>

--- a/unpackaged/config/dev_delete/profiles/Admin.profile
+++ b/unpackaged/config/dev_delete/profiles/Admin.profile
@@ -74,4 +74,24 @@
     <layoutAssignments>
         <layout>Contact-Contact Layout</layout>
     </layoutAssignments>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%CMP_SettingsDataProvider</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Base_CTRL</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_CourseConnections</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Courses</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%UTIL_Describe</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
 </Profile>

--- a/unpackaged/config/qa/profiles/Admin.profile
+++ b/unpackaged/config/qa/profiles/Admin.profile
@@ -11,4 +11,24 @@
         <visibility>DefaultOn</visibility>
     </tabVisibilities>
     <userLicense>Salesforce</userLicense>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%CMP_SettingsDataProvider</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Base_CTRL</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_CourseConnections</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%STG_Courses</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>%%%NAMESPACE%%%UTIL_Describe</apexClass>
+        <enabled>True</enabled>
+    </classAccesses>
 </Profile>


### PR DESCRIPTION
# Critical Changes

# Changes
## Update Access to EDA Apex Controllers
The Salesforce Summer'20 release restricted access to certain Apex classes through Lightning components to improve security. In new EDA installations, these changes will have no impact. However, if you installed an earlier version of EDA, these changes may impact users' ability to access EDA Settings.

In this case, grant the System Administrator profile access to the following EDA Apex classes: CMP_SettingsDataProvider, STG_Base_CTRL, STG_CourseConnections, STG_Courses, and UTIL_Describe.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
