### PR TITLE
[EDA] Add Education History to  CON_CannotDelete_TDTM and ACCT_CannotDelete_TDTM classes

### DIFF
--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -34,40 +34,42 @@
 * @group-content ../../ApexDocContent/Accounts.htm
 * @description Stops an Account from being deleted if it has any Address, Affiliation, 
 * Attribute, Course, Contact(Household), Contact(Business Organization), Course Connection, 
-* Facility, Program Enrollment, Program Plan, Term, or Time Block child records. 
+* Education History, Facility, Program Enrollment, Program Plan, Term, or Time Block child records. 
 */
 public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
+
     /*******************************************************************************************************
     * @description Get the setting of preventing Account deletion
     */
     private static Boolean enabledPreventAccountDeletion = UTIL_CustomSettingsFacade.getSettings().Prevent_Account_Deletion__c;
-    
+
     /*******************************************************************************************************
     * @description Stops an Account from being deleted if it has any Address, Affiliation, 
     * Attribute, Course, Contact(Household), Contact(Business Organization), Course Connection, 
     * Facility, Program Enrollment, Program Plan, Term, or Time Block child records. 
     * @param listNew the list of Accounts from trigger new. 
     * @param listOld the list of Accounts from trigger old. 
-    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
+    * @param triggerAction which trigger event (BeforeDelete). 
     * @param objResult the describe for Accounts 
     * @return dmlWrapper.  
     ********************************************************************************************************/
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
     TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-        
+
         if (!enabledPreventAccountDeletion) {
             return new DmlWrapper(); 
         }
-        
+
         Map<ID, Account> oldmap = new Map<ID, Account>((List<Account>)oldList);
-        
+
         if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
-            for (Account a : [SELECT ID, 
+            for (Account acc : [SELECT ID, 
                                 (SELECT ID FROM Account.Addresses__r LIMIT 1),
                                 (SELECT ID FROM Account.Affl_Contacts__r LIMIT 1), 
                                 (SELECT ID FROM Account.Attributes__r LIMIT 1), 
                                 (SELECT ID FROM Account.Courses__r LIMIT 1), 
                                 (SELECT ID FROM Account.Course_Enrollments__r LIMIT 1),
+                                (SELECT ID FROM Account.Education_History__r LIMIT 1),
                                 (SELECT ID FROM Account.Facilities__r LIMIT 1),
                                 (SELECT ID FROM Account.Household_Members__r LIMIT 1),
                                 (SELECT ID FROM Account.Organization_Members__r LIMIT 1),
@@ -75,26 +77,35 @@ public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
                                 (SELECT ID FROM Account.Program_Plans__r LIMIT 1),
                                 (SELECT ID FROM Account.Terms__r LIMIT 1),
                                 (SELECT ID FROM Account.Time_Blocks__r LIMIT 1)
-                                FROM Account WHERE ID in :oldlist]) {
-                
-                if (hasChildRecords(a)) {
-                    Account accountInContext = oldMap.get(a.ID);
+                                FROM Account WHERE ID IN :oldlist]) {
+
+                if (hasChildRecords(acc)) {
+                    Account accountInContext = oldMap.get(acc.ID);
                     accountInContext.addError(Label.CannotDelete);
                 }
             }     
         }
         return new DmlWrapper();
     }
-    
+
     /*******************************************************************************************************
      * @description Evaluates whether the Account has any child related records.
      * @param a is the current Account record.
      * @return Boolean.
      ********************************************************************************************************/
-    private static Boolean hasChildRecords(Account a) {
-        return (a.Addresses__r.size() > 0 || a.Affl_Contacts__r.size() > 0 || a.Attributes__r.size() > 0 ||
-            a.Courses__r.size() > 0 || a.Course_Enrollments__r.size() > 0 || a.Facilities__r.size() > 0 ||
-            a.Household_Members__r.size() > 0 || a.Organization_Members__r.size() > 0 || a.Program_Enrollments__r.size() > 0 || 
-            a.Program_Plans__r.size() > 0 || a.Terms__r.size() > 0 || a.Time_Blocks__r.size() > 0); 
+    private static Boolean hasChildRecords(Account acc) {
+        return (acc.Addresses__r.size() > 0 ||
+                acc.Affl_Contacts__r.size() > 0 ||
+                acc.Attributes__r.size() > 0 ||
+                acc.Courses__r.size() > 0 ||
+                acc.Course_Enrollments__r.size() > 0 ||
+                acc.Education_History__r.size() > 0
+                acc.Facilities__r.size() > 0 ||
+                acc.Household_Members__r.size() > 0 ||
+                acc.Organization_Members__r.size() > 0 ||
+                acc.Program_Enrollments__r.size() > 0 ||
+                acc.Program_Plans__r.size() > 0 ||
+                acc.Terms__r.size() > 0 ||
+                acc.Time_Blocks__r.size() > 0);
     }
 }

--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -99,7 +99,7 @@ public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
                 acc.Attributes__r.size() > 0 ||
                 acc.Courses__r.size() > 0 ||
                 acc.Course_Enrollments__r.size() > 0 ||
-                acc.Education_History__r.size() > 0
+                acc.Education_History__r.size() > 0 ||
                 acc.Facilities__r.size() > 0 ||
                 acc.Household_Members__r.size() > 0 ||
                 acc.Organization_Members__r.size() > 0 ||

--- a/src/classes/ACCT_CannotDelete_TDTM.cls
+++ b/src/classes/ACCT_CannotDelete_TDTM.cls
@@ -79,7 +79,7 @@ public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
                                 (SELECT ID FROM Account.Time_Blocks__r LIMIT 1)
                                 FROM Account WHERE ID IN :oldlist]) {
 
-                if (hasChildRecords(acc)) {
+                if (this.hasChildRecords(acc)) {
                     Account accountInContext = oldMap.get(acc.ID);
                     accountInContext.addError(Label.CannotDelete);
                 }
@@ -93,19 +93,19 @@ public with sharing class ACCT_CannotDelete_TDTM extends TDTM_Runnable {
      * @param a is the current Account record.
      * @return Boolean.
      ********************************************************************************************************/
-    private static Boolean hasChildRecords(Account acc) {
-        return (acc.Addresses__r.size() > 0 ||
-                acc.Affl_Contacts__r.size() > 0 ||
-                acc.Attributes__r.size() > 0 ||
-                acc.Courses__r.size() > 0 ||
-                acc.Course_Enrollments__r.size() > 0 ||
-                acc.Education_History__r.size() > 0 ||
-                acc.Facilities__r.size() > 0 ||
-                acc.Household_Members__r.size() > 0 ||
-                acc.Organization_Members__r.size() > 0 ||
-                acc.Program_Enrollments__r.size() > 0 ||
-                acc.Program_Plans__r.size() > 0 ||
-                acc.Terms__r.size() > 0 ||
-                acc.Time_Blocks__r.size() > 0);
+    private Boolean hasChildRecords(Account acc) {
+        return (acc.Addresses__r.isEmpty() == false ||
+                acc.Affl_Contacts__r.isEmpty() == false ||
+                acc.Attributes__r.isEmpty() == false ||
+                acc.Courses__r.isEmpty() == false ||
+                acc.Course_Enrollments__r.isEmpty() == false ||
+                acc.Education_History__r.isEmpty() == false ||
+                acc.Facilities__r.isEmpty() == false ||
+                acc.Household_Members__r.isEmpty() == false ||
+                acc.Organization_Members__r.isEmpty() == false ||
+                acc.Program_Enrollments__r.isEmpty() == false ||
+                acc.Program_Plans__r.isEmpty() == false ||
+                acc.Terms__r.isEmpty() == false ||
+                acc.Time_Blocks__r.isEmpty() == false);
     }
 }

--- a/src/classes/ACCT_CannotDelete_TEST.cls
+++ b/src/classes/ACCT_CannotDelete_TEST.cls
@@ -36,11 +36,12 @@
 */
 @isTest
 public with sharing class ACCT_CannotDelete_TEST {
+
     /*********************************************************************************************************
     * @description Retrieves the Business Account record type Id. 
     */
     public static String bizAccRecordTypeId = UTIL_Describe_API.getBizAccRecTypeID(); 
-    
+
     /*********************************************************************************************************
     * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
     * Account has an Address record associated to it, that it cannot be deleted.
@@ -295,7 +296,39 @@ public with sharing class ACCT_CannotDelete_TEST {
         System.assertEquals(2, returnAccounts.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
     }
-    
+
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
+    * Account has a Education History record associated to it, that it cannot be deleted.
+    */
+    @isTest
+    public static void accCannotDeleteWithEducationHistoryBULK() {
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = bizAccRecordTypeId,
+                                                            Prevent_Account_Deletion__c = true));
+
+        List<Account> newAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(2, UTIL_Describe.getAcademicAccRecTypeID()); 
+        insert newAccounts;
+        
+        Education_History__c educationHistory1 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
+        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+        
+        insert new List<Education_History__c> {educationHistory1, educationHistory2};
+            
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(newAccounts, false);
+        Test.stopTest();
+        
+        List<Account> returnAccounts = [SELECT Id
+                                        FROM Account
+                                        WHERE Id IN :newAccounts];
+        
+        System.assertEquals(2, returnAccounts.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
+        System.assertEquals(Label.CannotDelete, results[1].errors[0].message);
+        
+    }
+
     /*********************************************************************************************************
     * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
     * Account has a Facility record associated to it, that it cannot be deleted.
@@ -701,7 +734,38 @@ public with sharing class ACCT_CannotDelete_TEST {
 
         System.assertEquals(0, returnAccounts.size()); 
     }
-    
+
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
+    * Account has a Education History record associated to it, that it can be deleted.
+    */
+    @isTest
+    public static void accCanDeleteWithEducationHistoryBULK() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c
+                                                            (Account_Processor__c = bizAccRecordTypeId,
+                                                            Prevent_Account_Deletion__c = false));
+
+        List<Account> newAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(2, UTIL_Describe.getAcademicAccRecTypeID()); 
+        insert newAccounts;
+
+        Education_History__c educationHistory1 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
+        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+
+        insert new List<Education_History__c> {educationHistory1, educationHistory2};
+
+        Test.startTest();
+        Database.DeleteResult[] results = Database.delete(newAccounts, false);
+        Test.stopTest();
+
+        List<Account> returnAccounts = [SELECT Id
+                                        FROM Account
+                                        WHERE Id IN :newAccounts];
+
+        System.assertEquals(0, returnAccounts.size());
+
+    }
+
     /*********************************************************************************************************
     * @description Test method to test if Prevent_Account_Deletion__c is disabled in Hierarchy Settings, and
     * Account has a Facility record associated to it, that it can be deleted.
@@ -961,7 +1025,10 @@ public with sharing class ACCT_CannotDelete_TEST {
         insert term; 
 
         Time_Block__c timeBlock = new Time_Block__c (Name = 'TimeB', Educational_Institution__c = lastNameByContact.get('Willy').AccountId);
-        insert timeBlock; 
+        insert timeBlock;
+
+        Education_History__c educationHistory = UTIL_UnitTestData_TEST.getEduHistory(lastNameByContact.get('Willy').AccountId, null);
+        insert educationHistory;
 
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(newAccounts, false);
@@ -1022,7 +1089,10 @@ public with sharing class ACCT_CannotDelete_TEST {
         insert course; 
 
         Facility__c facility = new Facility__c (Name = 'MeetingRoom1', Account__c = lastNameByContact.get('Willy').AccountId);
-        insert facility; 
+        insert facility;
+
+        Education_History__c educationHistory = UTIL_UnitTestData_TEST.getEduHistory(lastNameByContact.get('Willy').AccountId, null);
+        insert educationHistory;
 
         Program_Enrollment__c pe = new Program_Enrollment__c (Contact__c = lastNameByContact.get('Willy').Id, Account__c = lastNameByContact.get('Willy').AccountId);
         insert pe; 

--- a/src/classes/ACCT_CannotDelete_TEST.cls
+++ b/src/classes/ACCT_CannotDelete_TEST.cls
@@ -297,8 +297,8 @@ public with sharing class ACCT_CannotDelete_TEST {
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
     }
 
-    /*********************************************************************************************************
-    * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
+    /************************************************************************************************************
+    * @description Bulk test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
     * Account has a Education History record associated to it, that it cannot be deleted.
     */
     @isTest
@@ -309,11 +309,13 @@ public with sharing class ACCT_CannotDelete_TEST {
 
         List<Account> newAccounts = UTIL_UnitTestData_TEST.getMultipleTestAccounts(2, UTIL_Describe.getAcademicAccRecTypeID()); 
         insert newAccounts;
-        
+
         Education_History__c educationHistory1 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
-        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
+        Education_History__c educationHistory3 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+        Education_History__c educationHistory4 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
         
-        insert new List<Education_History__c> {educationHistory1, educationHistory2};
+        insert new List<Education_History__c> {educationHistory1, educationHistory2, educationHistory3, educationHistory4};
             
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(newAccounts, false);
@@ -736,7 +738,7 @@ public with sharing class ACCT_CannotDelete_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
+    * @description Bulk test method to test if Prevent_Account_Deletion__c is enabled in Hierarchy Settings, and
     * Account has a Education History record associated to it, that it can be deleted.
     */
     @isTest
@@ -750,9 +752,11 @@ public with sharing class ACCT_CannotDelete_TEST {
         insert newAccounts;
 
         Education_History__c educationHistory1 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
-        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+        Education_History__c educationHistory2 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[0].Id, null);
+        Education_History__c educationHistory3 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
+        Education_History__c educationHistory4 = UTIL_UnitTestData_TEST.getEduHistory(newAccounts[1].Id, null);
 
-        insert new List<Education_History__c> {educationHistory1, educationHistory2};
+        insert new List<Education_History__c> {educationHistory1, educationHistory2, educationHistory3, educationHistory4};
 
         Test.startTest();
         Database.DeleteResult[] results = Database.delete(newAccounts, false);
@@ -1116,5 +1120,4 @@ public with sharing class ACCT_CannotDelete_TEST {
 
         System.assertEquals(0, returnAccounts.size());
     }
-    
 }

--- a/src/classes/CON_CannotDelete_TDTM.cls
+++ b/src/classes/CON_CannotDelete_TDTM.cls
@@ -34,7 +34,7 @@
 * @group-content ../../ApexDocContent/Contacts.htm
 * @description Stops a Contact from being deleted if it has any Address, Affiliation,
 * Application, Attendance Event, Attribute, Behavior Involement, Contact Language,
-* Course Offering, Course Enrollment, Program Enrollment,
+* Course Offering, Course Enrollment, Education History, Program Enrollment,
 * Term Grade, or Test child records.
 */
 public with sharing class CON_CannotDelete_TDTM extends TDTM_Runnable {

--- a/src/classes/CON_CannotDelete_TEST.cls
+++ b/src/classes/CON_CannotDelete_TEST.cls
@@ -469,7 +469,7 @@ private with sharing class CON_CannotDelete_TEST {
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
         insert contacts;
         
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(null,contacts[0].Id);
         insert eduHis;
         
         Test.startTest();
@@ -1271,8 +1271,8 @@ private with sharing class CON_CannotDelete_TEST {
 
         update new List<Course_Offering__c> {courseOfferings1, courseOfferings2};
 
-        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
-        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
+        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[1].Id);
         insert new List<Education_History__c> {eduHis1, eduHis2};
 
         Term_Grade__c termGrade1 = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id, courseOfferings1.Id, null);
@@ -1365,7 +1365,7 @@ private with sharing class CON_CannotDelete_TEST {
         courseOffering.Faculty__c = contacts[1].Id;
         update courseOffering;
         
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[1].Id);
         insert eduHis;
 
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id,courseOffering.Id, null);
@@ -1466,8 +1466,8 @@ private with sharing class CON_CannotDelete_TEST {
 
         update new List<Course_Offering__c> {courseOfferings1, courseOfferings2};
 
-        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
-        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
+        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[1].Id);
         insert new List<Education_History__c> {eduHis1, eduHis2};
 
         Term_Grade__c termGrade1 = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id, courseOfferings1.Id, null);
@@ -1555,7 +1555,7 @@ private with sharing class CON_CannotDelete_TEST {
         courseOffering.Faculty__c = contacts[1].Id;
         update courseOffering;
 
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[1].Id);
         insert eduHis;
 
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id, courseOffering.Id, null);

--- a/src/classes/CON_CannotDelete_TEST.cls
+++ b/src/classes/CON_CannotDelete_TEST.cls
@@ -37,6 +37,10 @@
 @isTest
 private with sharing class CON_CannotDelete_TEST {
 
+    /**************************************************************************************************************************
+    ****************************************************** FUNCTIONAL TESTS ***************************************************
+    **************************************************************************************************************************/
+
     /*********************************************************************************************************
     * @description Test method to test if Prevent_Contact_Deletion__c is enabled in Hierarchy Settings, and
     * Contact has an Address record associated to it, that it cannot be deleted.
@@ -450,6 +454,34 @@ private with sharing class CON_CannotDelete_TEST {
 
         //Verify that none of the Contact records were deleted
         System.assertEquals(2, returnContacts.size());
+        System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
+    }
+
+    /*********************************************************************************************************
+    * @description Test method to test if Prevent_Contact_Deletion__c is enabled in Hierarchy Settings, and
+    * Contact has an Education History record associated to it, that it cannot be deleted.
+    */
+    @isTest
+    private static void conCannotDeleteWithEduHistory() {
+
+        UTIL_CustomSettingsFacade.getSettingsForTests(new Hierarchy_Settings__c (Prevent_Contact_Deletion__c = true));
+
+        List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
+        insert contacts;
+        
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        insert eduHis;
+        
+        Test.startTest();
+            List<Database.DeleteResult> results = Database.delete(contacts, false);
+        Test.stopTest();
+
+        List<Contact> returnContacts = [SELECT Id
+                                       FROM Contact
+                                       WHERE Id IN :contacts];
+
+        //Verify that only one of the Contact records was deleted
+        System.assertEquals(1, returnContacts.size());
         System.assertEquals(Label.CannotDelete, results[0].errors[0].message);
     }
 
@@ -1239,6 +1271,10 @@ private with sharing class CON_CannotDelete_TEST {
 
         update new List<Course_Offering__c> {courseOfferings1, courseOfferings2};
 
+        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        insert new List<Education_History__c> {eduHis1, eduHis2};
+
         Term_Grade__c termGrade1 = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id, courseOfferings1.Id, null);
         Term_Grade__c termGrade2 = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id, courseOfferings2.Id, null);
 
@@ -1328,6 +1364,9 @@ private with sharing class CON_CannotDelete_TEST {
         Course_Offering__c courseOffering = UTIL_UnitTestData_TEST.createCourseOffering(course.Id, term.Id);
         courseOffering.Faculty__c = contacts[1].Id;
         update courseOffering;
+        
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        insert eduHis;
 
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id,courseOffering.Id, null);
         insert termGrade;
@@ -1427,6 +1466,10 @@ private with sharing class CON_CannotDelete_TEST {
 
         update new List<Course_Offering__c> {courseOfferings1, courseOfferings2};
 
+        Education_History__c eduHis1 = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis2 = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        insert new List<Education_History__c> {eduHis1, eduHis2};
+
         Term_Grade__c termGrade1 = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id, courseOfferings1.Id, null);
         Term_Grade__c termGrade2 = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id, courseOfferings2.Id, null);
 
@@ -1512,6 +1555,9 @@ private with sharing class CON_CannotDelete_TEST {
         courseOffering.Faculty__c = contacts[1].Id;
         update courseOffering;
 
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[1].Id);
+        insert eduHis;
+
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[1].Id, courseOffering.Id, null);
         insert termGrade;
 
@@ -1538,6 +1584,10 @@ private with sharing class CON_CannotDelete_TEST {
         System.assertEquals(true, results[0].success);
         System.assertEquals(true, results[1].success);
     }
+
+    /**************************************************************************************************************************
+    ****************************************************** UNIT TESTS *********************************************************
+    **************************************************************************************************************************/
 
     /*************************************************************************************************************
     * @description NULL test for run method to verify new DmlWrapper(); is returned when oldList is null
@@ -1585,6 +1635,9 @@ private with sharing class CON_CannotDelete_TEST {
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
 
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        insert eduHis;
+
         List<SObject> oldList = new List<SObject>((List<SObject>)contacts);
 
         Map<Id, Contact> contactById = new Map<Id, Contact>(contacts);
@@ -1631,6 +1684,9 @@ private with sharing class CON_CannotDelete_TEST {
 
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
+
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        insert eduHis;
 
         List<SObject> oldList = new List<SObject>((List<SObject>)contacts);
 
@@ -1706,6 +1762,9 @@ private with sharing class CON_CannotDelete_TEST {
 
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
+
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        insert eduHis;
 
         CON_CannotDelete_TDTM conCanNotDeleteTDTM = new CON_CannotDelete_TDTM();
         Test.startTest();
@@ -1813,6 +1872,10 @@ private with sharing class CON_CannotDelete_TEST {
         System.assertEquals(false, isContactDeletionPreventionEnabled);
 
     }
+
+    /**************************************************************************************************************************
+    ****************************************************** STUB CLASS *********************************************************
+    **************************************************************************************************************************/
 
     /*************************************************************************************************************
     * STUB class which extends SRVC_Contact_PreventDeletion

--- a/src/classes/CON_CannotDelete_TEST.cls
+++ b/src/classes/CON_CannotDelete_TEST.cls
@@ -468,10 +468,10 @@ private with sharing class CON_CannotDelete_TEST {
 
         List<Contact> contacts = UTIL_UnitTestData_TEST.getMultipleTestContacts(2);
         insert contacts;
-        
+
         Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(null,contacts[0].Id);
         insert eduHis;
-        
+
         Test.startTest();
             List<Database.DeleteResult> results = Database.delete(contacts, false);
         Test.stopTest();
@@ -1635,7 +1635,7 @@ private with sharing class CON_CannotDelete_TEST {
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
 
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
         insert eduHis;
 
         List<SObject> oldList = new List<SObject>((List<SObject>)contacts);
@@ -1685,7 +1685,7 @@ private with sharing class CON_CannotDelete_TEST {
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
 
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
         insert eduHis;
 
         List<SObject> oldList = new List<SObject>((List<SObject>)contacts);
@@ -1763,7 +1763,7 @@ private with sharing class CON_CannotDelete_TEST {
         Affiliation__c affiliation = new Affiliation__c(Account__c = acc.Id, Contact__c = contacts[0].Id);
         insert affiliation;
 
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
         insert eduHis;
 
         CON_CannotDelete_TDTM conCanNotDeleteTDTM = new CON_CannotDelete_TDTM();

--- a/src/classes/SRVC_Contact_PreventDeletion.cls
+++ b/src/classes/SRVC_Contact_PreventDeletion.cls
@@ -95,6 +95,7 @@ public virtual with sharing class SRVC_Contact_PreventDeletion {
                 (SELECT ID FROM Behavior_Involvements__r LIMIT 1),
                 (SELECT ID FROM Contact_Languages__r LIMIT 1),
                 (SELECT ID FROM Courses_Taught__r LIMIT 1),
+                (SELECT ID FROM Education_History__r LIMIT 1),
                 (SELECT ID FROM Program_Enrollments__r LIMIT 1),
                 (SELECT ID FROM Student_Course_Enrollments__r LIMIT 1),
                 (SELECT ID FROM Term_Grades__r LIMIT 1),
@@ -119,6 +120,7 @@ public virtual with sharing class SRVC_Contact_PreventDeletion {
                 con.Behavior_Involvements__r.isEmpty() == false ||
                 con.Contact_Languages__r.isEmpty() == false ||
                 con.Courses_Taught__r.isEmpty() == false ||
+                con.Education_History__r.isEmpty() == false ||
                 con.Program_Enrollments__r.isEmpty() == false ||
                 con.Student_Course_Enrollments__r.isEmpty() == false ||
                 con.Term_Grades__r.isEmpty() == false ||

--- a/src/classes/SRVC_Contact_PreventDeletion_TEST.cls
+++ b/src/classes/SRVC_Contact_PreventDeletion_TEST.cls
@@ -95,6 +95,9 @@ private class SRVC_Contact_PreventDeletion_TEST {
         Course_Enrollment__c courseCxn = UTIL_UnitTestData_TEST.getCourseConnection(contacts[0].Id, courseOffering.Id);
         insert courseCxn;
 
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        insert eduHis;
+
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id,  courseOffering.Id, courseCxn.Id);
         insert termGrade;
 
@@ -238,6 +241,7 @@ private class SRVC_Contact_PreventDeletion_TEST {
         System.assertEquals(1, contactsWithChildRecords[0].Behavior_Involvements__r.size());
         System.assertEquals(1, contactsWithChildRecords[0].Contact_Languages__r.size());
         System.assertEquals(1, contactsWithChildRecords[0].Courses_Taught__r.size());
+        System.assertEquals(1, contactsWithChildRecords[0].Education_History__r.size());
         System.assertEquals(1, contactsWithChildRecords[0].Program_Enrollments__r.size());
         System.assertEquals(1, contactsWithChildRecords[0].Student_Course_Enrollments__r.size());
         System.assertEquals(1, contactsWithChildRecords[0].Term_Grades__r.size());
@@ -269,6 +273,7 @@ private class SRVC_Contact_PreventDeletion_TEST {
         System.assertEquals(0, contactsWithChildRecords[0].Behavior_Involvements__r.size());
         System.assertEquals(0, contactsWithChildRecords[0].Contact_Languages__r.size());
         System.assertEquals(0, contactsWithChildRecords[0].Courses_Taught__r.size());
+        System.assertEquals(0, contactsWithChildRecords[0].Education_History__r.size());
         System.assertEquals(0, contactsWithChildRecords[0].Program_Enrollments__r.size());
         System.assertEquals(0, contactsWithChildRecords[0].Student_Course_Enrollments__r.size());
         System.assertEquals(0, contactsWithChildRecords[0].Term_Grades__r.size());
@@ -293,6 +298,7 @@ private class SRVC_Contact_PreventDeletion_TEST {
                        (SELECT ID FROM Behavior_Involvements__r LIMIT 1),
                        (SELECT ID FROM Contact_Languages__r LIMIT 1),
                        (SELECT ID FROM Courses_Taught__r LIMIT 1),
+                       (SELECT ID FROM Education_History__r LIMIT 1),
                        (SELECT ID FROM Program_Enrollments__r LIMIT 1),
                        (SELECT ID FROM Student_Course_Enrollments__r LIMIT 1),
                        (SELECT ID FROM Term_Grades__r LIMIT 1),

--- a/src/classes/SRVC_Contact_PreventDeletion_TEST.cls
+++ b/src/classes/SRVC_Contact_PreventDeletion_TEST.cls
@@ -95,7 +95,7 @@ private class SRVC_Contact_PreventDeletion_TEST {
         Course_Enrollment__c courseCxn = UTIL_UnitTestData_TEST.getCourseConnection(contacts[0].Id, courseOffering.Id);
         insert courseCxn;
 
-        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(contacts[0].Id);
+        Education_History__c eduHis = UTIL_UnitTestData_Test.getEduHistory(acc.Id, contacts[0].Id);
         insert eduHis;
 
         Term_Grade__c termGrade = UTIL_UnitTestData_TEST.getTermGrade(contacts[0].Id,  courseOffering.Id, courseCxn.Id);

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -373,6 +373,16 @@ public class UTIL_UnitTestData_TEST {
     }
 
     /*********************************************************************************************************
+    * @description Returns an instance Education History record
+    * @Param contactId id of the Contact record
+    * @return eduHistory The instance of education history record
+    **********************************************************************************************************/
+    public static Education_History__c getEduHistory(Id contactId) {
+        Education_History__c eduHistory = new Education_History__c(Contact__c = contactId);
+        return eduHistory;
+    }
+
+    /*********************************************************************************************************
     * @description Create a list of error records for the current system time.
     **********************************************************************************************************/
     public static List<Error__c> getListOfErrors(Integer n) {

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -377,8 +377,8 @@ public class UTIL_UnitTestData_TEST {
     * @Param contactId id of the Contact record
     * @return eduHistory The instance of education history record
     **********************************************************************************************************/
-    public static Education_History__c getEduHistory(Id contactId) {
-        Education_History__c eduHistory = new Education_History__c(Contact__c = contactId);
+    public static Education_History__c getEduHistory(Id accId, Id contactId) {
+        Education_History__c eduHistory = new Education_History__c(Account__c = accId, Contact__c = contactId);
         return eduHistory;
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated CON_CannotDelete_TDTM and ACCT_CannotDelete_TDTM to include Education History to the existing Prevent Delete logic. With this change an Account or a Contact with Education History as one of the related records can not be deleted when Prevent Deletion flags are enabled.

# Issues Closed
Closes #1339 

# New Metadata

# Deleted Metadata

# Testing Notes
