### PR TITLE
moving the calls to insertContactAccount inside the AfterInsert and A…

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -314,13 +314,13 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     private void handleInsertProcessing(HandleInsertWrapperLogic insertWrapper, List<Contact> contactsNeedAccounts) {
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        //Creates new Account
-        if (contactsNeedAccounts.size() > 0) {
-            UTIL_Debug.debug('****Number of Contacts that need Accounts created: ' + contactsNeedAccounts.size());
-            insertContactAccount(contactsNeedAccounts, dmlWrapper);
-        }
-
         if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+
+            //Creates new Account
+            if (contactsNeedAccounts.size() > 0) {
+                UTIL_Debug.debug('****Number of Contacts that need Accounts created: ' + contactsNeedAccounts.size());
+                insertContactAccount(contactsNeedAccounts, dmlWrapper);
+            }
 
             //Updates the Primary Contact Field on New Account
             if (insertWrapper.accIdConIdToUpdate.size() > 0) {
@@ -431,14 +431,14 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         DmlWrapper dmlWrapper = new DmlWrapper();
         Map<Id, sObject> idToSObjectTobeUpdated = new Map<Id, sObject>();
         List<sObject> duplicateOccurence = new List<sObject>();
-		
-        //Creates new Account
-        if (contactsNeedAccounts.size() > 0) {
-            UTIL_Debug.debug('****Number of Contacts that need Accounts created: ' + contactsNeedAccounts.size());
-            insertContactAccount(contactsNeedAccounts, dmlWrapper);
-        }
 
         if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+
+            //Creates new Account
+            if (contactsNeedAccounts.size() > 0) {
+                UTIL_Debug.debug('****Number of Contacts that need Accounts created: ' + contactsNeedAccounts.size());
+                insertContactAccount(contactsNeedAccounts, dmlWrapper);
+            }
 
             //Updates Household Account name
             if (updateWrapper.accountIdsToRename.size() > 0) {

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -39,63 +39,63 @@ private class TDTM_DMLgt200_TEST {
     /*********************************************************************************************************
     * NOTE - Temporarily disabled due to CPU timeout issues that prevent build.
     */
-	
-	static Integer inputSize = 250;
+    
+    static Integer inputSize = 250;
 
     /*********************************************************************************************************
     * @description Test Method for inserting large amounts of Contacts
     */
-	@isTest
+    @isTest
     static void testInsertContact() {
-        return;/*
+
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
-		// test data set up
-		List<Contact> testContacts = new List<Contact>();
-		for (Integer i = 0; i < inputSize; i++)
-		{
-			Contact testContact = new Contact(LastName = 'testLastName ' + i);
-			testContacts.add(testContact);
-		}
-		insert testContacts;
+        // test data set up
+        List<Contact> testContacts = new List<Contact>();
+        for (Integer i = 0; i < inputSize; i++)
+        {
+            Contact testContact = new Contact(LastName = 'testLastName ' + i);
+            testContacts.add(testContact);
+        }
+        insert testContacts;
 
-		//assert
-		List<Account> assertAccounts = [SELECT Id FROM Account];
-		system.assertEquals(inputSize, assertAccounts.size());*/
-	}
+        //assert
+        List<Account> assertAccounts = [SELECT Id FROM Account];
+        system.assertEquals(inputSize, assertAccounts.size());
+    }
 
     /*********************************************************************************************************
     * @description Test Method for inserting and updating large amounts of Contact
     */
     @isTest
     public static void insertUpdateContact() {
-        return; /*
+
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
         String newContactMailingStreet = '123 Elm St';
-		List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
-		for (Integer i = 0; i < inputSize; i++) {
+        List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
+        for (Integer i = 0; i < inputSize; i++) {
             testContacts[i].OtherCity = null;
             testContacts[i].MailingStreet = newContactMailingStreet;
         }
         insert testContacts;
 
         List<Contact> insertedContacts = [SELECT FirstName, LastName, AccountId, Account.Name, Account.Primary_Contact__c, WorkEmail__c, WorkPhone__c, Email, Phone
-        							    	FROM Contact];
+                                            FROM Contact];
 
         //many contacts should have been created
         system.assertEquals(inputSize, insertedContacts.size());
 
         //relationship should be bi-directional
         for (Contact con : insertedContacts) {
-	        system.assertEquals(con.id, con.Account.Primary_Contact__c);
+            system.assertEquals(con.id, con.Account.Primary_Contact__c);
             system.assertEquals(con.WorkEmail__c, con.Email);
             system.assertEquals(con.WorkPhone__c, con.Phone);
 
             con.LastName = 'Contact_forTestsChange';
-        	con.OtherCity = 'Seattle';  
+            con.OtherCity = 'Seattle';  
         }
         update insertedContacts;
 
@@ -104,25 +104,24 @@ private class TDTM_DMLgt200_TEST {
 
         //relationship should be bi-directional
         for (Contact con : updatedContacts) {
-        	system.assertEquals(con.id, con.Account.Primary_Contact__c);
+            system.assertEquals(con.id, con.Account.Primary_Contact__c);
         }
         system.assertEquals(inputSize, updatedContacts.size());
-        */
-	}	
+    }
 
     /*********************************************************************************************************
     * @description Delete large amounts of Contacts and verify its parent Account is deleted.
     */
      @isTest
      public static void deleteContactNoOpps() {
-        return; /*
+        
          if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
          UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(
                     Account_Processor__c = UTIL_Describe_API.getAdminAccRecTypeID(),
                     Accounts_to_Delete__c = UTIL_Describe_API.getAdminAccRecTypeID()));
 
-		 List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
+         List<Contact> testContacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(inputSize);
          insert testContacts;
 
          List<Account> insertedAccounts = [Select Id from Account];
@@ -134,7 +133,7 @@ private class TDTM_DMLgt200_TEST {
 
          insertedAccounts = [Select Id from Account];
          System.assertEquals(0,insertedAccounts.size());
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -143,7 +142,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/            
     @isTest 
     public static void updateDefaultAddr() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -174,7 +173,7 @@ private class TDTM_DMLgt200_TEST {
             System.assert(acc.BillingCity.contains('New City'));
             System.assertNotEquals(null, acc.Current_Address__c);
         }
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -183,7 +182,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/            
     @isTest 
     static void deleteDefaultAddr() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -208,7 +207,7 @@ private class TDTM_DMLgt200_TEST {
             System.assertEquals(null, acc.BillingStreet);
             System.assertEquals(null, acc.BillingCity);
         }
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -217,7 +216,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/            
     @isTest
     static void deleteNonDefaultOverrideAddr() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -263,7 +262,7 @@ private class TDTM_DMLgt200_TEST {
             System.assert(acc.BillingCity.contains('City')); 
             System.assertNotEquals(null, acc.Current_Address__c);                
         }
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -272,7 +271,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void updateNonDefaultAddr() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -303,7 +302,7 @@ private class TDTM_DMLgt200_TEST {
             System.assertEquals(null, acc.BillingCity); //address information has been cleared because address is no longer the default
             System.assertEquals(null, acc.Current_Address__c); //account no longer has a current address, since address is no longer the defaults
         }
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -314,7 +313,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/            
     @isTest
     public static void insertNewDefaultAddr() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -364,12 +363,12 @@ private class TDTM_DMLgt200_TEST {
                System.assertEquals(System.today(), addr.Latest_End_Date__c);                
             }
         }        
-        */
+        
     }
 
-	@isTest
+    @isTest
     public static void noContactToAccPropagation() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         Hierarchy_Settings__c hs = new Hierarchy_Settings__c(
@@ -381,9 +380,9 @@ private class TDTM_DMLgt200_TEST {
         
         List<Contact> testContacts = new List<Contact>();
         for (Integer i = 0; i < inputSize; i++){
- 			Contact contact = new Contact(LastName = 'Testerson' + i, MailingStreet = '123 Main St', 
-        	MailingCity = 'Austin', MailingState = 'Texas', MailingPostalcode = '78701', MailingCountry = 'United States');
-        	testContacts.add(contact);       	
+             Contact contact = new Contact(LastName = 'Testerson' + i, MailingStreet = '123 Main St', 
+            MailingCity = 'Austin', MailingState = 'Texas', MailingPostalcode = '78701', MailingCountry = 'United States');
+            testContacts.add(contact);       	
         }
         Test.startTest();
         insert testContacts;
@@ -393,15 +392,15 @@ private class TDTM_DMLgt200_TEST {
         List<Contact> insertedContacts = [select AccountID from Contact];
         Set<Id> setInsertedContactsIds = new Set<Id>();
         for (Contact insertedContact : insertedContacts) {
-        	setInsertedContactsIds.add(insertedContact.Id);
-        	System.assertNotEquals(null, contact.AccountID);
+            setInsertedContactsIds.add(insertedContact.Id);
+            System.assertNotEquals(null, contact.AccountID);
         }
         
         //Verify child address record was created
         List<Address__c> addrs = [select Parent_Account__c from Address__c]; 
-		System.assertEquals(inputSize, addrs.size());
+        System.assertEquals(inputSize, addrs.size());
         for (Address__c addr : addrs){
-        	System.assertEquals(null, addr.Parent_Account__c);       	
+            System.assertEquals(null, addr.Parent_Account__c);       	
         }
 
         
@@ -413,14 +412,14 @@ private class TDTM_DMLgt200_TEST {
         List<Account> accs = [select BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry
                                 from Account];
         for (Account acc : accs) {
-			System.assertEquals(null, acc.BillingStreet);
-	        System.assertEquals(null, acc.BillingState);
-	        System.assertEquals(null, acc.BillingPostalCode);
-	        if (!ADDR_Addresses_UTIL.isStateCountryPickListsEnabled) {
-	            System.assertEquals(null, acc.BillingCountry);   
-	        }
+            System.assertEquals(null, acc.BillingStreet);
+            System.assertEquals(null, acc.BillingState);
+            System.assertEquals(null, acc.BillingPostalCode);
+            if (!ADDR_Addresses_UTIL.isStateCountryPickListsEnabled) {
+                System.assertEquals(null, acc.BillingCountry);   
+            }
         }
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -431,38 +430,38 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/    
     @isTest
     public static void changeContact() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
       
-    	  UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
+          UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
 
         Id orgRecTypeID = UTIL_Describe_API.getBizAccRecTypeID();
         Id householdRecTypeID = UTIL_Describe_API.getHhAccRecTypeID();
 
-    	Contact oldContact = new Contact(FirstName = 'Old', LastName = 'Testerson');
-    	insert oldContact;
+        Contact oldContact = new Contact(FirstName = 'Old', LastName = 'Testerson');
+        insert oldContact;
 
-    	List<Contact> newContacts = new List<Contact>();
-    	for (Integer i = 0; i < inputSize; i++) {
-    		Contact newContact = new Contact(FirstName = 'New' + i, LastName = 'Testerson');
-    		newContacts.add(newContact);
-    	}
-    	insert newContacts;
+        List<Contact> newContacts = new List<Contact>();
+        for (Integer i = 0; i < inputSize; i++) {
+            Contact newContact = new Contact(FirstName = 'New' + i, LastName = 'Testerson');
+            newContacts.add(newContact);
+        }
+        insert newContacts;
 
-		//Create accounts of Business Organization record type
+        //Create accounts of Business Organization record type
         Account bizOrg1 = new Account(Name='Acme', RecordTypeId = orgRecTypeID);
         insert bizOrg1;
 
         List<Affiliation__c> testAffls = new List<Affiliation__c>();
-    	for (Integer i = 0; i < inputSize; i++){
-    		Affiliation__c testAffl = new Affiliation__c(Contact__c = newContacts[i].ID, Account__c = bizOrg1.ID, Primary__c = true);
-    		testAffls.add(testAffl);
-    	}
-    	insert testAffls;
+        for (Integer i = 0; i < inputSize; i++){
+            Affiliation__c testAffl = new Affiliation__c(Contact__c = newContacts[i].ID, Account__c = bizOrg1.ID, Primary__c = true);
+            testAffls.add(testAffl);
+        }
+        insert testAffls;
 
         Test.startTest();
         for (Integer i = 0; i < inputSize; i++){
-        	testAffls[i].Contact__c = newContacts[i].Id;
+            testAffls[i].Contact__c = newContacts[i].Id;
         }
         update testAffls;
         Test.stopTest();
@@ -470,7 +469,7 @@ private class TDTM_DMLgt200_TEST {
         //Confirm Primary Business Organization field has been cleared in contact
         Contact contact = [select Primary_Organization__c from Contact where Id =:oldContact.Id];
         System.assertEquals(null, contact.Primary_Organization__c);
-        */
+        
     }
 
     /*********************************************************************************************************
@@ -480,7 +479,7 @@ private class TDTM_DMLgt200_TEST {
     **********************************************************************************************************/    
     @isTest
     public static void createContactsWithOrg() {
-        return; /*
+        
         if(Advancement_Info.useAdv()) return; //Exit if advancement product installed
 
         UTIL_CustomSettings_API.getSettingsForTests(new Hierarchy_Settings__c(Account_Processor__c = UTIL_Describe_API.getHhAccRecTypeID()));
@@ -514,6 +513,6 @@ private class TDTM_DMLgt200_TEST {
         for (Affiliation__c affl : affls) {
             System.assertEquals('Business Organization', affl.Affiliation_Type__c);
         }
-        */
+        
     }
 }


### PR DESCRIPTION
# Critical Changes

# Changes
- In IndividualAccounts_TDTM, we now prevent repeat insert and update calls, improving the Trigger Handler's performance and decreasing run time for bulk unit tests.
# Issues Closed
- Fixes: #1302 
# New Metadata

# Deleted Metadata

# Testing Notes
