### PR TITLE
[Robot] Update settings to use API call

### DIFF
--- a/robot/EDA/resources/EDA.robot
+++ b/robot/EDA/resources/EDA.robot
@@ -94,3 +94,12 @@ Create Organization Foundation
     ${account_id} =            Get Current Record Id
     Store Session Record       Account  ${account_id}
     [return]                   ${account_id}
+
+Get Records Count
+    [Documentation]         Returns the no of record identified by the given field_name and
+    ...                     field_value input for a specific object
+    [Arguments]             ${obj_name}             ${field_name}       ${field_value}
+    ${result} =             SOQL Query
+    ...                     SELECT COUNT(Name) FROM ${obj_name} where ${field_name}=${field_value}
+    &{Id} =                 Get From List  ${result['records']}  0
+    [return]                ${Id}[expr0]

--- a/robot/EDA/tests/browser/settings/relationships_reciprocal.robot
+++ b/robot/EDA/tests/browser/settings/relationships_reciprocal.robot
@@ -4,10 +4,8 @@ Resource        robot/EDA/resources/EDA.robot
 Library         cumulusci.robotframework.PageObjects
 ...             robot/EDA/resources/RelationshipsSettingsPageObject.py
 Suite Setup     Run keywords
-...             Open Test Browser       AND
-...             Go to EDA settings tab          Relationships      AND
-...             Go to relationships sub tab     Reciprocal Settings     AND
 ...             Initialize test data
+...             Open Test Browser
 Suite Teardown  Run Keywords
 ...             Delete inserted data        AND
 ...             Capture screenshot and delete records and close browser
@@ -20,7 +18,7 @@ Test Setup      Run keywords
 Initialize test data
     [Documentation]             Reads the no of rows present in reciprocal relationship settings
     ...                         upon login and returns the count
-    ${settings_count} =         Get total settings count
+    ${settings_count} =         Get Records Count       Relationship_Lookup__c      Active__c       True
     Set Suite Variable          ${settings_count}
 
 Delete inserted data


### PR DESCRIPTION
This is a change to an existing test in which UI was used to get the no of records in reciprocal relationship settings. Now the same functionality is tested using API.


# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
