### PR TITLE
[EDA] : Affiliations Mapping error in EDA

### DIFF
--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -787,7 +787,6 @@ public class UTIL_Describe {
 
         for (SObject rt : results) {
 
-            // Check RecordType IS available for the running user
             if (!Test.isRunningTest()) {
                 recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
                 recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -786,16 +786,8 @@ public class UTIL_Describe {
         Map<Id, Schema.RecordTypeInfo> recordTypeInfos = obj.getRecordTypeInfosByID();
 
         for (SObject rt : results) {
-
-            if (!Test.isRunningTest()) {
-                recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
-                recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));
-            // We don't want our tests to depend on the profile configuration in the org. Otherwise tests
-            // might fail just because the user running them does not have certain record types assigned.
-            } else {
-                recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
-                recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));
-            }
+            recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
+            recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));
         }
 
         recordTypeInfoByDeveloperName.put(objectName, recordTypeByDeveloperName);

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -789,10 +789,8 @@ public class UTIL_Describe {
 
             // Check RecordType IS available for the running user
             if (!Test.isRunningTest()) {
-                if (recordTypeInfos.get(rt.Id).isAvailable()) {
-                    recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
-                    recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));
-                }
+                recordTypeByDeveloperName.put(String.valueOf(rt.get('DeveloperName')), recordTypeInfos.get(rt.Id));
+                recordTypeByName.put(String.valueOf(rt.get('Name')), recordTypeInfos.get(rt.Id));
             // We don't want our tests to depend on the profile configuration in the org. Otherwise tests
             // might fail just because the user running them does not have certain record types assigned.
             } else {


### PR DESCRIPTION
# Critical Changes

# Changes
We've fixed a customer-reported issue that affected orgs with Enable Record Type Validation enabled in EDA Settings. Before the fix, if the running user didn't have access to an Account record type involved in an Affiliation Mapping, we prevented them from creating or updating a Contact record. Now, we allow the Contact record to be saved.

# Issues Closed
Closes #1350 

# New Metadata

# Deleted Metadata

# Testing Notes
