### PR TITLE
[EDA] Add Decline to State as picklist option for Gender

### DIFF
--- a/src/objectTranslations/Contact-ca.objectTranslation
+++ b/src/objectTranslations/Contact-ca.objectTranslation
@@ -3470,6 +3470,10 @@
         <label>Sexe</label>
         <name>Gender__c</name>
         <picklistValues>
+            <masterLabel>Decline to State</masterLabel>
+            <translation><!-- Decline to State --></translation>
+        </picklistValues>
+        <picklistValues>
             <masterLabel>Female</masterLabel>
             <translation>Dona</translation>
         </picklistValues>

--- a/src/objectTranslations/Contact-en_GB.objectTranslation
+++ b/src/objectTranslations/Contact-en_GB.objectTranslation
@@ -3470,6 +3470,10 @@
         <label>Gender</label>
         <name>Gender__c</name>
         <picklistValues>
+            <masterLabel>Decline to State</masterLabel>
+            <translation><!-- Decline to State --></translation>
+        </picklistValues>
+        <picklistValues>
             <masterLabel>Female</masterLabel>
             <translation>Female</translation>
         </picklistValues>

--- a/src/objectTranslations/Contact-es.objectTranslation
+++ b/src/objectTranslations/Contact-es.objectTranslation
@@ -3470,6 +3470,10 @@
         <label>Género</label>
         <name>Gender__c</name>
         <picklistValues>
+            <masterLabel>Decline to State</masterLabel>
+            <translation><!-- Decline to State --></translation>
+        </picklistValues>
+        <picklistValues>
             <masterLabel>Female</masterLabel>
             <translation>Femenino</translation>
         </picklistValues>

--- a/src/objectTranslations/Contact-es_MX.objectTranslation
+++ b/src/objectTranslations/Contact-es_MX.objectTranslation
@@ -3470,6 +3470,10 @@
         <label>Género</label>
         <name>Gender__c</name>
         <picklistValues>
+            <masterLabel>Decline to State</masterLabel>
+            <translation><!-- Decline to State --></translation>
+        </picklistValues>
+        <picklistValues>
             <masterLabel>Female</masterLabel>
             <translation>Femenino</translation>
         </picklistValues>

--- a/src/objectTranslations/Contact-fr.objectTranslation
+++ b/src/objectTranslations/Contact-fr.objectTranslation
@@ -3470,6 +3470,10 @@
         <label>Sexe</label>
         <name>Gender__c</name>
         <picklistValues>
+            <masterLabel>Decline to State</masterLabel>
+            <translation><!-- Decline to State --></translation>
+        </picklistValues>
+        <picklistValues>
             <masterLabel>Female</masterLabel>
             <translation>Féminin</translation>
         </picklistValues>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -4478,6 +4478,11 @@
                     <default>false</default>
                     <label>Male</label>
                 </value>
+                <value>
+                    <fullName>Decline to State</fullName>
+                    <default>false</default>
+                    <label>Decline to State</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>


### PR DESCRIPTION
# Critical Changes

# Changes
We've added a new picklist value, "Decline to State," to the "Gender" field on Contact. For new EDA installations, the new picklist values are automatically added to Contact. If your organization has an existing EDA installation, manually add "Decline to State" as a new picklist value to the "Gender" field. For information, check out [Add Custom Fields and Picklist Values](https://powerofus.force.com/s/article/EDA-Add-Custom-Picklist-Values).

# Issues Closed
Closes #1293 

# New Metadata
- New picklist value: "Decline to State"

# Deleted Metadata

# Testing Notes
