### PR TITLE
adding labels for the Refresh Administrative|Household Account Names …

### DIFF
--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -11,9 +11,9 @@
     <aura:attribute name="adminOtherDisplay" type="Boolean" />
     <aura:attribute name="hhOtherDisplay" type="Boolean" />
     <aura:attribute name="adminAccNameFormatOptions" type="String[]"/>
-	<aura:attribute name="hhNameFormatOptions" type="String[]"/> 
+    <aura:attribute name="hhNameFormatOptions" type="String[]"/> 
     
-	<div aura:id="hhSuccessToast" id="hhSuccessToast" class="slds-hide">
+    <div aura:id="hhSuccessToast" id="hhSuccessToast" class="slds-hide">
         <div class="slds-box">
             <div class="slds-notify_container slds-notify_container--inline">
                 <div class="slds-notify slds-notify--toast slds-theme--success" role="alert">
@@ -26,8 +26,8 @@
                             <c:svgIcon name="success" category="utility" size="small" assistiveText="Close" pressIcon="{!c.closeToast}" containerClass="toast-icon" />
                         </div>
                          <div class="slds-col slds-align-middle slds-gutters">
-                        	<h2 class="slds-text-heading_small">{!$Label.c.stgSuccessHHAccountNameRefresh}</h2>
-                       	</div>
+                            <h2 class="slds-text-heading_small">{!$Label.c.stgSuccessHHAccountNameRefresh}</h2>
+                           </div>
 
                     </div>
                 </div>
@@ -48,8 +48,8 @@
                         </div>
 
                          <div class="slds-col slds-align-middle slds-gutters">
-                        	<h2 class="slds-text-heading_small">{!$Label.c.stgSuccessAdminAccountNameRefresh}</h2>
-                       	</div>
+                            <h2 class="slds-text-heading_small">{!$Label.c.stgSuccessAdminAccountNameRefresh}</h2>
+                           </div>
 
                     </div>
                 </div>
@@ -58,12 +58,12 @@
     </div>
 
     <div id="systemTabs" class="slds-tabs--scoped">
-		<div aura:id="settingsContent" class="slds-tabs__content" role="tabpanel">
-        	<div class="slds-col slds-grid slds-wrap slds-size--1-of-1 slds-m-top--medium">
+        <div aura:id="settingsContent" class="slds-tabs__content" role="tabpanel">
+            <div class="slds-col slds-grid slds-wrap slds-size--1-of-1 slds-m-top--medium">
 
                 <div class="slds-col slds-size--1-of-2">
-            		<ui:outputText value="{!$Label.c.stgAccModelTitle}" />
-        		</div>
+                    <ui:outputText value="{!$Label.c.stgAccModelTitle}" />
+                </div>
 
                 <div class="slds-col slds-size--1-of-2">
                     <c:CMP_RecTypes_Dropdown class="default-account-model-record-type"
@@ -252,19 +252,19 @@
                 <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium">
                     {!$Label.c.stgRefreshAdminAcctNameTitle}
                     <div class="slds-col slds-size--1-of-1">
-                    	<ui:outputText value="{!$Label.c.stgRefreshAdminAcctNameDesc}" class="slds-text-body--small" />
+                        <ui:outputText value="{!$Label.c.stgRefreshAdminAcctNameDesc}" class="slds-text-body--small" />
                     </div>
                 </div>
 
-              	<div class="slds-col slds-size--1-of-2">
-              		<lightning:button
+                  <div class="slds-col slds-size--1-of-2">
+                      <lightning:button
                                 disabled="{!!v.isView}"
-                        	    variant="brand"
-                    		    label="Refresh All Administrative Names"
-                        	    title="refreshButton"
-                        	    onclick="{! c.handleRefreshAdminAccount}"/>
+                                variant="brand"
+                                label="{!$Label.c.stgBtnRefreshAdminNames}"
+                                title="refreshButton"
+                                onclick="{! c.handleRefreshAdminAccount}"/>
 
-              	</div>
+                  </div>
 
                 <hr class="slds-border--top slds-m-top--medium slds-m-bottom--medium" style="width:100%;" />
                 
@@ -320,15 +320,15 @@
                 <div class="slds-col slds-size--1-of-2 slds-m-bottom--medium">
                     {!$Label.c.stgRefreshHHAcctNameTitle}
                     <div class="slds-col slds-size--1-of-1">
-                    	<ui:outputText value="{!$Label.c.stgRefreshHHAcctNameDesc}" class="slds-text-body--small" />
+                        <ui:outputText value="{!$Label.c.stgRefreshHHAcctNameDesc}" class="slds-text-body--small" />
                     </div>
                 </div>
 
                 <div class="slds-col slds-size--1-of-2">
-               	<lightning:button
+                   <lightning:button
                                 variant="brand"
                                 disabled="{!!v.isView}"
-                                label="Refresh All Household Names"
+                                label="{!$Label.c.stgBtnRefreshHouseholdNames}"
                                 title="refreshHouseholdAccountButton"
                                 onclick="{! c.handleRefreshHouseholdAccount}"/>
                 </div>

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -257,7 +257,7 @@
 
                 <div class="slds-col slds-size--1-of-2">
                     <lightning:button
-                        disabled="{!v.isView}"
+                        disabled="{!!v.isView}"
                         variant="brand"
                         label="{!$Label.c.stgBtnRefreshAdminNames}"
                         title="refreshButton"

--- a/src/aura/STG_CMP_System/STG_CMP_System.cmp
+++ b/src/aura/STG_CMP_System/STG_CMP_System.cmp
@@ -49,8 +49,7 @@
 
                          <div class="slds-col slds-align-middle slds-gutters">
                             <h2 class="slds-text-heading_small">{!$Label.c.stgSuccessAdminAccountNameRefresh}</h2>
-                           </div>
-
+                        </div>
                     </div>
                 </div>
             </div>
@@ -256,15 +255,15 @@
                     </div>
                 </div>
 
-                  <div class="slds-col slds-size--1-of-2">
-                      <lightning:button
-                                disabled="{!!v.isView}"
-                                variant="brand"
-                                label="{!$Label.c.stgBtnRefreshAdminNames}"
-                                title="refreshButton"
-                                onclick="{! c.handleRefreshAdminAccount}"/>
-
-                  </div>
+                <div class="slds-col slds-size--1-of-2">
+                    <lightning:button
+                        disabled="{!v.isView}"
+                        variant="brand"
+                        label="{!$Label.c.stgBtnRefreshAdminNames}"
+                        title="refreshButton"
+                        onclick="{! c.handleRefreshAdminAccount}"
+                    />
+                </div>
 
                 <hr class="slds-border--top slds-m-top--medium slds-m-bottom--medium" style="width:100%;" />
                 

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -848,6 +848,22 @@
         <value>Edit</value>
     </labels>
     <labels>
+        <fullName>stgBtnRefreshAdminNames</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Button label for refreshing Administrative Account Names</shortDescription>
+        <value>Refresh All Administrative Names</value>
+    </labels>
+    <labels>
+        <fullName>stgBtnRefreshHouseholdNames</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Button label for refreshing Household Account Names</shortDescription>
+        <value>Refresh All Household Names</value>
+    </labels>
+    <labels>
         <fullName>stgBtnRunBackfill</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -727,6 +727,8 @@
         <members>stgBtnAddSetting</members>
         <members>stgBtnCancel</members>
         <members>stgBtnEdit</members>
+        <members>stgBtnRefreshAdminNames</members>
+        <members>stgBtnRefreshHouseholdNames</members>
         <members>stgBtnRunBackfill</members>
         <members>stgBtnRunCopy</members>
         <members>stgBtnSave</members>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -429,6 +429,14 @@
         <name>stgBtnEdit</name>
     </customLabels>
     <customLabels>
+        <label><!-- Refresh All Administrative Names --></label>
+        <name>stgBtnRefreshAdminNames</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Refresg All Household Names --></label>
+        <name>stgBtnRefreshHouseholdNames</name>
+    </customLabels>
+    <customLabels>
         <label>Executa el reenviament</label>
         <name>stgBtnRunBackfill</name>
     </customLabels>

--- a/src/translations/ca.translation
+++ b/src/translations/ca.translation
@@ -433,7 +433,7 @@
         <name>stgBtnRefreshAdminNames</name>
     </customLabels>
     <customLabels>
-        <label><!-- Refresg All Household Names --></label>
+        <label><!-- Refresh All Household Names --></label>
         <name>stgBtnRefreshHouseholdNames</name>
     </customLabels>
     <customLabels>

--- a/src/translations/en_GB.translation
+++ b/src/translations/en_GB.translation
@@ -433,7 +433,7 @@
         <name>stgBtnRefreshAdminNames</name>
     </customLabels>
     <customLabels>
-        <label><!-- Refresg All Household Names --></label>
+        <label><!-- Refresh All Household Names --></label>
         <name>stgBtnRefreshHouseholdNames</name>
     </customLabels>
     <customLabels>

--- a/src/translations/en_GB.translation
+++ b/src/translations/en_GB.translation
@@ -429,6 +429,14 @@
         <name>stgBtnEdit</name>
     </customLabels>
     <customLabels>
+        <label><!-- Refresh All Administrative Names --></label>
+        <name>stgBtnRefreshAdminNames</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Refresg All Household Names --></label>
+        <name>stgBtnRefreshHouseholdNames</name>
+    </customLabels>
+    <customLabels>
         <label>Run Backfill</label>
         <name>stgBtnRunBackfill</name>
     </customLabels>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -433,7 +433,7 @@
         <name>stgBtnRefreshAdminNames</name>
     </customLabels>
     <customLabels>
-        <label><!-- Refresg All Household Names --></label>
+        <label><!-- Refresh All Household Names --></label>
         <name>stgBtnRefreshHouseholdNames</name>
     </customLabels>
     <customLabels>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -429,6 +429,14 @@
         <name>stgBtnEdit</name>
     </customLabels>
     <customLabels>
+        <label><!-- Refresh All Administrative Names --></label>
+        <name>stgBtnRefreshAdminNames</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Refresg All Household Names --></label>
+        <name>stgBtnRefreshHouseholdNames</name>
+    </customLabels>
+    <customLabels>
         <label>Ejecutar Relleno</label>
         <name>stgBtnRunBackfill</name>
     </customLabels>

--- a/src/translations/es_MX.translation
+++ b/src/translations/es_MX.translation
@@ -433,7 +433,7 @@
         <name>stgBtnRefreshAdminNames</name>
     </customLabels>
     <customLabels>
-        <label><!-- Refresg All Household Names --></label>
+        <label><!-- Refresh All Household Names --></label>
         <name>stgBtnRefreshHouseholdNames</name>
     </customLabels>
     <customLabels>

--- a/src/translations/es_MX.translation
+++ b/src/translations/es_MX.translation
@@ -429,6 +429,14 @@
         <name>stgBtnEdit</name>
     </customLabels>
     <customLabels>
+        <label><!-- Refresh All Administrative Names --></label>
+        <name>stgBtnRefreshAdminNames</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Refresg All Household Names --></label>
+        <name>stgBtnRefreshHouseholdNames</name>
+    </customLabels>
+    <customLabels>
         <label>Ejecutar Relleno</label>
         <name>stgBtnRunBackfill</name>
     </customLabels>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -433,7 +433,7 @@
         <name>stgBtnRefreshAdminNames</name>
     </customLabels>
     <customLabels>
-        <label><!-- Refresg All Household Names --></label>
+        <label><!-- Refresh All Household Names --></label>
         <name>stgBtnRefreshHouseholdNames</name>
     </customLabels>
     <customLabels>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -429,6 +429,14 @@
         <name>stgBtnEdit</name>
     </customLabels>
     <customLabels>
+        <label><!-- Refresh All Administrative Names --></label>
+        <name>stgBtnRefreshAdminNames</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Refresg All Household Names --></label>
+        <name>stgBtnRefreshHouseholdNames</name>
+    </customLabels>
+    <customLabels>
         <label>Exécuter le remplissage</label>
         <name>stgBtnRunBackfill</name>
     </customLabels>


### PR DESCRIPTION
…buttons in System tab of EDA settings so they can be translated rather than hard-coding the labels

# Critical Changes

# Changes
- We've added two custom labels to be used by our Refresh All Administrative Names, and Refresh All Household Names buttons on the System Tab of EDA Settings. This was done to ensure that those buttons can be translated.
# Issues Closed

# New Metadata
- Custom labels: stgBtnRefreshAdminNames, stgBtnRefreshHouseholdNames
# Deleted Metadata

# Testing Notes
- Open EDA settings and ensure the buttons in question still read Refresh All Admin Names, and Refresh All Household Names (the translations themselves will be provided in a later release).
