### PR TITLE
[Robot] Validate admin account, hh account name format and error notification recipient settings

### DIFF
--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -370,6 +370,13 @@ class EDA(BaseEDAPage):
         tab = tab.replace(" ", "_")
         self.pageobjects.load_page_object(tab, "HEDA_Settings")
 
+    def go_to_groups_home(self):
+        """ Navigates to the Home view of the groups tab """
+        url = self.cumulusci.org.lightning_base_url
+        url = "{}/lightning/o/CollaborationGroup/list?filterName=Recent".format(url)
+        self.selenium.go_to(url)
+        self.salesforce.wait_until_loading_is_complete()
+
     def click_edit_on_eda_settings_page(self):
         locator = eda_lex_locators["eda_settings"]["edit"]
         self.selenium.wait_until_page_contains_element(locator, error="Edit button is not available on the page")
@@ -481,6 +488,7 @@ class EDA(BaseEDAPage):
             self.selenium.wait_until_element_is_visible(locator,
                                                 error= "Element is not displayed for the user")
             actual_value = self.selenium.get_webelement(locator).text
+            self.builtin.log("Actual value of " + locator + " is " + actual_value)
             if not str(expected_value).lower() == str(actual_value).lower() :
                 raise Exception (f"Dropdown value in {field} is {actual_value} but it should be {expected_value}")
 

--- a/robot/EDA/resources/EDA.robot
+++ b/robot/EDA/resources/EDA.robot
@@ -56,6 +56,15 @@ API Create Contact
     &{contact} =     Salesforce Get  Contact  ${contact_id}
     [return]         &{contact}
 
+API Create Collaboration Group
+    [Documentation]
+    ...             Creates a collaboration group by sending name and collaboration type
+    [Arguments]      ${group_name}
+    ${group_id} =  Salesforce Insert  CollaborationGroup
+    ...                  Name=${group_name}
+    ...                  CollaborationType=Public
+    [return]         ${group_id}
+
 Create Contact with Email
     [Documentation]         Creating a contact with email address through API
     ${first_name} =           Generate Random String

--- a/robot/EDA/resources/SystemSettingsPageObject.py
+++ b/robot/EDA/resources/SystemSettingsPageObject.py
@@ -54,8 +54,8 @@ class SystemSettingsPage(BaseEDAPage, BasePage):
             self.selenium.click_element(locator)
 
     def select_recipient(self,**kwargs):
-        """ This method will enter the account name format after selecting other in the drop down
-            Pass the expected value to be set in the input field as arguments
+        """ This method will select the lookup result for the recipient notification
+            Pass the expected value to be selected as arguments
         """
         for field,value in kwargs.items():
             locator = eda_lex_locators["eda_settings_system"]["recipient_name"].format(field)

--- a/robot/EDA/resources/SystemSettingsPageObject.py
+++ b/robot/EDA/resources/SystemSettingsPageObject.py
@@ -32,6 +32,43 @@ class SystemSettingsPage(BaseEDAPage, BasePage):
                                                 error=f"'{value}' as dropdown value in '{field}' field is not available ")
             self.selenium.click_element(locator)
 
+    def enter_account_name_format(self,**kwargs):
+        """ This method will enter the account name format after selecting other in the drop down
+            Pass the expected value to be set in the input field as arguments
+        """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_system"]["other_accname_format"].format(field)
+            self.selenium.wait_until_page_contains_element(locator,
+                                                error=f"'{field}' field is not available ")
+            self.selenium.clear_element_text(locator)
+            self.selenium.get_webelement(locator).send_keys(value)
+
+    def select_recipient_type_value(self,**kwargs):
+        """ This method will select the drop down field value passed in keyword arguments
+            Pass the expected value to be selected in the drop down field from the tests
+        """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_system"]["recipient_type_value"].format(field,value)
+            self.selenium.wait_until_page_contains_element(locator,
+                                                error=f"'{value}' as dropdown value in '{field}' field is not available ")
+            self.selenium.click_element(locator)
+
+    def select_recipient(self,**kwargs):
+        """ This method will enter the account name format after selecting other in the drop down
+            Pass the expected value to be set in the input field as arguments
+        """
+        for field,value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_system"]["recipient_name"].format(field)
+            self.selenium.wait_until_page_contains_element(locator,
+                                                error=f"'{field}' field is not available ")
+            self.selenium.clear_element_text(locator)
+            self.selenium.get_webelement(locator).send_keys(value)
+            time.sleep(0.5)
+            locator_lookup = eda_lex_locators["eda_settings_system"]["recipient_lookup"].format(value)
+            self.selenium.wait_until_page_contains_element(locator_lookup,
+                                                error=f"'{locator_lookup}'  is not available ")
+            self.selenium.click_element(locator_lookup)
+
     def verify_admin_toast_message(self, value):
         """ Verifies the admin  toast message """
         locator = eda_lex_locators["eda_settings_system"]["admin_success_toast"]
@@ -51,3 +88,17 @@ class SystemSettingsPage(BaseEDAPage, BasePage):
         self.builtin.log("Toast message :" + actual_value)
         if not str(value).lower() == str(actual_value).lower() :
                 raise Exception (f"Expected {value} but it displayed {actual_value}")
+
+    def verify_system_dropdown_value(self,**kwargs):
+        """ This method validates the dropdown value for the field passed in kwargs
+            Pass the field name and expected value to be verified from the tests using
+            keyword arguments
+        """
+        for field,expected_value in kwargs.items():
+            locator = eda_lex_locators["eda_settings_system"]["other_dropdown_value"].format(field,expected_value)
+            self.selenium.page_should_contain_element(locator)
+            self.selenium.wait_until_element_is_visible(locator,
+                                                error= "Element is not displayed for the user")
+            actual_value = self.selenium.get_webelement(locator).text
+            if not str(expected_value).lower() == str(actual_value).lower() :
+                raise Exception (f"Dropdown value in {field} is {actual_value} but it should be {expected_value}")

--- a/robot/EDA/resources/locators_50.py
+++ b/robot/EDA/resources/locators_50.py
@@ -135,6 +135,11 @@ eda_lex_locators = {
         "default_dropdown_value": "//span[text()='{}']/../following-sibling::div[1]/descendant::span[text()='{}']",
         "admin_success_toast": "//div[@id='adminSuccessToast']/descendant::h2",
         "hh_success_toast": "//div[@id='hhSuccessToast']/descendant::h2",
+        "other_accname_format": "//span[text()='{}']/../preceding-sibling::div[1]/descendant::input",
+        "other_dropdown_value": "//span[text()='{}']/../preceding-sibling::div[1]/descendant::span[text()='{}']",
+        "recipient_type_value": "//span[text()='{}']/../following-sibling::div/descendant::select/option[@value='{}']",
+        "recipient_name": "//label[text()='{}']/../div/descendant::input",
+        "recipient_lookup": "//div[contains(@class, 'lookup') and text()='{}']",
     },
     "account_types": {
         "administrative": "//span[contains(text(),'Administrative')]/parent::*",

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -75,13 +75,11 @@ Verify Error Notification Recipients field picklist availability
     Click action button on EDA settings page    Edit
     Select recipient type value
     ...                       Select recipient type:=Chatter Group
-    Log     ${group_name}   console=true
     Select recipient
     ...                       Select Chatter Group=${group_name}
     Click action button on EDA settings page    Save
     Verify dropdown value
     ...                       Error Notification Recipients=${group_id}
-    Log     ${user_id}   console=true
     Click action button on EDA settings page    Edit
     Select recipient type value
     ...                       Select recipient type:=All Sys Admins

--- a/robot/EDA/tests/browser/settings/system.robot
+++ b/robot/EDA/tests/browser/settings/system.robot
@@ -4,15 +4,31 @@ Resource        robot/EDA/resources/EDA.robot
 Library         cumulusci.robotframework.PageObjects
 ...             robot/EDA/resources/SystemSettingsPageObject.py
 
-Suite Setup     Open Test Browser
+Suite Setup     Run keywords
+...             Initialize test data
+...             Open Test Browser
 Suite Teardown  Capture screenshot and delete records and close browser
+
+
+*** Keywords ***
+Initialize test data
+    [Documentation]                     Creates collaboration group and gets the SFID of group and
+    ...                                 also reads SFID of security user
+    ${group_name} =                     Set variable            Test Chatter Group
+    ${user_name} =                      Set variable            Security User
+    ${group_id}=                        API Create Collaboration Group  ${group_name}
+    ${user_id} =                        API Get ID          User     Name       Security User
+    Set Suite Variable  ${group_name}
+    Set Suite Variable  ${user_name}
+    Set Suite Variable  ${group_id}
+    Set Suite Variable  ${user_id}
 
 *** Test Cases ***
 Verify system settings can retain value on save
     [Documentation]         Updates the values of checkbox and dropdown fields in system settings to
     ...                     the passed value as arguments and verifies the same values are retained
     ...                     after saving it.
-    [tags]                    unstable        W-8042700     rbt:high
+    [tags]                    unstable        W-8042700     W-8119542     rbt:high
     Go to EDA settings tab    System
     Update checkbox value
     ...                       Store Errors=false
@@ -22,6 +38,11 @@ Verify system settings can retain value on save
     Click action button on EDA settings page    Edit
     Update system dropdown value
     ...                       Default Account Model=Household Account
+    ...                       Administrative Account Name Format=Other
+    ...                       Household Account Name Format=Other
+    Enter account name format
+    ...     The name format used for auto-created Administrative Accounts.={!LastName} Admin Account
+    ...     The format used for naming Household Accounts.={!LastName} House Account
     Click action button on EDA settings page    Save
     # Below step is necessary as sometimes the dropdown field is not loading to verify its value
     Go to EDA settings tab    System
@@ -33,6 +54,48 @@ Verify system settings can retain value on save
     ...                       Automatically Rename Household Accounts=true
     Verify dropdown value
     ...                       Default Account Model=Household Account
+    Verify system dropdown value
+    ...     The name format used for auto-created Administrative Accounts.={!LastName} Admin Account
+    ...     The format used for naming Household Accounts.={!LastName} House Account
+    Click action button on EDA settings page    Edit
+    Update system dropdown value
+    ...                       Administrative Account Name Format={!LastName} Administrative Account
+    ...                       Household Account Name Format={!{!FirstName}} {!LastName} Family
+    Click action button on EDA settings page    Save
+    Go to EDA settings tab    System
+    Verify dropdown value
+    ...                       Administrative Account Name Format={!LastName} Administrative Account
+    ...                       Household Account Name Format={!{!FirstName}} {!LastName} Family
+
+Verify Error Notification Recipients field picklist availability
+    [Documentation]         Updates 'Error Notification Recipients' to chatter group and user and
+    ...                     validates if the SFID values of the same are retained upon saving.
+    [tags]                    unstable        W-8134943     rbt:high
+    Go to EDA settings tab    System
+    Click action button on EDA settings page    Edit
+    Select recipient type value
+    ...                       Select recipient type:=Chatter Group
+    Log     ${group_name}   console=true
+    Select recipient
+    ...                       Select Chatter Group=${group_name}
+    Click action button on EDA settings page    Save
+    Verify dropdown value
+    ...                       Error Notification Recipients=${group_id}
+    Log     ${user_id}   console=true
+    Click action button on EDA settings page    Edit
+    Select recipient type value
+    ...                       Select recipient type:=All Sys Admins
+    Click action button on EDA settings page    Save
+    Verify dropdown value
+    ...                       Error Notification Recipients=All Sys Admins
+    Click action button on EDA settings page    Edit
+    Select recipient type value
+    ...                       Select recipient type:=User
+    Select recipient
+    ...                       Select User=${user_name}
+    Click action button on EDA settings page    Save
+    Verify dropdown value
+    ...                       Error Notification Recipients=${user_id}
 
 Verify refresh all administrative names and refresh all household names are active
     [Documentation]         Checks "Refresh  All Administrative Names" and "Refresh All Household


### PR DESCRIPTION
Validate disable preferred phone enforcement shows and hides as expected

Robot WI: W-8119542

New/Existing Test - This is a new test

Verify Administrative Account Name Format and Household Account Name Format field functionality can retain values on save

Robot WI: W-8134943

New/Existing Test - This is a new test

Verify Error Notification Recipients field pick list availability

To run the test case, run this from your CCI:
cci task run robot -o suites robot/EDA/tests/browser/settings/system.robot -o include W-8119542 W-8134943

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
