### PR TITLE
[EDA] Add Application Created Date field on Application Object

### DIFF
--- a/src/layouts/Application__c-EDA Application Layout.layout
+++ b/src/layouts/Application__c-EDA Application Layout.layout
@@ -38,6 +38,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Initial_Creation_Date__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Application_Date__c</field>
             </layoutItems>
             <layoutItems>

--- a/src/objectTranslations/Application__c-ca.objectTranslation
+++ b/src/objectTranslations/Application__c-ca.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-ca.objectTranslation
+++ b/src/objectTranslations/Application__c-ca.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objectTranslations/Application__c-en_GB.objectTranslation
+++ b/src/objectTranslations/Application__c-en_GB.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-en_GB.objectTranslation
+++ b/src/objectTranslations/Application__c-en_GB.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objectTranslations/Application__c-en_US.objectTranslation
+++ b/src/objectTranslations/Application__c-en_US.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-en_US.objectTranslation
+++ b/src/objectTranslations/Application__c-en_US.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objectTranslations/Application__c-es.objectTranslation
+++ b/src/objectTranslations/Application__c-es.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-es.objectTranslation
+++ b/src/objectTranslations/Application__c-es.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objectTranslations/Application__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Application__c-es_MX.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-es_MX.objectTranslation
+++ b/src/objectTranslations/Application__c-es_MX.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objectTranslations/Application__c-fr.objectTranslation
+++ b/src/objectTranslations/Application__c-fr.objectTranslation
@@ -102,6 +102,7 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <help><!-- The date the application was initially created by the applicant. --></help>
         <label><!-- Initial Creation Date --></label>
         <name>Initial_Creation_Date__c</name>
     </fields>

--- a/src/objectTranslations/Application__c-fr.objectTranslation
+++ b/src/objectTranslations/Application__c-fr.objectTranslation
@@ -102,6 +102,10 @@
         <relationshipLabel><!-- Applications --></relationshipLabel>
     </fields>
     <fields>
+        <label><!-- Initial Creation Date --></label>
+        <name>Initial_Creation_Date__c</name>
+    </fields>
+    <fields>
         <help><!-- The Contact preparing the application. For example, a guardian or a person assisting someone with special needs. --></help>
         <label><!-- Preparer --></label>
         <name>Preparer__c</name>

--- a/src/objects/Application__c.object
+++ b/src/objects/Application__c.object
@@ -221,6 +221,7 @@
     <fields>
         <fullName>Initial_Creation_Date__c</fullName>
         <description>The date the application was initially created by the applicant.</description>
+        <inlineHelpText>The date the application was initially created by the applicant.</inlineHelpText>
         <externalId>false</externalId>
         <label>Initial Creation Date</label>
         <required>false</required>

--- a/src/objects/Application__c.object
+++ b/src/objects/Application__c.object
@@ -219,6 +219,16 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>Initial_Creation_Date__c</fullName>
+        <description>The date the application was initially created by the applicant.</description>
+        <externalId>false</externalId>
+        <label>Initial Creation Date</label>
+        <required>false</required>
+        <trackHistory>false</trackHistory>
+        <trackTrending>false</trackTrending>
+        <type>Date</type>
+    </fields>
+    <fields>
         <fullName>Preparer__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <description>The Contact preparing the application, often a guardian.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -321,6 +321,7 @@
         <members>Application__c.Application_Status__c</members>
         <members>Application__c.Application_Type__c</members>
         <members>Application__c.Applying_To__c</members>
+        <members>Application__c.Initial_Creation_Date__c</members>
         <members>Application__c.Preparer__c</members>
         <members>Application__c.Term__c</members>
         <members>Attendance_Event__c.Arrival_Time__c</members>


### PR DESCRIPTION
# Critical Changes

# Changes
We've added a new field "Initial Creation Date" on "Application" object.

For new installations, the "Initial Creation Date" field is automatically added to the Application Page Layout. If you installed an earlier EDA release, manually add the new fields to the listed page layout, as needed. Learn how to [Display a New Custom Object After a Product Release](https://powerofus.force.com/s/article/EDA-Display-Cust-Obj-Post-Rel).

# Issues Closed
Closes #1268 

# New Metadata
Application__c.Initial_Creation_Date__c

# Deleted Metadata

# Testing Notes
