### PR TITLE
Updates to AFFL_MultiRecordType_TEST to prevent build failures

### DIFF
--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -676,15 +676,12 @@ public with sharing class AFFL_MultiRecordType_TEST {
     private static void autoCreateProgramEnrollment() {		
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
-        String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
-        //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing 
-        Affl_Mappings__c bizOrgMapping = [SELECT Auto_Program_Enrollment__c,
-            Auto_Program_Enrollment_Role__c,
-            Auto_Program_Enrollment_Status__c
-            FROM Affl_Mappings__c
-            WHERE Name = :bizOrgRecordTypeName];
+        AffiliationMappingWrapper bizOrgMappingWrapper = affiliationMappingWrapperList[1];
+        String bizOrgRecordTypeName = bizOrgMappingWrapper.getAccountRecordTypeName();
 
+        //Turn on Academic Record auto-creation for Business Organization mapping, which we are using as an arbitrary record type for testing.
+        Affl_Mappings__c bizOrgMapping = bizOrgMappingWrapper.getAffiliationMapping();
         bizOrgMapping.Auto_Program_Enrollment__c = true;
         bizOrgMapping.Auto_Program_Enrollment_Role__c = 'Student';
         bizOrgMapping.Auto_Program_Enrollment_Status__c = 'Current';
@@ -714,15 +711,12 @@ public with sharing class AFFL_MultiRecordType_TEST {
     private static void autoCreateProgramEnrollmentDifferentRole() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
-        String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
-        //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing
-        Affl_Mappings__c bizOrgMapping = [SELECT Auto_Program_Enrollment__c,
-            Auto_Program_Enrollment_Role__c,
-            Auto_Program_Enrollment_Status__c
-            FROM Affl_Mappings__c
-            WHERE Name = :bizOrgRecordTypeName];
+        AffiliationMappingWrapper bizOrgMappingWrapper = affiliationMappingWrapperList[1];
+        String bizOrgRecordTypeName = bizOrgMappingWrapper.getAccountRecordTypeName();
 
+        //Turn on Academic Record auto-creation for Business Organization mapping, which we are using as an arbitrary record type for testing.
+        Affl_Mappings__c bizOrgMapping = bizOrgMappingWrapper.getAffiliationMapping();
         bizOrgMapping.Auto_Program_Enrollment__c = true;
         bizOrgMapping.Auto_Program_Enrollment_Role__c = 'Student';
         bizOrgMapping.Auto_Program_Enrollment_Status__c = 'Current';

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -1000,12 +1000,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
         String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
 
         List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic_Program', Primary_Affl_Field__c = prefix + 'Primary_Academic_Program__c', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
             mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
             mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'HH_Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational_Institution', Primary_Affl_Field__c = prefix + 'Primary_Educational_Institution__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University_Department', Primary_Affl_Field__c = prefix + 'Primary_Department__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports_Organization', Primary_Affl_Field__c = prefix + 'Primary_Sports_Organization__c'));
         insert mappings;
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1059,12 +1055,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
         String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
         
         List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic Program', Primary_Affl_Field__c = prefix + 'Primary_Academic_Program__c', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
             mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
             mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational Institution', Primary_Affl_Field__c = prefix + 'Primary_Educational_Institution__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University Department', Primary_Affl_Field__c = prefix + 'Primary_Department__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports Organization', Primary_Affl_Field__c = prefix + 'Primary_Sports_Organization__c'));
         insert mappings;
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1186,14 +1178,15 @@ public with sharing class AFFL_MultiRecordType_TEST {
         String namespace = UTIL_Namespace.getNamespace();
         String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
         
+        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
+            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
+            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
+        insert mappings;
+
         // Construct a list of primary Affiliation field API Names
         List<String> primaryFieldsList = new List<String>();
-           primaryFieldsList.add(prefix + 'Primary_Academic_Program__c');
-           primaryFieldsList.add(prefix + 'Primary_Educational_Institution__c');
            primaryFieldsList.add(prefix + 'Primary_Organization__c');
            primaryFieldsList.add(prefix + 'Primary_Household__c');
-           primaryFieldsList.add(prefix + 'Primary_Department__c');
-           primaryFieldsList.add(prefix + 'Primary_Sports_Organization__c');
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1201,7 +1194,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         Test.stopTest();
 
         // Ensure List has all 6 mappings
-        System.assertEquals(6, validPrimaryFieldList.size());
+        System.assertEquals(2, validPrimaryFieldList.size());
 
     }
 
@@ -1235,18 +1228,19 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testsGetValidPrimaryAfflFieldsWithLabelsAndAPI() {
-
+        
         String namespace = UTIL_Namespace.getNamespace();
         String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
 
+        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
+            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
+            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
+        insert mappings;
+
         // Construct a list of primary Affiliation field Labels and API names
         List<String> primaryFieldsList = new List<String>();
-           primaryFieldsList.add(prefix + 'Primary_Academic_Program__c');
-           primaryFieldsList.add(prefix + 'Primary_Educational_Institution__c');
-           primaryFieldsList.add('Primary Business Organization');
+           primaryFieldsList.add(prefix + 'Primary_Organization__c');
            primaryFieldsList.add('Primary Household');
-           primaryFieldsList.add('Primary Department');
-           primaryFieldsList.add('Primary Sports Organization');      
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1254,7 +1248,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         Test.stopTest();
 
         // Ensure List has all 6 mappings
-        System.assertEquals(6, validPrimaryFieldList.size());
+        System.assertEquals(2, validPrimaryFieldList.size());
 
     }
     

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -36,9 +36,6 @@
 */
 @isTest
 public with sharing class AFFL_MultiRecordType_TEST {
-    
-    private static ID orgRecTypeID;
-    private static ID householdRecTypeID;
 
 /**************************************************************************
 * SETUP
@@ -49,13 +46,11 @@ public with sharing class AFFL_MultiRecordType_TEST {
     * tests using record type name and contact field api name
     * @return The affiliation mapping wrappers set up for the tests.
     **************************************************************************/
-    public static List<AffiliationMappingWrapper> setupAndGetMappingsByDevNameAndApiName() {
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
+    public static List<AffiliationMappingWrapper> setupMappingsByDevNameAndApiName() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.getAfflMappingWrapperByDevNameAndApiName();
 
-        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+        return AFFL_MultiRecordType_TEST.commonSetup(affiliationMappingWrapperList);
     }
 
     /**************************************************************************
@@ -63,13 +58,11 @@ public with sharing class AFFL_MultiRecordType_TEST {
     * tests using record type name and contact field label
     * @return The affiliation mapping wrappers set up for the tests.
     **************************************************************************/
-    public static List<AffiliationMappingWrapper> setupAndGetMappingsByDevNameAndLabel() {
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
+    public static List<AffiliationMappingWrapper> setupMappingsByDevNameAndLabel() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.getAfflMappingWrapperByDevNameAndLabel();
 
-        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+        return AFFL_MultiRecordType_TEST.commonSetup(affiliationMappingWrapperList);
     }
 
     /**************************************************************************
@@ -77,13 +70,11 @@ public with sharing class AFFL_MultiRecordType_TEST {
     * tests using record type name and contact field api name
     * @return The affiliation mapping wrappers set up for the tests.
     **************************************************************************/
-    public static List<AffiliationMappingWrapper> setupAndGetMappingsByNameAndApiName() {
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
+    public static List<AffiliationMappingWrapper> setupMappingsByNameAndApiName() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndApiName();
 
-        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+        return AFFL_MultiRecordType_TEST.commonSetup(affiliationMappingWrapperList);
     }
 
     /**************************************************************************
@@ -91,28 +82,27 @@ public with sharing class AFFL_MultiRecordType_TEST {
     * tests using record type name and contact field label
     * @return The affiliation mapping wrappers set up for the tests.
     **************************************************************************/
-    public static List<AffiliationMappingWrapper> setupAndGetMappingsByNameAndLabel() {
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
+    public static List<AffiliationMappingWrapper> setupMappingsByNameAndLabel() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndLabel();
 
-        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+        return AFFL_MultiRecordType_TEST.commonSetup(affiliationMappingWrapperList);
     }
 
     /**************************************************************************
     * @description Sets up hierarchy settings and affiliation mappings for
-    * tests using affiliation wrapper mappings
+    * tests using provided affiliation wrapper mappings common to all setup
+    * scenarios
     * @param affiliationMappingWrapperList The wrapper mappings to set up
     * the test with
     * @return The affiliation mapping wrappers set up for the tests.
     **************************************************************************/
-    private static List<AffiliationMappingWrapper> setupAndGetMappings(
+    private static List<AffiliationMappingWrapper> commonSetup(
         List<AffiliationMappingWrapper> affiliationMappingWrapperList
     ) {
-        AFFL_MultiRecordType_TEST.initializeHierarchySettings(
-            affiliationMappingWrapperList[0].getAccountRecordTypeId()
-        );
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
+            Account_Processor__c = affiliationMappingWrapperList[0].getAccountRecordTypeId()
+        ));
 
         affiliationMappingWrapperList = AFFL_MultiRecordType_TEST.populateRecordTypeNamesForWrappers(
             affiliationMappingWrapperList
@@ -142,14 +132,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         wrapperList.add(
             new AfflMappingWrapperByDevNameAndApiName(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 contactPrimaryAffiliationFieldApiNameList[0]
             )
         );
 
         wrapperList.add(
             new AfflMappingWrapperByDevNameAndApiName(
-                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                UTIL_Describe_API.getBizAccRecTypeID(),
                 contactPrimaryAffiliationFieldApiNameList[1]
             )
         );
@@ -173,14 +163,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         wrapperList.add(
             new AfflMappingWrapperByDevNameAndLabel(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 contactPrimaryAffiliationFieldNameList[0]
             )
         );
 
         wrapperList.add(
             new AfflMappingWrapperByDevNameAndLabel(
-                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                UTIL_Describe_API.getBizAccRecTypeID(),
                 contactPrimaryAffiliationFieldNameList[1]
             )
         );
@@ -204,14 +194,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndApiName(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 contactPrimaryAffiliationFieldApiNameList[0]
             )
         );
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndApiName(
-                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                UTIL_Describe_API.getBizAccRecTypeID(),
                 contactPrimaryAffiliationFieldApiNameList[1]
             )
         );
@@ -235,75 +225,19 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndLabel(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 contactPrimaryAffiliationFieldNameList[0]
             )
         );
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndLabel(
-                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                UTIL_Describe_API.getBizAccRecTypeID(),
                 contactPrimaryAffiliationFieldNameList[1]
             )
         );
 
         return wrapperList;
-    }
-
-    /**************************************************************************
-    * @description Gets the contact primary affiliation field labels with the 
-    * household field as the first index and the business organization field
-    * as the second index
-    * @return the list of contact primary affiliation field labels
-    **************************************************************************/
-    private static List<String> getContactPrimaryAffiliationFieldLabels() {
-        List<String> fieldLabelList = new List<String>();
-
-        fieldLabelList.add('Primary Household');
-        fieldLabelList.add('Primary Business Organization');
-
-        return fieldLabelList;
-    }
-
-    /**************************************************************************
-    * @description Gets the contact primary affiliation namespaced api names
-    * with the household field as the first index and the business
-    * organization field as the second index
-    * @return the list of contact primary affiliation local field names
-    **************************************************************************/
-    private static List<String> getContactPrimaryAffiliationFieldApiNames() {
-        List<String> fieldApiNameList = new List<String>();
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-
-        fieldApiNameList.add(prefix + 'Primary_Household__c');
-        fieldApiNameList.add(prefix + 'Primary_Organization__c');
-        
-        return fieldApiNameList;
-    }
-
-    /**************************************************************************
-    * @description Initializes account record type ids
-    **************************************************************************/
-    private static void initializeAccountRecordTypeIds() {
-        AFFL_MultiRecordType_TEST.householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
-        AFFL_MultiRecordType_TEST.orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
-    }
-
-    /**************************************************************************
-    * @description Initializes the hierarchy settings for testing, setting the
-    * first
-    * @param accountProcessorRecordTypeId The record type id to use for the
-    * account processor
-    * @return The hierarchy settings created by this process.
-    **************************************************************************/
-    private static Hierarchy_Settings__c initializeHierarchySettings(Id accountProcessorRecordTypeId) {
-        Hierarchy_Settings__c hierarchySettings = new Hierarchy_Settings__c(Account_Processor__c = accountProcessorRecordTypeId);
-
-        UTIL_CustomSettings_API.getSettingsForTests(hierarchySettings);
-
-        return hierarchySettings;
     }
 
     /**************************************************************************
@@ -366,28 +300,35 @@ public with sharing class AFFL_MultiRecordType_TEST {
 * UTILITIES
 **************************************************************************/
 
+
+
     /**************************************************************************
-    * @description Gets the contact primary affiliation field api name for
-    * Business Organization
-    * @return the contact primary affiliation field api name for Business
-    * Organization
+    * @description Gets the contact primary affiliation field labels with the 
+    * household field as the first index and the business organization field
+    * as the second index
+    * @return the list of contact primary affiliation field labels
     **************************************************************************/
-    private static String getBusinessOrganizationFieldApiName() {
-        List<String> fieldApiNameList =
-            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
-        return fieldApiNameList[1];
+    private static List<String> getContactPrimaryAffiliationFieldLabels() {
+        List<String> fieldLabelList = new List<String>();
+
+        fieldLabelList.add(
+            AFFL_MultiRecordType_TEST.getHouseholdFieldLabel()
+        );
+        fieldLabelList.add(
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel()
+        );
+
+        return fieldLabelList;
     }
 
     /**************************************************************************
-    * @description Gets the contact primary affiliation field labels for
+    * @description Gets the contact primary affiliation field label for
     * Business Organization
     * @return the contact primary affiliation field labels for Business
     * Organization
     **************************************************************************/
     private static String getBusinessOrganizationFieldLabel() {
-        List<String> fieldLabelList =
-            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
-        return fieldLabelList[1];
+        return 'Primary Business Organization';
     }
 
     /**************************************************************************
@@ -396,9 +337,45 @@ public with sharing class AFFL_MultiRecordType_TEST {
     * @return the contact primary affiliation field labels for Household
     **************************************************************************/
     private static String getHouseholdFieldLabel() {
-        List<String> fieldLabelList =
-            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
-        return fieldLabelList[0];
+        return 'Primary Household';
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation namespaced api names
+    * with the household field as the first index and the business
+    * organization field as the second index
+    * @return the list of contact primary affiliation local field names
+    **************************************************************************/
+    private static List<String> getContactPrimaryAffiliationFieldApiNames() {
+        List<String> fieldApiNameList = new List<String>();
+
+        fieldApiNameList.add(
+            AFFL_MultiRecordType_TEST.getHouseholdFieldApiName()
+        );
+        fieldApiNameList.add(
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName()
+        );
+        
+        return fieldApiNameList;
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field api name for
+    * Business Organization
+    * @return the contact primary affiliation field api name for Business
+    * Organization
+    **************************************************************************/
+    private static String getBusinessOrganizationFieldApiName() {
+        return UTIL_Namespace.StrTokenNSPrefix('Primary_Organization__c');
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field api name for
+    * Household
+    * @return the contact primary affiliation field api name for Household
+    **************************************************************************/
+    private static String getHouseholdFieldApiName() {
+        return UTIL_Namespace.StrTokenNSPrefix('Primary_Household__c');
     }
 
     /**************************************************************************
@@ -415,7 +392,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 **************************************************************************/
     private static void createPrimaryAffl() {		
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgAcctName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
@@ -434,7 +411,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         System.assertNotEquals(null, contact.Primary_Household__c);
 
         //Create account of Business Organization record type
-        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert bizOrg1;
 
         //Create another key affiliation, this time to a biz org
@@ -452,7 +429,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         System.assertEquals(bizOrg1.ID, Contact.Primary_Organization__c);
 
         //Create second account of the same record type
-        Account bizOrg2 = new Account(Name='Toys Inc', RecordTypeId = orgRecTypeID);
+        Account bizOrg2 = new Account(Name='Toys Inc', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert bizOrg2;
 
         //Create second primary affiliation
@@ -481,13 +458,13 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void noDuplicateAffl() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
 
         //Create account of Business Organization record type
-        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account bizOrg1 = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert bizOrg1;
 
         //Create primary affiliation
@@ -504,7 +481,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void deletePrimaryAffl() {		
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -522,7 +499,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         System.assertNotEquals(null, contact.Primary_Household__c);
 
         //Craete account of Business Organization record type
-        Account acc1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account acc1 = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert acc1;
 
         //Create primary Business affiliation
@@ -547,7 +524,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makePrimaryAfflNonPrimary() {		
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -584,13 +561,13 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makeNonPrimaryAfflPrimary() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
 
         //Create account of Business Organization record type
-        Account acc1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account acc1 = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert acc1;
 
         //Create non-primary Business affiliation
@@ -620,14 +597,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makeNonPrimaryAfflPrimaryWhenAnotherPrimaryExists() {		
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
 
         //Create 2 accounts of Business Organization record type
-        Account acc1 = new Account(Name='Acme1', RecordTypeId = orgRecTypeID);
-        Account acc2 = new Account(Name='Acme2', RecordTypeId = orgRecTypeID);
+        Account acc1 = new Account(Name='Acme1', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
+        Account acc2 = new Account(Name='Acme2', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert new Account[] {acc1, acc2};
 
         //Create primary Business affiliation
@@ -667,14 +644,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void createPrimaryAfflWhenAnotherPrimaryExists() {        
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
 
         //Create 2 accounts of Business Organization record type
-        Account acc1 = new Account(Name='Acme1', RecordTypeId = orgRecTypeID);
-        Account acc2 = new Account(Name='Acme2', RecordTypeId = orgRecTypeID);
+        Account acc1 = new Account(Name='Acme1', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
+        Account acc2 = new Account(Name='Acme2', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert new Account[] {acc1, acc2};
 
         //Create primary Business affiliation
@@ -698,7 +675,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void autoCreateProgramEnrollment() {		
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing 
@@ -717,7 +694,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         insert contact;
 
         //Craete account of Business Organization record type
-        Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account acc = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert acc;
 
         //Create Business affiliation
@@ -736,7 +713,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void autoCreateProgramEnrollmentDifferentRole() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing
@@ -755,7 +732,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         insert contact;
 
         //Craete account of Business Organization record type
-        Account acc = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
+        Account acc = new Account(Name='Acme', RecordTypeId = UTIL_Describe_API.getBizAccRecTypeID());
         insert acc;
 
         //Create Business affiliation
@@ -780,8 +757,6 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void incorrectAfflMappingsAfflTypeEnforced() {
         //Note custom setup
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             new List<AffiliationMappingWrapper>();
         String bizOrgContactFieldLabel =
@@ -789,14 +764,14 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         affiliationMappingWrapperList.add(
             new AfflMappingWrapperByNameAndApiName(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 bizOrgContactFieldLabel + 's'
             )
         );
 
-        AFFL_MultiRecordType_TEST.initializeHierarchySettings(
-            affiliationMappingWrapperList[0].getAccountRecordTypeId()
-        );
+        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
+            Account_Processor__c = affiliationMappingWrapperList[0].getAccountRecordTypeId()
+        ));
 
         affiliationMappingWrapperList[0].setAccountRecordTypeName(
             'EDA: Not A Valid Record Type Name'
@@ -810,7 +785,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         //Setup end
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(
-            1, AFFL_MultiRecordType_TEST.householdRecTypeID);
+            1, UTIL_Describe_API.getHhAccRecTypeID());
         insert testAccounts;
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson', Primary_Organization__c = testAccounts[0].Id);
@@ -838,10 +813,10 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void affiliationDeleteNPECheck() {        
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         // Insert a business account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert bizAcc;
 
         // Insert a contact
@@ -888,13 +863,13 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void multipleAffiliationUpdates() {        
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
-        // Insert Accounts       
-        Account bizAcc1 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
-        Account bizAcc2 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
-        Account hhAcc1 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, householdRecTypeID)[0];
-        Account hhAcc2 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, householdRecTypeID)[0];
+        // Insert Accounts
+        Account bizAcc1 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
+        Account bizAcc2 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
+        Account hhAcc1 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getHhAccRecTypeID())[0];
+        Account hhAcc2 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getHhAccRecTypeID())[0];
 
         insert new Account[] {bizAcc1, bizAcc2, hhAcc1, hhAcc2};
 
@@ -956,16 +931,16 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void bulkAffiliationUpdates() { 
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         List<Account> accList = new List<Account>();
 
         // Insert a Business Account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         accList.add(bizAcc);
 
         // Insert a Household Account
-        Account hhAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, householdRecTypeID)[0];
+        Account hhAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getHhAccRecTypeID())[0];
         accList.add(hhAcc);
 
         // Insert multiple contacts
@@ -1033,11 +1008,10 @@ public with sharing class AFFL_MultiRecordType_TEST {
      // Test the usage of custom API field name for affiliation mapping for multi-language support
     @isTest
     private static void customFieldAPIInMappings() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
-        orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndApiName();
 
         // Insert a business account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert bizAcc;
 
         // Insert a contact with business account as Primary business organization
@@ -1061,11 +1035,10 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithLabelForRecTypeAndAPINameForPrimaryAfflFields() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
-        orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndApiName();
 
         // Insert a business account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert bizAcc;
 
         // Insert a contact with business account as Primary business organization
@@ -1095,11 +1068,10 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithAPIForRecTypeAndLabelForPrimaryAfflFields() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
-        orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
+        AFFL_MultiRecordType_TEST.setupMappingsByDevNameAndLabel();
 
         // Insert a business account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert bizAcc;
 
         // Insert a contact with business account as Primary business organization
@@ -1129,11 +1101,10 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithAPIForRecTypeAndAPIForPrimaryAfflFields() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndApiName();
-        orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
+        AFFL_MultiRecordType_TEST.setupMappingsByDevNameAndApiName();
 
         // Insert a business account
-        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
+        Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, UTIL_Describe_API.getBizAccRecTypeID())[0];
         insert bizAcc;
 
         // Insert a contact with business account as Primary business organization
@@ -1162,7 +1133,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeTest() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         Test.startTest();
@@ -1181,7 +1152,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeNegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1194,7 +1165,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Null test for getPrimaryAffiliationLookupAPIFromAffiliationType method of AFFL_MultiRecordTypeMapper
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeNullTest() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1208,7 +1179,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getContactFieldFromSettingsPoitiveTest() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
         String bizOrgContactFieldLabel = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel();
 
@@ -1225,7 +1196,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getContactFieldFromSettingsNegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1239,7 +1210,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Positive test for getPrimaryAffiliationLookupAPI method of AFFL_MultiRecordTypeMapper using Label name
     @isTest
     private static void getPrimaryAffiliationLookupAPIPoitiveLabelTest() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         String bizOrgContactFieldLabel = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel();
         String bizOrgContactFieldApiName = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
 
@@ -1256,7 +1227,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWAPINamesForAccRecType() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByDevNameAndLabel();
         AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1303,7 +1274,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWLabelsForAccRecType() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
         AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1351,7 +1322,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWAPINamesForAccRecTypeAndPrimaryAffl() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndApiName();
+        AFFL_MultiRecordType_TEST.setupMappingsByDevNameAndApiName();
         AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1398,7 +1369,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWLabelsForAccRecTypeAndAPIForPrimaryAffl() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndApiName();
         AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
@@ -1443,8 +1414,6 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // This method tests getValidAccRecordTypesInMappings() of AFFL_MultiRecordTypeMapper class by passing Record Names Labels from affiliation mappings
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithLabels() {
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
             AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndLabel();
 
@@ -1471,7 +1440,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithAPIs() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
+            AFFL_MultiRecordType_TEST.setupMappingsByDevNameAndLabel();
 
         // Construct a list of Account Record Type Names
         List<String> accRecTypeDevNameList = new List<String>();
@@ -1494,7 +1463,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithAPIAndLabels() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndApiName();
 
         // Construct a list of Account Record Type Names and Labels
         List<String> accRecTypeLabelList = new List<String>();
@@ -1518,7 +1487,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void testsGetValidPrimaryAfflFields() {
         List<AffiliationMappingWrapper> affiliationMappingWrapperList =
-            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
+            AFFL_MultiRecordType_TEST.setupMappingsByNameAndApiName();
 
         List<Affl_Mappings__c> allMappings = [SELECT ID FROM Affl_Mappings__c];
         System.assertEquals(affiliationMappingWrapperList.size(), allMappings.size());
@@ -1559,8 +1528,6 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void testsGetValidPrimaryAfflFieldsWithLabelsAndAPI() {
         //Note custom setup
-        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
-
         List<AffiliationMappingWrapper> wrapperList =
             new List<AffiliationMappingWrapper>();
 
@@ -1575,19 +1542,19 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndApiName(
-                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                UTIL_Describe_API.getHhAccRecTypeID(),
                 contactPrimaryAffiliationFieldApiNameList[0]
             )
         );
 
         wrapperList.add(
             new AfflMappingWrapperByNameAndLabel(
-                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                UTIL_Describe_API.getBizAccRecTypeID(),
                 contactPrimaryAffiliationFieldLabelList[1]
             )
         );
 
-        wrapperList = AFFL_MultiRecordType_TEST.setupAndGetMappings(wrapperList);
+        wrapperList = AFFL_MultiRecordType_TEST.commonSetup(wrapperList);
         //Custom setup ended
         
         List<Affl_Mappings__c> allMappings = [SELECT Id from Affl_Mappings__c];
@@ -1611,7 +1578,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Positive test for getPrimaryAffiliationLookupAPI method of AFFL_MultiRecordTypeMapper using API name
     @isTest
     private static void getPrimaryAffiliationLookupAPIPoitiveAPITest() {
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         String bizOrgContactFieldApiName =
             AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
@@ -1630,7 +1597,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getPrimaryAffiliationLookupAPINegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.setupMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -151,6 +151,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         contact = [select Account.ID, Primary_Household__c from Contact where ID =:Contact.ID];
         System.assertNotEquals(null, contact.Account.ID);
         System.assertEquals(null, contact.Primary_Household__c);
+
         //Manually create an Affiliation to the household, since we are not automatically doing so any more.
         insert new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
 
@@ -194,6 +195,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         System.assertNotEquals(null, contact.Account.ID);
         ID parentAccountId = contact.Account.ID;
         System.assertEquals(null, contact.Primary_Household__c);
+
         //Manually create an Affiliation to the household, since we are not automatically doing so any more.
         Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = contact.Account.ID, Primary__c = true);
         AFFL_ContactAccChange_TEST.resetAfflFlags();
@@ -1183,6 +1185,9 @@ public with sharing class AFFL_MultiRecordType_TEST {
             mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
         insert mappings;
 
+        List<Affl_Mappings__c> allMappings = [SELECT ID from Affl_Mappings__c];
+        System.assertEquals(2, allMappings.size());
+
         // Construct a list of primary Affiliation field API Names
         List<String> primaryFieldsList = new List<String>();
            primaryFieldsList.add(prefix + 'Primary_Organization__c');
@@ -1236,6 +1241,9 @@ public with sharing class AFFL_MultiRecordType_TEST {
             mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
             mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
         insert mappings;
+        
+        List<Affl_Mappings__c> allMappings = [SELECT ID from Affl_Mappings__c];
+        System.assertEquals(2, allMappings.size());
 
         // Construct a list of primary Affiliation field Labels and API names
         List<String> primaryFieldsList = new List<String>();

--- a/src/classes/AFFL_MultiRecordType_TEST.cls
+++ b/src/classes/AFFL_MultiRecordType_TEST.cls
@@ -39,22 +39,384 @@ public with sharing class AFFL_MultiRecordType_TEST {
     
     private static ID orgRecTypeID;
     private static ID householdRecTypeID;
-    
-    public static void setup() {
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
-                
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));	
-        mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
-        insert mappings;
 
-        orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
-        householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
+/**************************************************************************
+* SETUP
+**************************************************************************/
+
+    /**************************************************************************
+    * @description Sets up hierarchy settings and affiliation mappings for
+    * tests using record type name and contact field api name
+    * @return The affiliation mapping wrappers set up for the tests.
+    **************************************************************************/
+    public static List<AffiliationMappingWrapper> setupAndGetMappingsByDevNameAndApiName() {
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
+
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.getAfflMappingWrapperByDevNameAndApiName();
+
+        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
     }
 
-    @isTest
+    /**************************************************************************
+    * @description Sets up hierarchy settings and affiliation mappings for
+    * tests using record type name and contact field label
+    * @return The affiliation mapping wrappers set up for the tests.
+    **************************************************************************/
+    public static List<AffiliationMappingWrapper> setupAndGetMappingsByDevNameAndLabel() {
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
+
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.getAfflMappingWrapperByDevNameAndLabel();
+
+        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+    }
+
+    /**************************************************************************
+    * @description Sets up hierarchy settings and affiliation mappings for
+    * tests using record type name and contact field api name
+    * @return The affiliation mapping wrappers set up for the tests.
+    **************************************************************************/
+    public static List<AffiliationMappingWrapper> setupAndGetMappingsByNameAndApiName() {
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
+
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndApiName();
+
+        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+    }
+
+    /**************************************************************************
+    * @description Sets up hierarchy settings and affiliation mappings for
+    * tests using record type name and contact field label
+    * @return The affiliation mapping wrappers set up for the tests.
+    **************************************************************************/
+    public static List<AffiliationMappingWrapper> setupAndGetMappingsByNameAndLabel() {
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
+
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndLabel();
+
+        return AFFL_MultiRecordType_TEST.setupAndGetMappings(affiliationMappingWrapperList);
+    }
+
+    /**************************************************************************
+    * @description Sets up hierarchy settings and affiliation mappings for
+    * tests using affiliation wrapper mappings
+    * @param affiliationMappingWrapperList The wrapper mappings to set up
+    * the test with
+    * @return The affiliation mapping wrappers set up for the tests.
+    **************************************************************************/
+    private static List<AffiliationMappingWrapper> setupAndGetMappings(
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList
+    ) {
+        AFFL_MultiRecordType_TEST.initializeHierarchySettings(
+            affiliationMappingWrapperList[0].getAccountRecordTypeId()
+        );
+
+        affiliationMappingWrapperList = AFFL_MultiRecordType_TEST.populateRecordTypeNamesForWrappers(
+            affiliationMappingWrapperList
+        );
+
+        insert AFFL_MultiRecordType_TEST.createAffiliationMappings(
+            affiliationMappingWrapperList
+        );
+
+        return affiliationMappingWrapperList;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type developer name to contact field
+    * api name wrappers for test setup and sets old id values for backward
+    * compatibility
+    * @return the list of account record type to contact label pairings to use
+    * for further setup with the intended record type id for the account
+    * processor as the first element.
+    **************************************************************************/
+    private static List<AfflMappingWrapperByDevNameAndApiName> getAfflMappingWrapperByDevNameAndApiName() {
+        List<AfflMappingWrapperByDevNameAndApiName> wrapperList =
+            new List<AfflMappingWrapperByDevNameAndApiName>();
+
+        List<String> contactPrimaryAffiliationFieldApiNameList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
+
+        wrapperList.add(
+            new AfflMappingWrapperByDevNameAndApiName(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                contactPrimaryAffiliationFieldApiNameList[0]
+            )
+        );
+
+        wrapperList.add(
+            new AfflMappingWrapperByDevNameAndApiName(
+                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                contactPrimaryAffiliationFieldApiNameList[1]
+            )
+        );
+
+        return wrapperList;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type developer name to contact label
+    * wrappers for test setup and sets old id values for backward compatibility
+    * @return the list of account record type to contact label pairings to use
+    * for further setup with the intended record type id for the account
+    * processor ashe first element.
+    **************************************************************************/
+    private static List<AfflMappingWrapperByDevNameAndLabel> getAfflMappingWrapperByDevNameAndLabel() {
+        List<AfflMappingWrapperByDevNameAndLabel> wrapperList =
+            new List<AfflMappingWrapperByDevNameAndLabel>();
+
+        List<String> contactPrimaryAffiliationFieldNameList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
+
+        wrapperList.add(
+            new AfflMappingWrapperByDevNameAndLabel(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                contactPrimaryAffiliationFieldNameList[0]
+            )
+        );
+
+        wrapperList.add(
+            new AfflMappingWrapperByDevNameAndLabel(
+                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                contactPrimaryAffiliationFieldNameList[1]
+            )
+        );
+
+        return wrapperList;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type name to contact field api name
+    * wrappers for test setup and sets old id values for backward compatibility
+    * @return the list of account record type to contact label pairings to use
+    * for further setup with the intended record type id for the account
+    * processor as the first element.
+    **************************************************************************/
+    private static List<AfflMappingWrapperByNameAndApiName> getAfflMappingWrapperByNameAndApiName() {
+        List<AfflMappingWrapperByNameAndApiName> wrapperList =
+            new List<AfflMappingWrapperByNameAndApiName>();
+
+        List<String> contactPrimaryAffiliationFieldApiNameList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndApiName(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                contactPrimaryAffiliationFieldApiNameList[0]
+            )
+        );
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndApiName(
+                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                contactPrimaryAffiliationFieldApiNameList[1]
+            )
+        );
+
+        return wrapperList;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type name to contact label wrappers
+    * for test setup and sets old id values for backward compatibility
+    * @return the list of account record type to contact label pairings to use
+    * for further setup with the intended record type id for the account
+    * processor ashe first element.
+    **************************************************************************/
+    private static List<AfflMappingWrapperByNameAndLabel> getAfflMappingWrapperByNameAndLabel() {
+        List<AfflMappingWrapperByNameAndLabel> wrapperList =
+            new List<AfflMappingWrapperByNameAndLabel>();
+
+        List<String> contactPrimaryAffiliationFieldNameList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndLabel(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                contactPrimaryAffiliationFieldNameList[0]
+            )
+        );
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndLabel(
+                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                contactPrimaryAffiliationFieldNameList[1]
+            )
+        );
+
+        return wrapperList;
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field labels with the 
+    * household field as the first index and the business organization field
+    * as the second index
+    * @return the list of contact primary affiliation field labels
+    **************************************************************************/
+    private static List<String> getContactPrimaryAffiliationFieldLabels() {
+        List<String> fieldLabelList = new List<String>();
+
+        fieldLabelList.add('Primary Household');
+        fieldLabelList.add('Primary Business Organization');
+
+        return fieldLabelList;
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation namespaced api names
+    * with the household field as the first index and the business
+    * organization field as the second index
+    * @return the list of contact primary affiliation local field names
+    **************************************************************************/
+    private static List<String> getContactPrimaryAffiliationFieldApiNames() {
+        List<String> fieldApiNameList = new List<String>();
+
+        String namespace = UTIL_Namespace.getNamespace();
+        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
+
+        fieldApiNameList.add(prefix + 'Primary_Household__c');
+        fieldApiNameList.add(prefix + 'Primary_Organization__c');
+        
+        return fieldApiNameList;
+    }
+
+    /**************************************************************************
+    * @description Initializes account record type ids
+    **************************************************************************/
+    private static void initializeAccountRecordTypeIds() {
+        AFFL_MultiRecordType_TEST.householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
+        AFFL_MultiRecordType_TEST.orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
+    }
+
+    /**************************************************************************
+    * @description Initializes the hierarchy settings for testing, setting the
+    * first
+    * @param accountProcessorRecordTypeId The record type id to use for the
+    * account processor
+    * @return The hierarchy settings created by this process.
+    **************************************************************************/
+    private static Hierarchy_Settings__c initializeHierarchySettings(Id accountProcessorRecordTypeId) {
+        Hierarchy_Settings__c hierarchySettings = new Hierarchy_Settings__c(Account_Processor__c = accountProcessorRecordTypeId);
+
+        UTIL_CustomSettings_API.getSettingsForTests(hierarchySettings);
+
+        return hierarchySettings;
+    }
+
+    /**************************************************************************
+    * @description Initializes the mappings based on the affiliation mapping
+    * wrappers passed to it
+    * @param affiliationMappingWrapperList The list of account record type ids to get
+    * mappings for.
+    * @return The List of Affiliation Mappings to insert.
+    **************************************************************************/
+    private static List<AffiliationMappingWrapper> populateRecordTypeNamesForWrappers(
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList
+    ) {
+        System.assertEquals(false, affiliationMappingWrapperList.size() < 2,
+            '2 Account Record Types were not found for affiliation mappings');
+            
+        Map<Id, Schema.RecordTypeInfo> accountRecordTypeInfosByIds =
+            AFFL_MultiRecordType_TEST.getIdToAccountRecordTypesMap();
+
+        for(AffiliationMappingWrapper affiliationMappingWrapper : affiliationMappingWrapperList) {
+            affiliationMappingWrapper.setRecordTypeNamesFromId(accountRecordTypeInfosByIds);
+        }
+
+        return affiliationMappingWrapperList;
+    }
+
+    /**************************************************************************
+    * @description Get record type infos for an account
+    * @return The List of Affiliation Mappings to insert.
+    **************************************************************************/
+    private static Map<Id, Schema.RecordTypeInfo> getIdToAccountRecordTypesMap() {
+        Schema.DescribeSObjectResult accountDescribe =
+            UTIL_Describe.getObjectDescribe('Account');
+
+        return accountDescribe.getRecordTypeInfosByID();
+    }
+
+    /**************************************************************************
+    * @description Creates affiliation mappings from wrappers, setting the
+    * related mapping to the wrapper for later reference
+    * @param affiliationMappingWrapperList The list of mapping wrappers to
+    * create mappings for
+    * @return The affiliation mappings created 
+    **************************************************************************/
+    private static List<Affl_Mappings__c> createAffiliationMappings(
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList
+    ) {
+        List<Affl_Mappings__c> affiliationMappingSettings = new List<Affl_Mappings__c>();
+
+        for(AffiliationMappingWrapper affiliationMappingWrapper : affiliationMappingWrapperList) {
+            affiliationMappingWrapper.setAffiliationMapping();
+            affiliationMappingSettings.add(
+                affiliationMappingWrapper.getAffiliationMapping()
+            );
+        }
+
+        return affiliationMappingSettings;
+    }
+
+/**************************************************************************
+* UTILITIES
+**************************************************************************/
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field api name for
+    * Business Organization
+    * @return the contact primary affiliation field api name for Business
+    * Organization
+    **************************************************************************/
+    private static String getBusinessOrganizationFieldApiName() {
+        List<String> fieldApiNameList =
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
+        return fieldApiNameList[1];
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field labels for
+    * Business Organization
+    * @return the contact primary affiliation field labels for Business
+    * Organization
+    **************************************************************************/
+    private static String getBusinessOrganizationFieldLabel() {
+        List<String> fieldLabelList =
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
+        return fieldLabelList[1];
+    }
+
+    /**************************************************************************
+    * @description Gets the contact primary affiliation field labels for
+    * Household
+    * @return the contact primary affiliation field labels for Household
+    **************************************************************************/
+    private static String getHouseholdFieldLabel() {
+        List<String> fieldLabelList =
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
+        return fieldLabelList[0];
+    }
+
+    /**************************************************************************
+    * @description Enables affiliation record type enforcement to true,
+    * assuming settings have been initialized. Leverages caching of the
+    * settings.
+    **************************************************************************/
+    private static void enableAffiliationRecordTypeEnforcement() {
+        UTIL_CustomSettings_API.getSettings().Affiliation_Record_Type_Enforced__c = true;
+    }
+
+/**************************************************************************
+* TESTS
+**************************************************************************/
     private static void createPrimaryAffl() {		
-        AFFL_MultiRecordType_TEST.setup();
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgAcctName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -83,8 +445,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
         Test.stopTest();
 
         //The business organization lookup should point to the account that is part of the affiliation we created
-        bizAffl1 = [select Affiliation_Type__c from Affiliation__c where Account__c = :bizOrg1.ID];
-        System.assertEquals('Business Organization', bizAffl1.Affiliation_Type__c);
+        bizAffl1 = [SELECT Affiliation_Type__c FROM Affiliation__c WHERE Account__c = :bizOrg1.ID];
+        System.assertEquals(bizOrgAcctName, bizAffl1.Affiliation_Type__c);
 
         contact = [select Primary_Organization__c from Contact where ID = :contact.ID];
         System.assertEquals(bizOrg1.ID, Contact.Primary_Organization__c);
@@ -99,7 +461,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
         insert bizAffl2;
 
         //The previous affiliation should not be the primary any more
-        bizAffl1 = [select Primary__c from Affiliation__c where ID = :bizAffl1.ID];
+        bizAffl1 = [SELECT Primary__c FROM Affiliation__c WHERE ID = :bizAffl1.ID];
         System.assertEquals(false, bizAffl1.Primary__c);
 
         //The business organization lookup should point to the account that is part of the second affiliation we created
@@ -119,7 +481,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void noDuplicateAffl() {
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -142,7 +504,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void deletePrimaryAffl() {		
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -185,7 +547,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makePrimaryAfflNonPrimary() {		
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -222,7 +584,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makeNonPrimaryAfflPrimary() {
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -258,7 +620,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void makeNonPrimaryAfflPrimaryWhenAnotherPrimaryExists() {		
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -305,7 +667,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void createPrimaryAfflWhenAnotherPrimaryExists() {        
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson');
         insert contact;
@@ -335,10 +697,17 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void autoCreateProgramEnrollment() {		
-        AFFL_MultiRecordType_TEST.setup();
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing 
-        Affl_Mappings__c bizOrgMapping = [select Auto_Program_Enrollment__c from Affl_Mappings__c where Name = 'Business Organization'];
+        Affl_Mappings__c bizOrgMapping = [SELECT Auto_Program_Enrollment__c,
+            Auto_Program_Enrollment_Role__c,
+            Auto_Program_Enrollment_Status__c
+            FROM Affl_Mappings__c
+            WHERE Name = :bizOrgRecordTypeName];
+
         bizOrgMapping.Auto_Program_Enrollment__c = true;
         bizOrgMapping.Auto_Program_Enrollment_Role__c = 'Student';
         bizOrgMapping.Auto_Program_Enrollment_Status__c = 'Current';
@@ -353,22 +722,30 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         //Create Business affiliation
         Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = acc.ID, Role__c = 'Student', Status__c = 'Current');
+
         Test.startTest();
-        AFFL_ContactAccChange_TEST.resetAfflFlags();
-        insert affl;
+            AFFL_ContactAccChange_TEST.resetAfflFlags();
+            insert affl;
         Test.stopTest();
         //Verify Progran Enrollment record has been created
-        List<Program_Enrollment__c> programEnrollments = [select ID, Contact__c from Program_Enrollment__c where Affiliation__c = :affl.ID];
+        List<Program_Enrollment__c> programEnrollments = [SELECT ID, Contact__c FROM Program_Enrollment__c WHERE Affiliation__c = :affl.ID];
         System.assertEquals(1, programEnrollments.size());
         System.assertEquals(contact.ID, programEnrollments[0].Contact__c);
     }
 
     @isTest
     private static void autoCreateProgramEnrollmentDifferentRole() {
-        AFFL_MultiRecordType_TEST.setup();
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         //Turn on Academic Record auto-creation for Business Organization mapping - doesn't make a lot of sense for this type, but just for testing
-        Affl_Mappings__c bizOrgMapping = [select Auto_Program_Enrollment__c from Affl_Mappings__c where Name = 'Business Organization'];
+        Affl_Mappings__c bizOrgMapping = [SELECT Auto_Program_Enrollment__c,
+            Auto_Program_Enrollment_Role__c,
+            Auto_Program_Enrollment_Status__c
+            FROM Affl_Mappings__c
+            WHERE Name = :bizOrgRecordTypeName];
+
         bizOrgMapping.Auto_Program_Enrollment__c = true;
         bizOrgMapping.Auto_Program_Enrollment_Role__c = 'Student';
         bizOrgMapping.Auto_Program_Enrollment_Status__c = 'Current';
@@ -383,57 +760,85 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
         //Create Business affiliation
         Affiliation__c affl = new Affiliation__c(Contact__c = contact.ID, Account__c = acc.ID, Role__c = 'Teacher', Status__c = 'Current');
+
         Test.startTest();
-        AFFL_ContactAccChange_TEST.resetAfflFlags();
-        insert affl;
+            AFFL_ContactAccChange_TEST.resetAfflFlags();
+            insert affl;
         Test.stopTest();
 
         //Verify Program Enrollment record has not been created
-        List<Program_Enrollment__c> programEnrollments = [select ID, Contact__c from Program_Enrollment__c where Affiliation__c = :affl.ID];
+        List<Program_Enrollment__c> programEnrollments = [SELECT ID, Contact__c FROM Program_Enrollment__c WHERE Affiliation__c = :affl.ID];
         System.assertEquals(0, programEnrollments.size());
     }
 
 
-/*********************************************************************************************************
-* @description
-* Enable Affiliation Type Enforcement and make Affiliation-Account mapping mismatch
-* Make sure Affiliation is not created and a custom exception is thrown
-*/
-
+    /*********************************************************************************************************
+    * @description
+    * Enable Affiliation Type Enforcement and make Affiliation-Account mapping mismatch
+    * Make sure Affiliation is not created and a custom exception is thrown
+    */
     @isTest
     private static void incorrectAfflMappingsAfflTypeEnforced() {
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
+        //Note custom setup
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
 
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organizations', Primary_Affl_Field__c = 'Primary Business Organization'));
-        insert mappings;
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            new List<AffiliationMappingWrapper>();
+        String bizOrgContactFieldLabel =
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel();
 
-        List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
+        affiliationMappingWrapperList.add(
+            new AfflMappingWrapperByNameAndApiName(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                bizOrgContactFieldLabel + 's'
+            )
+        );
+
+        AFFL_MultiRecordType_TEST.initializeHierarchySettings(
+            affiliationMappingWrapperList[0].getAccountRecordTypeId()
+        );
+
+        affiliationMappingWrapperList[0].setAccountRecordTypeName(
+            'EDA: Not A Valid Record Type Name'
+        );
+
+        insert AFFL_MultiRecordType_TEST.createAffiliationMappings(
+            affiliationMappingWrapperList
+        );
+
+        AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
+        //Setup end
+
+        List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(
+            1, AFFL_MultiRecordType_TEST.householdRecTypeID);
         insert testAccounts;
 
-        Test.startTest();
-        AFFL_ContactAccChange_TEST.resetAfflFlags();
         Contact contact = new Contact(FirstName = 'Test', LastName = 'Testerson', Primary_Organization__c = testAccounts[0].Id);
-        Database.SaveResult result = Database.insert(contact, false);
+        AFFL_ContactAccChange_TEST.resetAfflFlags();
+
+        Test.startTest();
+            try {
+                insert contact;
+                System.assert(false, 'Always throw an exception when Account record type is not a part of Affiliation Mappings and when Affiliation Record Type is Enforced.');
+            } catch (System.DmlException error) {
+                System.assert(error.getMessage().contains(Label.afflAccoutMappingError));
+            }
         Test.stopTest();
 
         //Assert
-        List<Affiliation__c> assertAffls = [select ID from Affiliation__c];
+        List<Affiliation__c> assertAffls = [SELECT ID FROM Affiliation__c];
         System.assertEquals(0, assertAffls.size());
-
-        System.assertEquals(false, result.success);
-        System.assertEquals(Label.afflAccoutMappingError, result.errors[0].message);
     }
 
-/*********************************************************************************************************
-* @description
-* This method ensures there is no NPE when a primay affiliation 
-* with no contact is deleted
-*/
+    /*********************************************************************************************************
+    * @description
+    * This method ensures there is no NPE when a primay affiliation 
+    * with no contact is deleted
+    */
     @isTest
     private static void affiliationDeleteNPECheck() {        
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         // Insert a business account
         Account bizAcc = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
@@ -475,15 +880,15 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     }
 
-/*********************************************************************************************************
-* @description
-* This method ensures concurrent updates to multiple affiliation records as Primary populates correct  
-* Primary fields on related Contact
-*/
+    /*********************************************************************************************************
+    * @description
+    * This method ensures concurrent updates to multiple affiliation records as Primary populates correct  
+    * Primary fields on related Contact
+    */
     @isTest
     private static void multipleAffiliationUpdates() {        
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         // Insert Accounts       
         Account bizAcc1 = UTIL_UnitTestData_API.getMultipleTestAccounts(1, orgRecTypeID)[0];
@@ -542,16 +947,16 @@ public with sharing class AFFL_MultiRecordType_TEST {
             System.assertEquals(eachAffl.Primary__c, False);
         }                                   
     }
-/*********************************************************************************************************
-* @description
-* This bulk test method ensures Multiple affiliations to the same Business Organization don't
-* prevent Primary fields on Contacts from updating
-*/
 
+    /*********************************************************************************************************
+    * @description
+    * This bulk test method ensures Multiple affiliations to the same Business Organization don't
+    * prevent Primary fields on Contacts from updating
+    */
     @isTest
     private static void bulkAffiliationUpdates() { 
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         List<Account> accList = new List<Account>();
 
@@ -628,15 +1033,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
      // Test the usage of custom API field name for affiliation mapping for multi-language support
     @isTest
     private static void customFieldAPIInMappings() {
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = ( String.isNotBlank(namespace) ) ? namespace + '__' : '';
-
-        // insert custom api field name as an affiliation mapping    
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-        insert mappings;
-
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
 
         // Insert a business account
@@ -664,15 +1061,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithLabelForRecTypeAndAPINameForPrimaryAfflFields() {
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = ( String.isNotBlank(namespace) ) ? namespace + '__' : '';
-
-        // Insert custom api field name as an affiliation mapping
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-        insert mappings;
-
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
 
         // Insert a business account
@@ -706,12 +1095,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithAPIForRecTypeAndLabelForPrimaryAfflFields() {
-
-        // Insert custom api field name as an affiliation mapping    
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
-        insert mappings;
-
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
 
         // Insert a business account
@@ -745,15 +1129,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void testAfflDeletionWithAPIForRecTypeAndAPIForPrimaryAfflFields() {
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = ( String.isNotBlank(namespace) ) ? namespace + '__' : '';
-
-        // Insert custom api field name as an affiliation mapping
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-        mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-        insert mappings;
-
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndApiName();
         orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
 
         // Insert a business account
@@ -785,18 +1161,19 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Test getPrimaryAffiliationLookupAPIFromAffiliationType method of AFFL_MultiRecordTypeMapper
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeTest() {
-
-        AFFL_MultiRecordType_TEST.setup();
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgRecordTypeName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-            String primaryAfflLookupAPIName = afflMapper.getPrimaryAffiliationLookupAPIFromAffiliationType('Business Organization');
+            String primaryAfflLookupAPIName = afflMapper.getPrimaryAffiliationLookupAPIFromAffiliationType(bizOrgRecordTypeName);
         Test.stopTest();
 
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = ( String.isNotBlank(namespace) ) ? namespace + '__' : '';
+        String bizOrgPrimaryAfflFieldApiName =
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
 
-        System.assertEquals(prefix + 'Primary_Organization__c', primaryAfflLookupAPIName);
+        System.assertEquals(bizOrgPrimaryAfflFieldApiName, primaryAfflLookupAPIName);
 
     }
 
@@ -804,7 +1181,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeNegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -817,8 +1194,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Null test for getPrimaryAffiliationLookupAPIFromAffiliationType method of AFFL_MultiRecordTypeMapper
     @isTest
     private static void getPrimaryAffiliationLookupAPIFromAffiliationTypeNullTest() {
-
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -826,21 +1202,22 @@ public with sharing class AFFL_MultiRecordType_TEST {
         Test.stopTest();
 
         System.assertEquals(null, primaryAfflLookupAPIName);
-
     }
 
     // Positive test for getContactFieldFromSettings method of AFFL_MultiRecordTypeMapper
     @isTest
     private static void getContactFieldFromSettingsPoitiveTest() {
-
-        AFFL_MultiRecordType_TEST.setup();
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgName = affiliationMappingWrapperList[1].getAccountRecordTypeName();
+        String bizOrgContactFieldLabel = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-            String contactFieldFromSettings = afflMapper.getContactFieldFromSettings('Business Organization');
+            String contactFieldFromSettings = afflMapper.getContactFieldFromSettings(bizOrgName);
         Test.stopTest();
 
-        System.assertEquals('Primary Business Organization', contactFieldFromSettings);
+        System.assertEquals(bizOrgContactFieldLabel, contactFieldFromSettings);
 
     }
     
@@ -848,7 +1225,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
     @isTest
     private static void getContactFieldFromSettingsNegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -862,19 +1239,16 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // Positive test for getPrimaryAffiliationLookupAPI method of AFFL_MultiRecordTypeMapper using Label name
     @isTest
     private static void getPrimaryAffiliationLookupAPIPoitiveLabelTest() {
-
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        String bizOrgContactFieldLabel = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldLabel();
+        String bizOrgContactFieldApiName = AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-            String primaryAfflLookupAPIName = afflMapper.getPrimaryAffiliationLookupAPI('Primary Business Organization');
+            String primaryAfflLookupAPIName = afflMapper.getPrimaryAffiliationLookupAPI(bizOrgContactFieldLabel);
         Test.stopTest();
         
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-        
-        System.assertEquals(prefix + 'Primary_Organization__c', primaryAfflLookupAPIName);
-       
+        System.assertEquals(bizOrgContactFieldApiName, primaryAfflLookupAPIName);
     }
 
     /* Test to ensure users can create Contacts and Affilaitons when Affiliation Record Type Enforced is enabled in EDA Settings
@@ -882,17 +1256,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWAPINamesForAccRecType() {
-
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
-
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic_Program', Primary_Affl_Field__c = 'Primary Academic Program', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'HH_Account', Primary_Affl_Field__c = 'Primary Household'));
-            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational_Institution', Primary_Affl_Field__c = 'Primary Educational Institution'));
-            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University_Department', Primary_Affl_Field__c = 'Primary Department'));
-            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports_Organization', Primary_Affl_Field__c = 'Primary Sports Organization'));
-        insert mappings;
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
+        AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
         insert testAccounts;
@@ -913,12 +1278,12 @@ public with sharing class AFFL_MultiRecordType_TEST {
             List<Contact> contactsInserted = [SELECT Id FROM Contact];
             System.assertEquals(contactsInserted.size(), 4);
 
-            // Ensure only 1 affilation is created for testContact
+            // Ensure only 1 affiliation is created for testContact
             List<Affiliation__c> affiliationsBeforeInserted = [SELECT Id, Contact__c FROM Affiliation__c];
             System.assertEquals(1, affiliationsBeforeInserted.size());
             System.assertEquals(testContact.Id, affiliationsBeforeInserted[0].Contact__c);
 
-            // Create 1 affilaiton each for a Contact
+            // Create 1 affiliaton each for a Contact
             List<Affiliation__c> affiliationsToBeInserted = new List<Affiliation__c>();
             for (Contact each: contactsInserted) {
                 Affiliation__c affl = UTIL_UnitTestData_TEST.getAffiliation(each.Id, accountsInserted[0].Id, False);
@@ -938,17 +1303,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWLabelsForAccRecType() {
-
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
-
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Academic Program', Account_Record_Type__c = 'Academic Program', Primary_Affl_Field__c = 'Primary Academic Program', Auto_Program_Enrollment__c = true, Auto_Program_Enrollment_Status__c = 'Current', Auto_Program_Enrollment_Role__c = 'Student'));
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = 'Primary Business Organization'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
-            mappings.add(new Affl_Mappings__c(Name = 'Educational Institution', Account_Record_Type__c = 'Educational Institution', Primary_Affl_Field__c = 'Primary Educational Institution'));
-            mappings.add(new Affl_Mappings__c(Name = 'University Department', Account_Record_Type__c = 'University Department', Primary_Affl_Field__c = 'Primary Department'));
-            mappings.add(new Affl_Mappings__c(Name = 'Sports Organization', Account_Record_Type__c = 'Sports Organization', Primary_Affl_Field__c = 'Primary Sports Organization'));
-        insert mappings;
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
+        AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
         insert testAccounts;
@@ -969,7 +1325,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
             List<Contact> contactsInserted = [SELECT Id FROM Contact];
             System.assertEquals(contactsInserted.size(), 4);
 
-            // Ensure only 1 affilation is created for testContact
+            // Ensure only 1 affiliation is created for testContact
             List<Affiliation__c> affiliationsBeforeInserted = [SELECT Id, Contact__c FROM Affiliation__c];
             System.assertEquals(1, affiliationsBeforeInserted.size());
             System.assertEquals(testContact.Id, affiliationsBeforeInserted[0].Contact__c);
@@ -995,16 +1351,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWAPINamesForAccRecTypeAndPrimaryAffl() {
-
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business_Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'HH_Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
-        insert mappings;
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndApiName();
+        AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
         insert testAccounts;
@@ -1025,7 +1373,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
             List<Contact> contactsInserted = [SELECT Id FROM Contact];
             System.assertEquals(contactsInserted.size(), 4);
 
-            // Ensure only 1 affilation is created for testContact
+            // Ensure only 1 affiliation is created for testContact
             List<Affiliation__c> affiliationsBeforeInserted = [SELECT Id, Contact__c FROM Affiliation__c];
             System.assertEquals(1, affiliationsBeforeInserted.size());
             System.assertEquals(testContact.Id, affiliationsBeforeInserted[0].Contact__c);
@@ -1050,16 +1398,8 @@ public with sharing class AFFL_MultiRecordType_TEST {
 
     @isTest
     private static void affiliationRecordTypeEnforceWLabelsForAccRecTypeAndAPIForPrimaryAffl() {
-
-        UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Affiliation_Record_Type_Enforced__c = true));
-
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-        
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
-        insert mappings;
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
+        AFFL_MultiRecordType_TEST.enableAffiliationRecordTypeEnforcement();
 
         List<Account> testAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(1, UTIL_Describe.getBizAccRecTypeID());
         insert testAccounts;
@@ -1080,7 +1420,7 @@ public with sharing class AFFL_MultiRecordType_TEST {
             List<Contact> contactsInserted = [SELECT Id FROM Contact];
             System.assertEquals(contactsInserted.size(), 4);
 
-            // Ensure only 1 affilation is created for testContact
+            // Ensure only 1 affiliation is created for testContact
             List<Affiliation__c> affiliationsBeforeInserted = [SELECT Id, Contact__c FROM Affiliation__c];
             System.assertEquals(1, affiliationsBeforeInserted.size());
             System.assertEquals(testContact.Id, affiliationsBeforeInserted[0].Contact__c);
@@ -1103,188 +1443,194 @@ public with sharing class AFFL_MultiRecordType_TEST {
     // This method tests getValidAccRecordTypesInMappings() of AFFL_MultiRecordTypeMapper class by passing Record Names Labels from affiliation mappings
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithLabels() {
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
 
-       // Construct a list of Account Record Type Labels 
-       List<String> accRecTypeLabels = new List<String>();
-           accRecTypeLabels.add('Academic Program');
-           accRecTypeLabels.add('Educational Institution');
-           accRecTypeLabels.add('Business Organization');
-           accRecTypeLabels.add('Household Account');
-           accRecTypeLabels.add('University Department');
-           accRecTypeLabels.add('Sports Organization');
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.getAfflMappingWrapperByNameAndLabel();
+
+        affiliationMappingWrapperList = AFFL_MultiRecordType_TEST.populateRecordTypeNamesForWrappers(
+            affiliationMappingWrapperList
+        );
+
+        List<String> accRecTypeLabelList = new List<String>();
+        for(AffiliationMappingWrapper affiliationMappingWrapper : affiliationMappingWrapperList) {
+            accRecTypeLabelList.add(affiliationMappingWrapper.getAccountRecordTypeName());
+        }
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-           List<String> matchingRecordTypes = afflMapper.getValidAccRecordTypesInMappings(accRecTypeLabels);
+           List<String> matchingRecordTypeList = afflMapper.getValidAccRecordTypesInMappings(accRecTypeLabelList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(6, matchingRecordTypes.size());
+        // Ensure List has all mappings
+        System.assertEquals(accRecTypeLabelList.size(), matchingRecordTypeList.size());
 
     }
 
     // This method tests getValidAccRecordTypesInMappings() of AFFL_MultiRecordTypeMapper class by passing Record Names list from affiliation mappings
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithAPIs() {
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByDevNameAndLabel();
 
         // Construct a list of Account Record Type Names
-        List<String> accRecTypeLabels = new List<String>();
-           accRecTypeLabels.add('Academic_Program');
-           accRecTypeLabels.add('Educational_Institution');
-           accRecTypeLabels.add('Business_Organization');
-           accRecTypeLabels.add('HH_Account');
-           accRecTypeLabels.add('University_Department');
-           accRecTypeLabels.add('Sports_Organization');
+        List<String> accRecTypeDevNameList = new List<String>();
+        for(AffiliationMappingWrapper affiliationMappingWrapper : affiliationMappingWrapperList) {
+            accRecTypeDevNameList.add(affiliationMappingWrapper.getAccountRecordTypeDeveloperName());
+        }
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-           List<String> matchingRecordTypes = afflMapper.getValidAccRecordTypesInMappings(accRecTypeLabels);
+           List<String> matchingRecordTypeList = afflMapper.getValidAccRecordTypesInMappings(accRecTypeDevNameList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(6, matchingRecordTypes.size());
+        // Ensure List has all mappings
+        System.assertEquals(affiliationMappingWrapperList.size(), matchingRecordTypeList.size());
 
     }
 
     /* This method tests getValidAccRecordTypesInMappings() of AFFL_MultiRecordTypeMapper class by passing 
      both Record type Names and Labels list from affiliation mappings */
-
     @isTest
     private static void testGetValidAccRecordTypesInMappingsMethodwithAPIAndLabels() {
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
 
         // Construct a list of Account Record Type Names and Labels
-        List<String> accRecTypeLabels = new List<String>();
-           accRecTypeLabels.add('Academic Program');
-           accRecTypeLabels.add('Educational Institution');
-           accRecTypeLabels.add('Business Organization');
-           accRecTypeLabels.add('HH_Account');
-           accRecTypeLabels.add('University_Department');
-           accRecTypeLabels.add('Sports_Organization');
+        List<String> accRecTypeLabelList = new List<String>();
+
+        for(AffiliationMappingWrapper affiliationMappingWrapper : affiliationMappingWrapperList) {
+            accRecTypeLabelList.add( affiliationMappingWrapper.getAccountRecordTypeName() );
+        }
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-           List<String> matchingRecordTypes = afflMapper.getValidAccRecordTypesInMappings(accRecTypeLabels);
+           List<String> matchingRecordTypeList = afflMapper.getValidAccRecordTypesInMappings(accRecTypeLabelList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(6, matchingRecordTypes.size());
+        // Ensure List has all mappings
+        System.assertEquals(affiliationMappingWrapperList.size(), matchingRecordTypeList.size());
 
     }
 
     /* This method tests getValidPrimaryAfflFields() of AFFL_MultiRecordTypeMapper class by passing 
      both API names for Primary Affiliation Fields */
-
     @isTest
     private static void testsGetValidPrimaryAfflFields() {
+        List<AffiliationMappingWrapper> affiliationMappingWrapperList =
+            AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndApiName();
 
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-        
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = prefix + 'Primary_Household__c'));
-        insert mappings;
-
-        List<Affl_Mappings__c> allMappings = [SELECT ID from Affl_Mappings__c];
-        System.assertEquals(2, allMappings.size());
+        List<Affl_Mappings__c> allMappings = [SELECT ID FROM Affl_Mappings__c];
+        System.assertEquals(affiliationMappingWrapperList.size(), allMappings.size());
 
         // Construct a list of primary Affiliation field API Names
-        List<String> primaryFieldsList = new List<String>();
-           primaryFieldsList.add(prefix + 'Primary_Organization__c');
-           primaryFieldsList.add(prefix + 'Primary_Household__c');
+        List<String> primaryFieldsList =
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
            List<String> validPrimaryFieldList = afflMapper.getValidPrimaryAfflFields(primaryFieldsList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(2, validPrimaryFieldList.size());
+        // Ensure List has both mappings
+        System.assertEquals(affiliationMappingWrapperList.size(), validPrimaryFieldList.size());
 
     }
 
     /* This method tests getValidprimaryAfflFields() of AFFL_MultiRecordTypeMapper class by passing 
       labels for Primary Affiliation Fields */
-
     @isTest
     private static void testsGetValidPrimaryAfflFieldsWithLabels() {
-
         // Construct a list of primary Affiliation field Labels
-        List<String> primaryFieldsList = new List<String>();
-           primaryFieldsList.add('Primary Academic Program');
-           primaryFieldsList.add('Primary Educational Institution');
-           primaryFieldsList.add('Primary Business Organization');
-           primaryFieldsList.add('Primary Household');
-           primaryFieldsList.add('Primary Department');
-           primaryFieldsList.add('Primary Sports Organization');
+        List<String> primaryFieldsList =
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
 
         Test.startTest();
            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
            List<String> validPrimaryFieldList = afflMapper.getValidPrimaryAfflFields(primaryFieldsList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(6, validPrimaryFieldList.size());
-
+        // Ensure List has all mappings
+        System.assertEquals(primaryFieldsList.size(), validPrimaryFieldList.size());
     }
 
     /* This method tests getValidPrimaryAfflFields() of AFFL_MultiRecordTypeMapper class by passing 
     both label and API names for Primary Affiliation Fields */
-
     @isTest
     private static void testsGetValidPrimaryAfflFieldsWithLabelsAndAPI() {
-        
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
+        //Note custom setup
+        AFFL_MultiRecordType_TEST.initializeAccountRecordTypeIds();
 
-        List<Affl_Mappings__c> mappings = new List<Affl_Mappings__c>();
-            mappings.add(new Affl_Mappings__c(Name = 'Business Organization', Account_Record_Type__c = 'Business Organization', Primary_Affl_Field__c = prefix + 'Primary_Organization__c'));
-            mappings.add(new Affl_Mappings__c(Name = 'Household Account', Account_Record_Type__c = 'Household Account', Primary_Affl_Field__c = 'Primary Household'));
-        insert mappings;
+        List<AffiliationMappingWrapper> wrapperList =
+            new List<AffiliationMappingWrapper>();
+
+        List<String> contactPrimaryAffiliationFieldApiNameList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldApiNames();
+        List<String> contactPrimaryAffiliationFieldLabelList = 
+            AFFL_MultiRecordType_TEST.getContactPrimaryAffiliationFieldLabels();
+        String bizOrgContactFieldApiName =
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
+        String householdContactFieldLabel =
+            AFFL_MultiRecordType_TEST.getHouseholdFieldLabel();
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndApiName(
+                AFFL_MultiRecordType_TEST.householdRecTypeID,
+                contactPrimaryAffiliationFieldApiNameList[0]
+            )
+        );
+
+        wrapperList.add(
+            new AfflMappingWrapperByNameAndLabel(
+                AFFL_MultiRecordType_TEST.orgRecTypeID,
+                contactPrimaryAffiliationFieldLabelList[1]
+            )
+        );
+
+        wrapperList = AFFL_MultiRecordType_TEST.setupAndGetMappings(wrapperList);
+        //Custom setup ended
         
-        List<Affl_Mappings__c> allMappings = [SELECT ID from Affl_Mappings__c];
-        System.assertEquals(2, allMappings.size());
+        List<Affl_Mappings__c> allMappings = [SELECT Id from Affl_Mappings__c];
+        System.assertEquals(wrapperList.size(), allMappings.size());
 
         // Construct a list of primary Affiliation field Labels and API names
         List<String> primaryFieldsList = new List<String>();
-           primaryFieldsList.add(prefix + 'Primary_Organization__c');
-           primaryFieldsList.add('Primary Household');
+        primaryFieldsList.add(bizOrgContactFieldApiName);
+        primaryFieldsList.add(householdContactFieldLabel);
 
         Test.startTest();
-           AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-           List<String> validPrimaryFieldList = afflMapper.getValidPrimaryAfflFields(primaryFieldsList);
+            AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
+            List<String> validPrimaryFieldList = afflMapper.getValidPrimaryAfflFields(primaryFieldsList);
         Test.stopTest();
 
-        // Ensure List has all 6 mappings
-        System.assertEquals(2, validPrimaryFieldList.size());
+        // Ensure List has all mappings
+        System.assertEquals(wrapperList.size(), validPrimaryFieldList.size());
 
     }
     
     // Positive test for getPrimaryAffiliationLookupAPI method of AFFL_MultiRecordTypeMapper using API name
     @isTest
     private static void getPrimaryAffiliationLookupAPIPoitiveAPITest() {
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
-        AFFL_MultiRecordType_TEST.setup();
-        
-        String namespace = UTIL_Namespace.getNamespace();
-        String prefix = (String.isNotBlank(namespace)) ? namespace + '__' : '';
-        String lookupAPI = prefix + 'Primary_Organization__c';
+        String bizOrgContactFieldApiName =
+            AFFL_MultiRecordType_TEST.getBusinessOrganizationFieldApiName();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
-            String primaryAfflLookupAPIName = afflMapper.getPrimaryAffiliationLookupAPI(lookupAPI);
+            String primaryAfflLookupAPIName =
+                afflMapper.getPrimaryAffiliationLookupAPI(bizOrgContactFieldApiName);
         Test.stopTest();
 
         
-        System.assertEquals(prefix + 'Primary_Organization__c', primaryAfflLookupAPIName);
-       
+        System.assertEquals(bizOrgContactFieldApiName, primaryAfflLookupAPIName);
     }
     
     // Negative test for getPrimaryAffiliationLookupAPI method of AFFL_MultiRecordTypeMapper
     @isTest
     private static void getPrimaryAffiliationLookupAPINegativeTest() {
 
-        AFFL_MultiRecordType_TEST.setup();
+        AFFL_MultiRecordType_TEST.setupAndGetMappingsByNameAndLabel();
 
         Test.startTest();
             AFFL_MultiRecordTypeMapper afflMapper = new AFFL_MultiRecordTypeMapper();
@@ -1292,7 +1638,201 @@ public with sharing class AFFL_MultiRecordType_TEST {
         Test.stopTest();
 
         System.assertEquals(null, primaryAfflLookupAPIName);
-       
+
     }
 
+/**************************************************************************
+* INNER CLASS MODELS
+**************************************************************************/
+
+private abstract class AffiliationMappingWrapper {
+    Id accountRecordTypeId;
+    String accountRecordTypeDeveloperName;
+    String accountRecordTypeName;
+    Affl_Mappings__c affiliationMapping;
+    String contactFieldApiName;
+    String contactFieldLabel;
+
+    /**************************************************************************
+    * @description Gets the account record type Id for the mapping
+    * @return The account record type Id for the mapping
+    **************************************************************************/
+    public Id getAccountRecordTypeId() {
+        return this.accountRecordTypeId;
+    }
+
+    /**************************************************************************
+    * @description Gets the underlying affiliation mapping
+    * @return The underlying affiliation mapping
+    **************************************************************************/
+    public Affl_Mappings__c getAffiliationMapping() {
+        return this.affiliationMapping;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type developer name for the mapping
+    * @return The account record type developer name for the mapping
+    **************************************************************************/
+    public String getAccountRecordTypeDeveloperName() {
+        return this.accountRecordTypeDeveloperName;
+    }
+
+    /**************************************************************************
+    * @description Gets the account record type name for the mapping
+    * @return The account record type name for the mapping
+    **************************************************************************/
+    public String getAccountRecordTypeName() {
+        return this.accountRecordTypeName;
+    }
+
+    /**************************************************************************
+    * @description Sets the account record type name for the mapping
+    * @param accountRecordTypeName the new account record type name for the
+    * mapping
+    **************************************************************************/
+    public void setAccountRecordTypeName(String accountRecordTypeName) {
+        this.accountRecordTypeName = accountRecordTypeName;
+    }
+
+    /**************************************************************************
+    * @description Gets the contact field label for the mapping
+    * @return The contact field label for the mapping
+    **************************************************************************/
+    public String getContactFieldLabel() {
+        return this.contactFieldLabel;
+    }
+
+    /**************************************************************************
+    * @description Sets the record name from its id and the map of account
+    * record type infos
+    **************************************************************************/
+    public void setRecordTypeNamesFromId(Map<Id, Schema.RecordTypeInfo> accountRecordTypeInfosByIds) {
+        if( String.isBlank( this.getAccountRecordTypeId() ) ) {
+            return;
+        }
+
+        this.accountRecordTypeName =
+            accountRecordTypeInfosByIds.get(this.accountRecordTypeId).getName();
+        this.accountRecordTypeDeveloperName =
+            accountRecordTypeInfosByIds.get(this.accountRecordTypeId).getDeveloperName();
+    }
+
+    public virtual void setAffiliationMapping() {}
+}
+
+    private class AfflMappingWrapperByDevNameAndApiName extends AffiliationMappingWrapper {
+        /**************************************************************************
+        * @description Creates a mapping wrapper using contact field api name,
+        * account record type developer name, and account record type Id
+        * @param accountRecordTypeId The record type id to use for the
+        * mapping
+        * @param contactFieldApiName The api name of the contact field to use for
+        * the mapping
+        **************************************************************************/
+        public AfflMappingWrapperByDevNameAndApiName(
+            Id accountRecordTypeId,
+            String contactFieldApiName
+        ) {
+            this.accountRecordTypeId = accountRecordTypeId;
+            this.contactFieldApiName = contactFieldApiName;
+        }
+        /**************************************************************************
+        * @description Sets the wrapper's mapping to one created by account name
+        * and contact field label.
+        **************************************************************************/
+        public override void setAffiliationMapping() {
+            this.affiliationMapping = new Affl_Mappings__c(
+                Name = this.accountRecordTypeName,
+                Account_Record_Type__c = this.accountRecordTypeDeveloperName,
+                Primary_Affl_Field__c = this.contactFieldApiName
+            );
+        }
+    }
+
+    private class AfflMappingWrapperByDevNameAndLabel extends AffiliationMappingWrapper {
+        /**************************************************************************
+        * @description Creates a mapping wrapper using contact field label, account
+        * record type developer name, and account record type Id
+        * @param accountRecordTypeId The record type id to use for the
+        * mapping
+        * @param contactFieldLabel The label of the contact field to use for the
+        * mapping
+        **************************************************************************/
+        public AfflMappingWrapperByDevNameAndLabel(
+            Id accountRecordTypeId,
+            String contactFieldLabel
+        ) {
+            this.accountRecordTypeId = accountRecordTypeId;
+            this.contactFieldLabel = contactFieldLabel;
+        }
+        /**************************************************************************
+        * @description Sets the wrapper's mapping to one created by account name
+        * and contact field label.
+        **************************************************************************/
+        public override void setAffiliationMapping() {
+            this.affiliationMapping = new Affl_Mappings__c(
+                Name = this.accountRecordTypeName,
+                Account_Record_Type__c = this.accountRecordTypeDeveloperName,
+                Primary_Affl_Field__c = this.contactFieldLabel
+            );
+        }
+    }
+
+    private class AfflMappingWrapperByNameAndApiName extends AffiliationMappingWrapper {
+        /**************************************************************************
+        * @description Creates a mapping wrapper using contact field api name,
+        * account record type name, and account record type Id
+        * @param accountRecordTypeId The record type id to use for the
+        * mapping
+        * @param contactFieldApiName The api name of the contact field to use for
+        * the mapping
+        **************************************************************************/
+        public AfflMappingWrapperByNameAndApiName(
+            Id accountRecordTypeId,
+            String contactFieldApiName
+        ) {
+            this.accountRecordTypeId = accountRecordTypeId;
+            this.contactFieldApiName = contactFieldApiName;
+        }
+        /**************************************************************************
+        * @description Sets the wrapper's mapping to one created by account name
+        * and contact field label.
+        **************************************************************************/
+        public override void setAffiliationMapping() {
+            this.affiliationMapping = new Affl_Mappings__c(
+                Name = this.accountRecordTypeName,
+                Account_Record_Type__c = this.accountRecordTypeName,
+                Primary_Affl_Field__c = this.contactFieldApiName
+            );
+        }
+    }
+
+    private class AfflMappingWrapperByNameAndLabel extends AffiliationMappingWrapper {
+        /**************************************************************************
+        * @description Creates a mapping wrapper using contact field label, account
+        * record type name, and account record type Id
+        * @param accountRecordTypeId The record type id to use for the
+        * mapping
+        * @param contactFieldLabel The label of the contact field to use for the
+        * mapping
+        **************************************************************************/
+        public AfflMappingWrapperByNameAndLabel(
+            Id accountRecordTypeId,
+            String contactFieldLabel
+        ) {
+            this.accountRecordTypeId = accountRecordTypeId;
+            this.contactFieldLabel = contactFieldLabel;
+        }
+        /**************************************************************************
+        * @description Sets the wrapper's mapping to one created by account name
+        * and contact field label.
+        **************************************************************************/
+        public override void setAffiliationMapping() {
+            this.affiliationMapping = new Affl_Mappings__c(
+                Name = this.accountRecordTypeName,
+                Account_Record_Type__c = this.accountRecordTypeName,
+                Primary_Affl_Field__c = this.contactFieldLabel
+            );
+        }
+    }
 }

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -574,6 +574,7 @@ public class UTIL_Describe {
     * Object name as the key and Map as the value. The value Map is the RecordType Developer Name to
     * RecordType Id
     */
+    @testVisible
     private static Map<String, Map<String, Id>> mapRecordTypes = new Map<String, Map<String, Id>>();
 
     /*******************************************************************************************************


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
Updated AFFL_MultiRecordType_TEST to prevent build failures. Unit tests running and a successful build will likely be a sufficient test. No customer impact as this hasn't hit them yet.