### PR TITLE
[Robot] Validate accounts and contacts, system settings

### DIFF
--- a/robot/EDA/resources/AccountsAndContactsSettingsPageObject.py
+++ b/robot/EDA/resources/AccountsAndContactsSettingsPageObject.py
@@ -166,3 +166,41 @@ class AccountsAndContactsSettingsPage(BaseEDAPage, BasePage):
                 "Saving changes.\n" +
                 "Proper configuration is in place for testing 'Disable Preferred Phone enforcement'."
             )
+
+    def verify_disable_preferred_phone_enforcement_displayed(self,**kwargs):
+        """ Verify disable preferred phone enforcement is displayed """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_program_plans"]["checkbox_edit"].format(field)
+            if str(value).lower() == "false":
+                self.selenium.page_should_not_contain_element(locator)
+            else:
+                self.selenium.page_should_contain_element(locator)
+
+    def update_enable_preferred_phone_checkbox_value(self,**kwargs):
+        """ This method will update the checkbox field value passed in keyword arguments
+            Pass the expected value to be set in the checkbox field from the tests
+            true - checked, false - unchecked
+        """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_program_plans"]["checkbox_read"].format(field)
+            self.selenium.wait_until_page_contains_element(locator)
+            self.selenium.wait_until_element_is_visible(locator)
+            actual_value = self.selenium.get_element_attribute(locator, "alt")
+            if not str(actual_value).lower() == str(value).lower():
+                self.eda.click_action_button_on_eda_settings_page("Edit")
+                locator_edit = eda_lex_locators["eda_settings_program_plans"]["checkbox_edit"].format(field)
+                self.selenium.wait_until_page_contains_element(locator_edit,
+                                                error=f"'{locator_edit}' is not available ")
+                self.salesforce._jsclick(locator_edit)
+
+    def update_disable_preferred_phone_checkbox_value(self,**kwargs):
+        """ This method will update the checkbox field value passed in keyword arguments
+            Pass the expected value to be set in the checkbox field from the tests
+            true - checked, false - unchecked
+        """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_program_plans"]["checkbox_edit"].format(field)
+            if str(value).lower() == "true":
+                self.selenium.wait_until_page_contains_element(locator)
+                self.selenium.wait_until_element_is_visible(locator)
+                self.salesforce._jsclick(locator)

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -235,16 +235,19 @@ class EDA(BaseEDAPage):
             locator_toast = eda_lex_locators["success_message"].format("Settings successfully saved.")
             self.selenium.wait_until_page_contains_element(locator_toast)
 
+    @capture_screenshot_on_error
     def verify_toast_message(self, value):
         """ Verifies the toast message """
         locator = eda_lex_locators["toast_message"].format(value)
         self.selenium.wait_until_page_contains_element(locator)
 
+    @capture_screenshot_on_error
     def close_toast_message(self):
         """ Close the toast message banner """
-        self.selenium.wait_until_element_is_visible(eda_lex_locators["toast_close"])
-        self.selenium.click_element(eda_lex_locators["toast_close"])
-        self.selenium.wait_until_element_is_not_visible(eda_lex_locators["toast_close"])
+        locator = eda_lex_locators["toast_close"]
+        if self._check_if_element_exists(locator):
+            self.salesforce._jsclick(locator)
+        #self.selenium.capture_page_screenshot()
 
     def get_eda_namespace_prefix(self):
         """ Returns the EDA namespace value if the target org is a managed org else returns blank value """
@@ -373,16 +376,18 @@ class EDA(BaseEDAPage):
         self.selenium.wait_until_element_is_visible(locator)
         self.selenium.click_element(locator)
 
+    @capture_screenshot_on_error
     def click_action_button_on_eda_settings_page(self, action):
         """ Clicks on the action (eg: Save, Cancel) button on the EDA Settings page """
         locator = eda_lex_locators["eda_settings"]["action"].format(lower(action))
         self.selenium.wait_until_page_contains_element(
             locator, error=f"Action button with locator '{locator}' is not available on the EDA settings page")
-        self.selenium.click_element(locator)
+        self.salesforce._jsclick(locator)
         if action == "Save":
             self.verify_toast_message("Settings successfully saved.")
             self.close_toast_message()
 
+    @capture_screenshot_on_error
     def update_checkbox_value(self,**kwargs):
         """ This method will update the checkbox field value passed in keyword arguments
             Pass the expected value to be set in the checkbox field from the tests
@@ -393,12 +398,18 @@ class EDA(BaseEDAPage):
             self.selenium.wait_until_page_contains_element(locator)
             self.selenium.wait_until_element_is_visible(locator)
             actual_value = self.selenium.get_element_attribute(locator, "alt")
+            self.builtin.log("Locator " + locator + "actual value is " + actual_value)
             if not str(actual_value).lower() == str(value).lower():
                 self.click_action_button_on_eda_settings_page("Edit")
                 locator_edit = eda_lex_locators["eda_settings_program_plans"]["checkbox_edit"].format(field)
                 self.selenium.wait_until_page_contains_element(locator_edit,
                                                 error=f"'{locator_edit}' is not available ")
                 self.salesforce._jsclick(locator_edit)
+                time.sleep(1)
+                actual_value = self.selenium.get_element_attribute(locator_edit, "data-qa-checkbox-state")
+                if actual_value == 'true':
+                    self.builtin.log("The checkbox value in edit mode is" + actual_value)
+                self.builtin.log("Updated locator " + locator_edit)
                 self.click_action_button_on_eda_settings_page("Save")
 
     def update_dropdown_value(self,**kwargs):
@@ -489,11 +500,12 @@ class EDA(BaseEDAPage):
             this message gets displayed when the 'Run copy' button is clicked
             in both read and edit mode
         """
-        time.sleep(0.5) #No other element to wait until this page loads so using sleep
+        time.sleep(1) #No other element to wait until this page loads so using sleep
         locator = eda_lex_locators["eda_settings_courses"]["text_message"].format(textMessage)
-        self.selenium.wait_until_page_contains_element(locator,
+        self.selenium.wait_until_element_is_enabled(locator,
                                                            error="Run copy text is not displayed")
         text = self.selenium.get_webelement(locator).get_attribute("className")
+        self.builtin.log("The text message is " + text)
         if "slds-hide" in text:
             raise Exception(f"The text message {textMessage} is not displayed")
 

--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -404,12 +404,15 @@ class EDA(BaseEDAPage):
                 locator_edit = eda_lex_locators["eda_settings_program_plans"]["checkbox_edit"].format(field)
                 self.selenium.wait_until_page_contains_element(locator_edit,
                                                 error=f"'{locator_edit}' is not available ")
-                self.salesforce._jsclick(locator_edit)
-                time.sleep(1)
-                actual_value = self.selenium.get_element_attribute(locator_edit, "data-qa-checkbox-state")
-                if actual_value == 'true':
-                    self.builtin.log("The checkbox value in edit mode is" + actual_value)
-                self.builtin.log("Updated locator " + locator_edit)
+                for i in range(3):
+                    i += 1
+                    self.salesforce._jsclick(locator_edit)
+                    time.sleep(1)
+                    actual_value = self.selenium.get_element_attribute(locator_edit, "data-qa-checkbox-state")
+                    if actual_value == str(value).lower():
+                        self.builtin.log("The checkbox value in edit mode is" + actual_value)
+                        self.builtin.log("Updated locator " + locator_edit)
+                        break
                 self.click_action_button_on_eda_settings_page("Save")
 
     def update_dropdown_value(self,**kwargs):
@@ -449,6 +452,7 @@ class EDA(BaseEDAPage):
             if not str(expected_value).lower() == str(actual_value).lower() :
                 raise Exception (f"Drop down field {field} status is {actual_value} instead of {expected_value}")
 
+    @capture_screenshot_on_error
     def verify_checkbox_value(self,**kwargs):
         """ This method validates the checkbox value for the field passed in kwargs
             Pass the field name and expected value to be verified from the tests using
@@ -462,6 +466,7 @@ class EDA(BaseEDAPage):
             self.selenium.wait_until_element_is_visible(locator,
                                                 error= "Element is not displayed for the user")
             actual_value = self.selenium.get_element_attribute(locator, "alt")
+            self.builtin.log("Actual value of " + locator + " is " + actual_value)
             if not str(expected_value).lower() == str(actual_value).lower() :
                 raise Exception (f"Checkbox value in {field} is {actual_value} but it should be {expected_value}")
 

--- a/robot/EDA/resources/SystemSettingsPageObject.py
+++ b/robot/EDA/resources/SystemSettingsPageObject.py
@@ -2,6 +2,7 @@ from BaseObjects import BaseEDAPage
 from EDA import eda_lex_locators
 from cumulusci.robotframework.pageobjects import BasePage
 from cumulusci.robotframework.pageobjects import pageobject
+import time
 
 
 @pageobject("System", "HEDA_Settings")
@@ -30,3 +31,23 @@ class SystemSettingsPage(BaseEDAPage, BasePage):
             self.selenium.wait_until_page_contains_element(locator,
                                                 error=f"'{value}' as dropdown value in '{field}' field is not available ")
             self.selenium.click_element(locator)
+
+    def verify_admin_toast_message(self, value):
+        """ Verifies the admin  toast message """
+        locator = eda_lex_locators["eda_settings_system"]["admin_success_toast"]
+        time.sleep(0.5) # This wait is needed for the toast message validation
+        self.selenium.wait_until_page_contains_element(locator)
+        actual_value = self.selenium.get_webelement(locator).text
+        self.builtin.log("Toast message :" + actual_value)
+        if not str(value).lower() == str(actual_value).lower() :
+                raise Exception (f"Expected {value} but it displayed {actual_value}")
+
+    def verify_household_toast_message(self, value):
+        """ Verifies the household specific toast message """
+        locator = eda_lex_locators["eda_settings_system"]["hh_success_toast"]
+        time.sleep(0.5) # This wait is needed for the toast message validation
+        self.selenium.wait_until_page_contains_element(locator)
+        actual_value = self.selenium.get_webelement(locator).text
+        self.builtin.log("Toast message :" + actual_value)
+        if not str(value).lower() == str(actual_value).lower() :
+                raise Exception (f"Expected {value} but it displayed {actual_value}")

--- a/robot/EDA/resources/locators_50.py
+++ b/robot/EDA/resources/locators_50.py
@@ -7,7 +7,7 @@ eda_lex_locators = {
     "panel_tab_lookup": "//a/span[text()='{}']",
     "toast_message": "//div[@id='successToast']/descendant::h2[text()='{}']",
     "success_message": "//div[@id='successToast']/descendant::h2[text()='{}']",
-    "toast_close": "//div[contains(@class, 'slds-theme--success')]/button[contains(@class, 'slds-notify__close')]",
+    "toast_close": "//div[@id='successToast']/descendant::button[contains(@class, 'slds-notify__close')]",
     "close_tab": "//*[@data-key='close']/ancestor::button[contains(@class, 'slds-button slds-button_icon-x-small')]",
     "mailing_address": "//*[contains(@placeholder,'{}')]",
     "record": {

--- a/robot/EDA/resources/locators_50.py
+++ b/robot/EDA/resources/locators_50.py
@@ -133,6 +133,8 @@ eda_lex_locators = {
     "eda_settings_system": {
         "default_checkbox": "//span[text()='{}']/../following-sibling::div[1]/descendant::img",
         "default_dropdown_value": "//span[text()='{}']/../following-sibling::div[1]/descendant::span[text()='{}']",
+        "admin_success_toast": "//div[@id='adminSuccessToast']/descendant::h2",
+        "hh_success_toast": "//div[@id='hhSuccessToast']/descendant::h2",
     },
     "account_types": {
         "administrative": "//span[contains(text(),'Administrative')]/parent::*",

--- a/robot/EDA/tests/browser/settings/accounts_contacts.robot
+++ b/robot/EDA/tests/browser/settings/accounts_contacts.robot
@@ -23,3 +23,40 @@ Validate run cleanup button is active in read and edit mode
     Click run action button                     Run Cleanup
     Verify text appears
     ...     The Cleanup was queued successfully. An email will be sent when the batch is completed.
+
+Verify disable preferred phone enforcement shows and hides as expected
+    [Documentation]         Checks disable preferred phone enforcement is displayed when enable
+    ...                     enhanced preferred phone functionality is checked and vice versa.
+    [tags]                                      unstable        W-8089752       rbt:high
+    Update checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=true
+    ...                       Disable Preferred Phone Enforcement=false
+    Verify checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=true
+    ...                       Disable Preferred Phone Enforcement=false
+    Update enable preferred phone checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=false
+    Verify disable preferred phone enforcement displayed
+    ...                       Disable Preferred Phone Enforcement=false
+    Click action button on EDA settings page    Save
+    Verify checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=false
+    Update enable preferred phone checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=true
+    Verify disable preferred phone enforcement displayed
+    ...                       Disable Preferred Phone Enforcement=true
+    Update disable preferred phone checkbox value
+    ...                       Disable Preferred Phone Enforcement=true
+    Click action button on EDA settings page    Save
+    Verify checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=true
+    ...                       Disable Preferred Phone Enforcement=true
+    Update enable preferred phone checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=false
+    Verify disable preferred phone enforcement displayed
+    ...                       Disable Preferred Phone Enforcement=false
+    Click action button on EDA settings page    Save
+    Verify checkbox value
+    ...                       Enable Enhanced Preferred Phone Functionality=false
+    Verify disable preferred phone enforcement displayed
+    ...                       Disable Preferred Phone Enforcement=false

--- a/robot/EDA/tests/browser/settings/course_connections.robot
+++ b/robot/EDA/tests/browser/settings/course_connections.robot
@@ -20,6 +20,7 @@ Validate drop down values appear when checkbox is unchecked
     [tags]                                      unstable        W-041782        rbt:high
     Click action button on EDA settings page    Edit
     Verify enable course connections warning    true
+    Sleep                                       10
     Verify dropdown field status
     ...                                         Default Active Student Record Type=disabled
     ...                                         Default Faculty Record Type=disabled

--- a/robot/EDA/tests/browser/settings/eda_settings_accounts_and_contacts_edit_mode.robot
+++ b/robot/EDA/tests/browser/settings/eda_settings_accounts_and_contacts_edit_mode.robot
@@ -49,7 +49,7 @@ Unclick Checkboxes
     Test Checkbox                   University Department
 
     Wait for Locator                account_types.save
-    Click on Element                account_types.save
+    Click action button on EDA settings page    Save
 
 
 *** Keywords ***

--- a/robot/EDA/tests/browser/settings/expected_values.robot
+++ b/robot/EDA/tests/browser/settings/expected_values.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Documentation   Validate system tab in EDA Settings
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+...             robot/EDA/resources/SystemSettingsPageObject.py
+
+Suite Setup     Open Test Browser
+Suite Teardown  Capture screenshot and delete records and close browser
+
+*** Test Cases ***
+Verify standard field values
+    [Documentation]         Checks for the default account model value as Administrative and checks
+    ...                     store errors checkbox is checked and send error notification checkbox
+    ...                     is unchecked and error notification recipient dropdown is set to
+    ...                     All Sys Admins and checkboxes for disable error handling and automatic
+    ...                     household naming are unchecked and administrative account name format
+    ...                     is set to {!LastName} Administrative and household account name format
+    ...                     dropdown is set to {!LastName} Household.
+    [tags]                    unstable        W-041787      rbt:high
+    Go to EDA settings tab    System
+    Verify checkbox value
+    ...                       Store Errors=true
+    ...                       Send Error Notifications=false
+    ...                       Disable Error Handling=false
+    ...                       Automatically Rename Household Accounts=false
+    Verify dropdown value
+    ...                       Default Account Model=Administrative
+    ...                       Error Notification Recipients=All Sys Admins
+    ...                       Administrative Account Name Format={!LastName} Administrative Account
+    ...                       Household Account Name Format={!LastName} Household

--- a/robot/EDA/tests/browser/settings/expected_values.robot
+++ b/robot/EDA/tests/browser/settings/expected_values.robot
@@ -16,7 +16,7 @@ Verify standard field values
     ...                     household naming are unchecked and administrative account name format
     ...                     is set to {!LastName} Administrative and household account name format
     ...                     dropdown is set to {!LastName} Household.
-    [tags]                    unstable        W-041787      rbt:high
+    [tags]                    unstable        W-041787      rbt:medium
     Go to EDA settings tab    System
     Verify checkbox value
     ...                       Store Errors=true

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -25,6 +25,7 @@ Verify system settings can retain value on save
     Click action button on EDA settings page    Save
     # Below step is necessary as sometimes the dropdown field is not loading to verify its value
     Go to EDA settings tab    System
+    Sleep                     25
     Verify checkbox value
     ...                       Store Errors=false
     ...                       Send Error Notifications=true

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -8,27 +8,6 @@ Suite Setup     Open Test Browser
 Suite Teardown  Capture screenshot and delete records and close browser
 
 *** Test Cases ***
-Verify standard field values
-    [Documentation]         Checks for the default account model value as Administrative and checks
-    ...                     store errors checkbox is checked and send error notification checkbox
-    ...                     is unchecked and error notification recipient dropdown is set to
-    ...                     All Sys Admins and checkboxes for disable error handling and automatic
-    ...                     household naming are unchecked and administrative account name format
-    ...                     is set to {!LastName} Administrative and household account name format
-    ...                     dropdown is set to {!LastName} Household.
-    [tags]                    unstable        W-041787      rbt:high
-    Go to EDA settings tab    System
-    Verify checkbox value
-    ...                       Store Errors=true
-    ...                       Send Error Notifications=false
-    ...                       Disable Error Handling=false
-    ...                       Automatically Rename Household Accounts=false
-    Verify dropdown value
-    ...                       Default Account Model=Administrative
-    ...                       Error Notification Recipients=All Sys Admins
-    ...                       Administrative Account Name Format={!LastName} Administrative Account
-    ...                       Household Account Name Format={!LastName} Household
-
 Verify system settings can retain value on save
     [Documentation]         Updates the values of checkbox and dropdown fields in system settings to
     ...                     the passed value as arguments and verifies the same values are retained
@@ -53,3 +32,15 @@ Verify system settings can retain value on save
     ...                       Automatically Rename Household Accounts=true
     Verify dropdown value
     ...                       Default Account Model=Household Account
+
+Verify refresh all administrative names and refresh all household names are active
+    [Documentation]         Checks "Refresh  All Administrative Names" and "Refresh All Household
+    ...                     Names" button are active in read mode.
+    [tags]                                      unstable        W-8109925        rbt:high
+    Go to EDA settings tab    System
+    Click run action button                     Refresh All Administrative Names
+    Verify admin toast message
+    ...     The Administrative Account naming refresh was queued successfully. An email will be sent at the completion of the batch.
+    Click run action button                     Refresh All Household Names
+    Verify household toast message
+    ...     The Household Account naming refresh was queued successfully. An email will be sent at the completion of the batch.


### PR DESCRIPTION
Validate disable preferred phone enforcement shows and hides as expected

Robot WI: W-8089752

New/Existing Test - This is a new test

Validate refresh all administrative names and refresh all household names are active

Robot WI: W-8109925

New/Existing Test - This is a new test

To run the test case, run this from your CCI:
cci task run robot -o suites robot/EDA/tests/browser/settings/accounts_contacts.robot -o include W-8089752
cci task run robot -o suites robot/EDA/tests/browser/settings/system.robot -o include W-8109925


# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
