### PR TITLE
[EDA] - Health Check labels missing apostrophes in text

### DIFF
--- a/src/classes/AccountModelHealthCheckVMapper.cls
+++ b/src/classes/AccountModelHealthCheckVMapper.cls
@@ -129,10 +129,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccModelTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeNotFound, 
-                                                                                                new List<Object>{accountModelSettingsModel.defaultAccountModelId}),
-                                                                                String.format(Label.stgHCAccountModelDefaultNotFoundFix, 
-                                                                                                new List<Object>{accountModelSettingsModel.defaultAccountModelId}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeNotFound, 
+                                                                                    new List<Object>{accountModelSettingsModel.defaultAccountModelId}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelDefaultNotFoundFix, 
+                                                                                    new List<Object>{accountModelSettingsModel.defaultAccountModelId}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -144,10 +148,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccModelTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeInactive, 
-                                                                                                new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}),
-                                                                                String.format(Label.stgHCAccountModelDefaultInactiveFix, 
-                                                                                                new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeInactive, 
+                                                                                    new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelDefaultInactiveFix, 
+                                                                                    new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -158,8 +166,10 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAccModelTitle,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            String.format(Label.stgHCRecordTypeValid, 
-                                                                                        new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}),
+                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                Label.stgHCRecordTypeValid, 
+                                                                                new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
+                                                                            ),
                                                                             Label.stgHealthCheckFixNotApplicable,
                                                                             new List<HealthCheckItemVModel>()));
         healthCheckGroupVModel.totalChecks++;
@@ -197,10 +207,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAdminAccountRecordType,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeNotFound, 
-                                                                                                new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}),
-                                                                                String.format(Label.stgHCAccountModelAdminNotFoundFix, 
-                                                                                                new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeNotFound, 
+                                                                                    new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelAdminNotFoundFix, 
+                                                                                    new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -212,10 +226,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAdminAccountRecordType,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeInactive, 
-                                                                                                new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}),
-                                                                                String.format(Label.stgHCAccountModelAdminInactiveFix, 
-                                                                                                new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeInactive, 
+                                                                                    new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelAdminInactiveFix, 
+                                                                                    new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -226,8 +244,10 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAdminAccountRecordType,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            String.format(Label.stgHCRecordTypeValid, 
-                                                                                        new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}),
+                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                Label.stgHCRecordTypeValid, 
+                                                                                new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
+                                                                            ),
                                                                             Label.stgHealthCheckFixNotApplicable,
                                                                             new List<HealthCheckItemVModel>()));
         healthCheckGroupVModel.totalChecks++;
@@ -264,10 +284,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccountRecordTypeSupportsHHAddress,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeNotFound, 
-                                                                                                new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}),
-                                                                                String.format(Label.stgHCAccountModelHHNotFoundFix, 
-                                                                                                new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeNotFound, 
+                                                                                    new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelHHNotFoundFix, 
+                                                                                    new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -279,10 +303,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccountRecordTypeSupportsHHAddress,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeInactive, 
-                                                                                                new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}),
-                                                                                String.format(Label.stgHCAccountModelHHInactiveFix, 
-                                                                                                new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeInactive, 
+                                                                                    new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCAccountModelHHInactiveFix, 
+                                                                                    new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             healthCheckGroupVModel.totalChecks++;
             healthCheckGroupVModel.updateHealthCheckStatus();
@@ -293,8 +321,10 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAccountRecordTypeSupportsHHAddress,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            String.format(Label.stgHCRecordTypeValid, 
-                                                                                        new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}),
+                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                Label.stgHCRecordTypeValid, 
+                                                                                new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
+                                                                            ),
                                                                             Label.stgHealthCheckFixNotApplicable,
                                                                             new List<HealthCheckItemVModel>()));
         healthCheckGroupVModel.totalChecks++;
@@ -371,5 +401,14 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
     @TestVisible
     private RecordTypeService locateRecordTypeService() {
         return RecordTypeService.getInstance();
+    }
+
+    /*****************************************************************************
+    * @description Retrieve an instance of the StringHandlingService class.
+    * @return An instance of StringHandlingService.
+    *****************************************************************************/
+    @TestVisible
+    private StringHandlingService locateStringHandlingService() {
+        return StringHandlingService.getInstance();
     }
 }

--- a/src/classes/AccountModelHealthCheckVMapper.cls
+++ b/src/classes/AccountModelHealthCheckVMapper.cls
@@ -129,11 +129,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccModelTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeNotFound, 
                                                                                     new List<Object>{accountModelSettingsModel.defaultAccountModelId}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelDefaultNotFoundFix, 
                                                                                     new List<Object>{accountModelSettingsModel.defaultAccountModelId}
                                                                                 ),
@@ -148,11 +148,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccModelTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeInactive, 
                                                                                     new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelDefaultInactiveFix, 
                                                                                     new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
                                                                                 ),
@@ -166,7 +166,7 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAccModelTitle,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                 Label.stgHCRecordTypeValid, 
                                                                                 new List<Object>{defaultAccountRTModel.name, defaultAccountRTModel.developerName}
                                                                             ),
@@ -207,11 +207,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAdminAccountRecordType,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeNotFound, 
                                                                                     new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelAdminNotFoundFix, 
                                                                                     new List<Object>{accountModelSettingsModel.administrativeAccountRecordTypeId}
                                                                                 ),
@@ -226,11 +226,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAdminAccountRecordType,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeInactive, 
                                                                                     new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelAdminInactiveFix, 
                                                                                     new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
                                                                                 ),
@@ -244,7 +244,7 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAdminAccountRecordType,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                 Label.stgHCRecordTypeValid, 
                                                                                 new List<Object>{adminAccountRTModel.name, adminAccountRTModel.developerName}
                                                                             ),
@@ -284,11 +284,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccountRecordTypeSupportsHHAddress,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeNotFound, 
                                                                                     new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelHHNotFoundFix, 
                                                                                     new List<Object>{accountModelSettingsModel.householdAccountRecordTypeId}
                                                                                 ),
@@ -303,11 +303,11 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                                 Label.stgAccountRecordTypeSupportsHHAddress,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeInactive, 
                                                                                     new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCAccountModelHHInactiveFix, 
                                                                                     new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
                                                                                 ),
@@ -321,7 +321,7 @@ public virtual with sharing class AccountModelHealthCheckVMapper {
                                                                             Label.stgAccountRecordTypeSupportsHHAddress,
                                                                             'Pass',
                                                                             Label.stgHealthCheckStatusPassed,
-                                                                            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                 Label.stgHCRecordTypeValid, 
                                                                                 new List<Object>{hhAccountRTModel.name, hhAccountRTModel.developerName}
                                                                             ),

--- a/src/classes/AccountModelHealthCheckVMapper_TEST.cls
+++ b/src/classes/AccountModelHealthCheckVMapper_TEST.cls
@@ -202,7 +202,7 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeValid, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -249,11 +249,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeInactive, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelDefaultInactiveFix, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -298,11 +298,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'Not an ID default acct'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelDefaultNotFoundFix, 
             new List<Object>{'Not an ID default acct'}
         );
@@ -348,11 +348,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'000000000000000000'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelDefaultNotFoundFix, 
             new List<Object>{'000000000000000000'}
         );
@@ -398,7 +398,7 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeValid, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -445,11 +445,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeInactive, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelAdminInactiveFix, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -494,11 +494,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'Not an ID admin acct'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelAdminNotFoundFix, 
             new List<Object>{'Not an ID admin acct'}
         );
@@ -544,11 +544,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'000000000000000000'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelAdminNotFoundFix, 
             new List<Object>{'000000000000000000'}
         );
@@ -594,7 +594,7 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeValid, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -641,11 +641,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeInactive, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelHHInactiveFix, 
             new List<Object>{'Test Record Name', 'testRecordDevName'}
         );
@@ -690,11 +690,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'Not an ID HH acct'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelHHNotFoundFix, 
             new List<Object>{'Not an ID HH acct'}
         );
@@ -740,11 +740,11 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{'000000000000000000'}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAccountModelHHNotFoundFix, 
             new List<Object>{'000000000000000000'}
         );

--- a/src/classes/AccountModelHealthCheckVMapper_TEST.cls
+++ b/src/classes/AccountModelHealthCheckVMapper_TEST.cls
@@ -92,6 +92,19 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
     }
 
     /**************************************************************************************************************************
+    * @description Test to verify locateStringHandlingService() returns an instance of the StringHandlingService class.
+    **************************************************************************************************************************/ 
+    @isTest
+    private static void locateStringHandlingServiceValid(){
+        Test.startTest();
+        StringHandlingService stringHandlingServiceInstance = AccountModelHealthCheckVMapper.getInstance().locateStringHandlingService();
+        Test.stopTest();
+
+        System.assertEquals(StringHandlingService.getInstance(), stringHandlingServiceInstance, 'Should return instance of StringHandlingService class.');
+        System.assertEquals(true, stringHandlingServiceInstance != null, 'Instance of StringHandlingService class should not be null.');
+    }
+
+    /**************************************************************************************************************************
     * @description Test to verify combineAccountHealthCheckGroupViewModels() returns a combined HealthCheckGroupVModel comprised of
     * the combined properties of the group view models passed as arguments.
     **************************************************************************************************************************/ 
@@ -189,7 +202,10 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeValid, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeValid, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
         String expectedFix = Label.stgHealthCheckFixNotApplicable;
 
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccModelTitle, 
@@ -233,8 +249,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeInactive, new List<Object>{'Test Record Name', 'testRecordDevName'});
-        String expectedFix = String.format(Label.stgHCAccountModelDefaultInactiveFix, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeInactive, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelDefaultInactiveFix, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
 
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccModelTitle, 
                                                                                 'Fail', 
@@ -276,8 +298,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'Not an ID default acct'});
-        String expectedFix = String.format(Label.stgHCAccountModelDefaultNotFoundFix, new List<Object>{'Not an ID default acct'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'Not an ID default acct'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelDefaultNotFoundFix, 
+            new List<Object>{'Not an ID default acct'}
+        );
 
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccModelTitle, 
                                                                                 'Fail', 
@@ -320,8 +348,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'000000000000000000'});
-        String expectedFix = String.format(Label.stgHCAccountModelDefaultNotFoundFix, new List<Object>{'000000000000000000'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'000000000000000000'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelDefaultNotFoundFix, 
+            new List<Object>{'000000000000000000'}
+        );
 
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccModelTitle, 
                                                                                 'Fail', 
@@ -364,7 +398,10 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeValid, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeValid, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
         String expectedFix = Label.stgHealthCheckFixNotApplicable;
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAdminAccountRecordType, 
@@ -408,8 +445,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeInactive, new List<Object>{'Test Record Name', 'testRecordDevName'});
-        String expectedFix = String.format(Label.stgHCAccountModelAdminInactiveFix, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeInactive, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelAdminInactiveFix, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAdminAccountRecordType, 
                                                                                 'Fail', 
@@ -451,8 +494,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'Not an ID admin acct'});
-        String expectedFix = String.format(Label.stgHCAccountModelAdminNotFoundFix, new List<Object>{'Not an ID admin acct'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'Not an ID admin acct'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelAdminNotFoundFix, 
+            new List<Object>{'Not an ID admin acct'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAdminAccountRecordType, 
                                                                                 'Fail', 
@@ -495,8 +544,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'000000000000000000'});
-        String expectedFix = String.format(Label.stgHCAccountModelAdminNotFoundFix, new List<Object>{'000000000000000000'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'000000000000000000'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelAdminNotFoundFix, 
+            new List<Object>{'000000000000000000'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAdminAccountRecordType, 
                                                                                 'Fail', 
@@ -539,7 +594,10 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeValid, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeValid, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
         String expectedFix = Label.stgHealthCheckFixNotApplicable;
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccountRecordTypeSupportsHHAddress, 
@@ -583,8 +641,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeInactive, new List<Object>{'Test Record Name', 'testRecordDevName'});
-        String expectedFix = String.format(Label.stgHCAccountModelHHInactiveFix, new List<Object>{'Test Record Name', 'testRecordDevName'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeInactive, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelHHInactiveFix, 
+            new List<Object>{'Test Record Name', 'testRecordDevName'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccountRecordTypeSupportsHHAddress, 
                                                                                 'Fail', 
@@ -626,8 +690,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'Not an ID HH acct'});
-        String expectedFix = String.format(Label.stgHCAccountModelHHNotFoundFix, new List<Object>{'Not an ID HH acct'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'Not an ID HH acct'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelHHNotFoundFix, 
+            new List<Object>{'Not an ID HH acct'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccountRecordTypeSupportsHHAddress, 
                                                                                 'Fail', 
@@ -670,8 +740,14 @@ public with sharing class AccountModelHealthCheckVMapper_TEST {
                                                                                    1,
                                                                                    healthCheckGroupVModel);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{'000000000000000000'});
-        String expectedFix = String.format(Label.stgHCAccountModelHHNotFoundFix, new List<Object>{'000000000000000000'});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{'000000000000000000'}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCAccountModelHHNotFoundFix, 
+            new List<Object>{'000000000000000000'}
+        );
         
         AccountModelHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgAccountRecordTypeSupportsHHAddress, 
                                                                                 'Fail', 

--- a/src/classes/AffiliationMappingsHCVMapper_TEST.cls
+++ b/src/classes/AffiliationMappingsHCVMapper_TEST.cls
@@ -120,6 +120,19 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
         System.assertEquals(true, PicklistEntryServiceInstance != null, 'Instance of PicklistEntryService class should not be null.');
     }
 
+    /**************************************************************************************************************************
+    * @description Test to verify locateStringHandlingService() returns an instance of the StringHandlingService class.
+    **************************************************************************************************************************/ 
+    @isTest
+    private static void locateStringHandlingServiceValid() {
+        Test.startTest();
+        StringHandlingService StringHandlingServiceInstance = AffiliationMappingsHealthCheckVMapper.getInstance().locateStringHandlingService();
+        Test.stopTest();
+
+        System.assertEquals(StringHandlingService.getInstance(), StringHandlingServiceInstance, 'Should return instance of StringHandlingService class.');
+        System.assertEquals(true, StringHandlingServiceInstance != null, 'Instance of StringHandlingService class should not be null.');
+    }
+
     /***************************************************************************
     * @description Test method to verify that getHealthCheckGroup handles all
     * passed health checks
@@ -283,7 +296,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCRecordTypeValid, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -342,11 +355,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCRecordTypeInactive, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
@@ -399,11 +412,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCRecordTypeNotFound, 
                 new List<Object>{affiliationMappingModelsList[0].accountRecordTypeFieldValue} 
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                 new List<Object>{affiliationMappingModelsList[0].accountRecordTypeFieldValue}
             ),
@@ -470,7 +483,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUnique, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -532,11 +545,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCRecordTypeNotFound, 
                 new List<Object>{affiliationMappingsModelsList[0].accountRecordTypeFieldValue} 
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                 new List<Object>{affiliationMappingsModelsList[0].accountRecordTypeFieldValue}
             ),
@@ -602,11 +615,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCRecordTypeInactive, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
@@ -673,11 +686,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotUnique, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUniqueFix, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -735,7 +748,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].primaryAffiliationField, 
@@ -796,7 +809,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].primaryAffiliationField, 
@@ -853,11 +866,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
@@ -902,7 +915,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
         List<String> listForSettingsLabel =
             new List<String>{affiliationMappingsModel.name};
         
-        String healthCheckItemSetting = String.format(
+        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
             Label.stgHCAffiliationMappingSettingHeading,
             listForSettingsLabel
         );
@@ -962,11 +975,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
@@ -1004,7 +1017,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
         List<String> listForSettingsLabel =
             new List<String>{affiliationMappingsModel.name};
         
-        String healthCheckItemSetting = String.format(
+        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
             Label.stgHCAffiliationMappingSettingHeading,
             listForSettingsLabel
         );
@@ -1069,7 +1082,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUnique, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
@@ -1126,11 +1139,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {'Valid Contact Lookup Field Name'}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {'Valid Contact Lookup Field Name'}
             ),
@@ -1189,13 +1202,13 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldNotUnique, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
                     'Valid Contact Lookup Field Name'}
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUniqueFix, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
@@ -1429,7 +1442,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleValid, 
                 new List<Object> {
                     affiliationRolePicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentRole).label, 
@@ -1501,14 +1514,14 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleInactive, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentRole, 
                     affiliationRolePicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentRole).name
                 }
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleInactiveFix, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentRole, 
@@ -1579,7 +1592,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentRole}
             ),
@@ -1648,7 +1661,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentRole}
             ),
@@ -1757,7 +1770,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusValid, 
                 new List<Object> {
                 affiliationStatusPicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentStatus).label, 
@@ -1829,14 +1842,14 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusInactive, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentStatus, 
                     affiliationStatusPicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentStatus).name
                 }
             ),
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusInactiveFix, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentStatus, 
@@ -1907,7 +1920,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentStatus}
             ),
@@ -1976,7 +1989,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentStatus}
             ),

--- a/src/classes/AffiliationMappingsHCVMapper_TEST.cls
+++ b/src/classes/AffiliationMappingsHCVMapper_TEST.cls
@@ -296,7 +296,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCRecordTypeValid, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -355,11 +355,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCRecordTypeInactive, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
@@ -412,11 +412,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCRecordTypeNotFound, 
                 new List<Object>{affiliationMappingModelsList[0].accountRecordTypeFieldValue} 
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                 new List<Object>{affiliationMappingModelsList[0].accountRecordTypeFieldValue}
             ),
@@ -483,7 +483,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUnique, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -545,11 +545,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCRecordTypeNotFound, 
                 new List<Object>{affiliationMappingsModelsList[0].accountRecordTypeFieldValue} 
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                 new List<Object>{affiliationMappingsModelsList[0].accountRecordTypeFieldValue}
             ),
@@ -615,11 +615,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCRecordTypeInactive, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                 new List<Object> {'Inactive RecordType Label', 'inactiveRTDevName'}
             ),
@@ -686,11 +686,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotUnique, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUniqueFix, 
                 new List<Object> {'Active RecordType Label', 'activeRTDevName'}
             ),
@@ -748,7 +748,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].primaryAffiliationField, 
@@ -809,7 +809,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].primaryAffiliationField, 
@@ -866,11 +866,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
@@ -915,7 +915,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
         List<String> listForSettingsLabel =
             new List<String>{affiliationMappingsModel.name};
         
-        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAffiliationMappingSettingHeading,
             listForSettingsLabel
         );
@@ -975,11 +975,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {affiliationMappingsModelsList[0].primaryAffiliationField}
             ),
@@ -1017,7 +1017,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
         List<String> listForSettingsLabel =
             new List<String>{affiliationMappingsModel.name};
         
-        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String healthCheckItemSetting = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCAffiliationMappingSettingHeading,
             listForSettingsLabel
         );
@@ -1082,7 +1082,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUnique, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
@@ -1139,11 +1139,11 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                 new List<Object> {'Valid Contact Lookup Field Name'}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                 new List<Object> {'Valid Contact Lookup Field Name'}
             ),
@@ -1202,13 +1202,13 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,  
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldNotUnique, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
                     'Valid Contact Lookup Field Name'}
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUniqueFix, 
                 new List<Object> {
                     'Valid Contact Lookup Field Label', 
@@ -1442,7 +1442,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleValid, 
                 new List<Object> {
                     affiliationRolePicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentRole).label, 
@@ -1514,14 +1514,14 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleInactive, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentRole, 
                     affiliationRolePicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentRole).name
                 }
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleInactiveFix, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentRole, 
@@ -1592,7 +1592,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentRole}
             ),
@@ -1661,7 +1661,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentRole}
             ),
@@ -1770,7 +1770,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusValid, 
                 new List<Object> {
                 affiliationStatusPicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentStatus).label, 
@@ -1842,14 +1842,14 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusInactive, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentStatus, 
                     affiliationStatusPicklistEntryModelByName.get(affiliationMappingsModelsList[0].autoProgramEnrollmentStatus).name
                 }
             ),
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusInactiveFix, 
                 new List<Object> {
                     affiliationMappingsModelsList[0].autoProgramEnrollmentStatus, 
@@ -1920,7 +1920,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentStatus}
             ),
@@ -1989,7 +1989,7 @@ public with sharing class AffiliationMappingsHCVMapper_TEST {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                 new List<Object> {affiliationMappingsModelsList[0].autoProgramEnrollmentStatus}
             ),

--- a/src/classes/AffiliationMappingsHealthCheckVMapper.cls
+++ b/src/classes/AffiliationMappingsHealthCheckVMapper.cls
@@ -263,7 +263,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
 
         return new HealthCheckItemVModel(
             affiliationMappingsModel.name,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAffiliationMappingSettingHeading,
                 listForSettingsLabel
             ),
@@ -302,7 +302,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollStatusTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                     new List<Object>{affiliationMappingsModel.autoProgramEnrollmentStatus}
                 ),
@@ -323,14 +323,14 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollStatusTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusInactive, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentStatus, 
                         picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentStatus).name
                     }
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusInactiveFix, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentStatus, 
@@ -352,7 +352,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusValid, 
                 new List<Object>{
                     picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentStatus).label, 
@@ -397,7 +397,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollRoleTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                     new List<Object>{affiliationMappingsModel.autoProgramEnrollmentRole}
                 ),
@@ -417,14 +417,14 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollRoleTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleInactive, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentRole, 
                         picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentRole).name
                     }
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleInactiveFix, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentRole, 
@@ -445,7 +445,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleValid, 
                 new List<Object>{
                     picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentRole).label, 
@@ -486,11 +486,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapContactPrimaryFieldTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
@@ -508,7 +508,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object>{
                     affiliationMappingsModel.primaryAffiliationField, 
@@ -549,11 +549,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCRecordTypeNotFound, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
@@ -569,11 +569,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCRecordTypeInactive, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -589,7 +589,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Pass',
                 Label.stgHealthCheckStatusPassed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCRecordTypeValid, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -631,11 +631,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCRecordTypeNotFound, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
@@ -653,11 +653,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCRecordTypeInactive, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -675,11 +675,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotUnique, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUniqueFix, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
@@ -696,7 +696,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUnique, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
@@ -735,11 +735,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
@@ -757,11 +757,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldNotUnique, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUniqueFix, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),
@@ -778,7 +778,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            String.format(
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUnique, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),
@@ -826,6 +826,15 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
     @TestVisible
     private PicklistEntryService locatePicklistEntryService() {
         return PicklistEntryService.getInstance();
+    }
+
+    /*****************************************************************************
+    * @description Retrieve an instance of the StringHandlingService class.
+    * @return An instance of StringHandlingService.
+    *****************************************************************************/
+    @TestVisible
+    private StringHandlingService locateStringHandlingService() {
+        return StringHandlingService.getInstance();
     }
 
     /**********************************************************************************

--- a/src/classes/AffiliationMappingsHealthCheckVMapper.cls
+++ b/src/classes/AffiliationMappingsHealthCheckVMapper.cls
@@ -263,7 +263,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
 
         return new HealthCheckItemVModel(
             affiliationMappingsModel.name,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAffiliationMappingSettingHeading,
                 listForSettingsLabel
             ),
@@ -302,7 +302,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollStatusTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusNotFound, 
                     new List<Object>{affiliationMappingsModel.autoProgramEnrollmentStatus}
                 ),
@@ -323,14 +323,14 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollStatusTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusInactive, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentStatus, 
                         picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentStatus).name
                     }
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollStatusInactiveFix, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentStatus, 
@@ -352,7 +352,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAutoEnrollStatusTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollStatusValid, 
                 new List<Object>{
                     picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentStatus).label, 
@@ -397,7 +397,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollRoleTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleNotFound, 
                     new List<Object>{affiliationMappingsModel.autoProgramEnrollmentRole}
                 ),
@@ -417,14 +417,14 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAutoEnrollRoleTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleInactive, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentRole, 
                         picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentRole).name
                     }
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAutoEnrollRoleInactiveFix, 
                     new List<Object>{
                         affiliationMappingsModel.autoProgramEnrollmentRole, 
@@ -445,7 +445,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAutoEnrollRoleTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAutoEnrollRoleValid, 
                 new List<Object>{
                     picklistEntryModelByName.get(affiliationMappingsModel.autoProgramEnrollmentRole).label, 
@@ -486,11 +486,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapContactPrimaryFieldTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
@@ -508,7 +508,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContactPrimaryFieldTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldValid, 
                 new List<Object>{
                     affiliationMappingsModel.primaryAffiliationField, 
@@ -549,11 +549,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCRecordTypeNotFound, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
@@ -569,11 +569,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCRecordTypeInactive, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -589,7 +589,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeTitle,
                 'Pass',
                 Label.stgHealthCheckStatusPassed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCRecordTypeValid, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -631,11 +631,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCRecordTypeNotFound, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAccRecordTypeNotFoundFix, 
                     new List<Object>{affiliationMappingsModel.accountRecordTypeFieldValue}
                 ),
@@ -653,11 +653,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapAccRecordTypeUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCRecordTypeInactive, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapAccRecordTypeInactiveFix, 
                     new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
                 ),
@@ -675,11 +675,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeNotUnique, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUniqueFix, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
@@ -696,7 +696,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapAccRecordTypeUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapAccRecordTypeUnique, 
                 new List<Object>{accountRecordTypeModel.name, accountRecordTypeModel.developerName}
             ),
@@ -735,11 +735,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
                 Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapContactPrimaryFieldInvalid, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCAfflMapContPrimaryFieldInvalidFix, 
                     new List<Object>{affiliationMappingsModel.primaryAffiliationField}
                 ),
@@ -757,11 +757,11 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
             'Fail',
             Label.stgHealthCheckStatusFailed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldNotUnique, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUniqueFix, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),
@@ -778,7 +778,7 @@ public virtual with sharing class AffiliationMappingsHealthCheckVMapper {
             Label.stgHCAfflMapContPrimaryFieldUniqueTitle,
             'Pass',
             Label.stgHealthCheckStatusPassed,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCAfflMapContactPrimaryFieldUnique, 
                 new List<Object>{accountlookupFieldOnContactFieldModel.label, accountlookupFieldOnContactFieldModel.name}
             ),

--- a/src/classes/CourseConSettingHealthCheckVMapper.cls
+++ b/src/classes/CourseConSettingHealthCheckVMapper.cls
@@ -180,8 +180,10 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultStudentTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeNotFound, 
-                                                                                                new List<Object>{courseConnectionSettingsModel.studentRecordTypeId}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeNotFound, 
+                                                                                    new List<Object>{courseConnectionSettingsModel.studentRecordTypeId}
+                                                                                ),
                                                                                 Label.stgHCCourseConStudentNotFoundFix,
                                                                                 new List<HealthCheckItemVModel>()));
             hlthChkGroupVMod.totalChecks++;
@@ -193,10 +195,14 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultStudentTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeInactive, 
-                                                                                                new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}),
-                                                                                String.format(Label.stgHCCourseConStudentInactiveFix, 
-                                                                                                new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeInactive, 
+                                                                                    new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCCourseConStudentInactiveFix, 
+                                                                                    new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             hlthChkGroupVMod.totalChecks++;
             return hlthChkGroupVMod;
@@ -206,8 +212,10 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                           Label.stgDefaultStudentTypeTitle,
                                                                           'Pass',
                                                                           Label.stgHealthCheckStatusPassed,
-                                                                          String.format(Label.stgHCRecordTypeValid, 
-                                                                                      new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}),
+                                                                          this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                Label.stgHCRecordTypeValid, 
+                                                                                new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
+                                                                            ),
                                                                           Label.stgHealthCheckFixNotApplicable,
                                                                           new List<HealthCheckItemVModel>()));
         hlthChkGroupVMod.totalChecks++;
@@ -243,8 +251,10 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultFacultyTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeNotFound, 
-                                                                                                new List<Object>{courseConnectionSettingsModel.facultyRecordTypeId}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeNotFound, 
+                                                                                    new List<Object>{courseConnectionSettingsModel.facultyRecordTypeId}
+                                                                                ),
                                                                                 Label.stgHCCourseConFacultyNotFoundFix,
                                                                                 new List<HealthCheckItemVModel>()));
             hlthChkGroupVMod.totalChecks++;
@@ -256,10 +266,14 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultFacultyTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                String.format(Label.stgHCRecordTypeInactive, 
-                                                                                                new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}),
-                                                                                String.format(Label.stgHCCourseConFacultyInactiveFix, 
-                                                                                                new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCRecordTypeInactive, 
+                                                                                    new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
+                                                                                ),
+                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                    Label.stgHCCourseConFacultyInactiveFix, 
+                                                                                    new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
+                                                                                ),
                                                                                 new List<HealthCheckItemVModel>()));
             hlthChkGroupVMod.totalChecks++;
             return hlthChkGroupVMod;
@@ -269,8 +283,10 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                           Label.stgDefaultFacultyTypeTitle,
                                                                           'Pass',
                                                                           Label.stgHealthCheckStatusPassed,
-                                                                          String.format(Label.stgHCRecordTypeValid, 
-                                                                                      new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}),
+                                                                          this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                Label.stgHCRecordTypeValid, 
+                                                                                new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
+                                                                            ),
                                                                           Label.stgHealthCheckFixNotApplicable,
                                                                           new List<HealthCheckItemVModel>()));
         hlthChkGroupVMod.totalChecks++;
@@ -346,5 +362,14 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
     @TestVisible
     private RecordTypeService locateRecordTypeService() {
         return RecordTypeService.getInstance();
+    }
+
+    /*****************************************************************************
+    * @description Retrieve an instance of the StringHandlingService class.
+    * @return An instance of StringHandlingService.
+    *****************************************************************************/
+    @TestVisible
+    private StringHandlingService locateStringHandlingService() {
+        return StringHandlingService.getInstance();
     }
 }

--- a/src/classes/CourseConSettingHealthCheckVMapper.cls
+++ b/src/classes/CourseConSettingHealthCheckVMapper.cls
@@ -180,7 +180,7 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultStudentTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeNotFound, 
                                                                                     new List<Object>{courseConnectionSettingsModel.studentRecordTypeId}
                                                                                 ),
@@ -195,11 +195,11 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultStudentTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeInactive, 
                                                                                     new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCCourseConStudentInactiveFix, 
                                                                                     new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
                                                                                 ),
@@ -212,7 +212,7 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                           Label.stgDefaultStudentTypeTitle,
                                                                           'Pass',
                                                                           Label.stgHealthCheckStatusPassed,
-                                                                          this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                          this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                 Label.stgHCRecordTypeValid, 
                                                                                 new List<Object>{studentRecTypeModel.name, studentRecTypeModel.developerName}
                                                                             ),
@@ -251,7 +251,7 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultFacultyTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeNotFound, 
                                                                                     new List<Object>{courseConnectionSettingsModel.facultyRecordTypeId}
                                                                                 ),
@@ -266,11 +266,11 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                                 Label.stgDefaultFacultyTypeTitle,
                                                                                 'Fail',
                                                                                 Label.stgHealthCheckStatusFailed,
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCRecordTypeInactive, 
                                                                                     new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
                                                                                 ),
-                                                                                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                     Label.stgHCCourseConFacultyInactiveFix, 
                                                                                     new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
                                                                                 ),
@@ -283,7 +283,7 @@ public virtual with sharing class CourseConSettingHealthCheckVMapper {
                                                                           Label.stgDefaultFacultyTypeTitle,
                                                                           'Pass',
                                                                           Label.stgHealthCheckStatusPassed,
-                                                                          this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                                                                          this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                                                                                 Label.stgHCRecordTypeValid, 
                                                                                 new List<Object>{facultyRecTypeModel.name, facultyRecTypeModel.developerName}
                                                                             ),

--- a/src/classes/CourseConSettingHealthCheckVMapper_TEST.cls
+++ b/src/classes/CourseConSettingHealthCheckVMapper_TEST.cls
@@ -417,7 +417,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{courseConnModSettMod.studentRecordTypeId});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{courseConnModSettMod.studentRecordTypeId}
+        );
         String expectedFix = Label.stgHCCourseConStudentNotFoundFix;
         
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultStudentTypeTitle, 
@@ -461,7 +464,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{courseConnModSettMod.studentRecordTypeId});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{courseConnModSettMod.studentRecordTypeId}
+        );
         String expectedFix = Label.stgHCCourseConStudentNotFoundFix;
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultStudentTypeTitle, 
@@ -505,8 +511,14 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeInactive, new List<Object>{rtModel.name, rtModel.developerName});
-        String expectedFix = String.format(Label.stgHCCourseConStudentInactiveFix, new List<Object>{rtModel.name, rtModel.developerName});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeInactive, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCCourseConStudentInactiveFix, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultStudentTypeTitle, 
                                                                                    'Fail', 
@@ -549,7 +561,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeValid, new List<Object>{rtModel.name, rtModel.developerName});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeValid, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
         String expectedFix = Label.stgHealthCheckFixNotApplicable;
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultStudentTypeTitle, 
@@ -597,7 +612,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{courseConnModSettMod.facultyRecordTypeId});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{courseConnModSettMod.facultyRecordTypeId}
+        );
         String expectedFix = Label.stgHCCourseConFacultyNotFoundFix;
         
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultFacultyTypeTitle, 
@@ -641,7 +659,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeNotFound, new List<Object>{courseConnModSettMod.facultyRecordTypeId});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeNotFound, 
+            new List<Object>{courseConnModSettMod.facultyRecordTypeId}
+        );
         String expectedFix = Label.stgHCCourseConFacultyNotFoundFix;
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultFacultyTypeTitle, 
@@ -685,8 +706,14 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeInactive, new List<Object>{rtModel.name, rtModel.developerName});
-        String expectedFix = String.format(Label.stgHCCourseConFacultyInactiveFix, new List<Object>{rtModel.name, rtModel.developerName});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeInactive, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
+        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCCourseConFacultyInactiveFix, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultFacultyTypeTitle, 
                                                                                    'Fail', 
@@ -729,7 +756,10 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = String.format(Label.stgHCRecordTypeValid, new List<Object>{rtModel.name, rtModel.developerName});
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            Label.stgHCRecordTypeValid, 
+            new List<Object>{rtModel.name, rtModel.developerName}
+        );
         String expectedFix = Label.stgHealthCheckFixNotApplicable;
 
         CourseConSettingHealthCheckVMapper_TEST.verifyHealthCheckItemListAssertions(Label.stgDefaultFacultyTypeTitle, 
@@ -879,6 +909,36 @@ private class CourseConSettingHealthCheckVMapper_TEST {
         System.assertEquals(
             expectedRecordTypeService,
             recTypeService,
+            'Instance of service class from view model mapper should match the singleton instance.'
+        );
+    }
+
+    /***************************************************************************
+    * @description Test method to verify that a
+    * StringHandlingService is retrieved by the locator method.
+    ***************************************************************************/
+    @isTest 
+    private static void locateStringHandlingService(){
+        StringHandlingService expectedStringHandlingService
+            = StringHandlingService.getInstance();
+
+        CourseConSettingHealthCheckVMapper courseConHealthCheckVMapper =
+            CourseConSettingHealthCheckVMapper.getInstance();
+
+        Test.startTest();
+            StringHandlingService stringHandlingService
+                = courseConHealthCheckVMapper.locateStringHandlingService();
+        Test.stopTest();
+
+        System.assertNotEquals(
+            null,
+            stringHandlingService,
+            'Instance of service class should not be null.'
+        );
+
+        System.assertEquals(
+            expectedStringHandlingService,
+            stringHandlingService,
             'Instance of service class from view model mapper should match the singleton instance.'
         );
     }

--- a/src/classes/CourseConSettingHealthCheckVMapper_TEST.cls
+++ b/src/classes/CourseConSettingHealthCheckVMapper_TEST.cls
@@ -417,7 +417,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{courseConnModSettMod.studentRecordTypeId}
         );
@@ -464,7 +464,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{courseConnModSettMod.studentRecordTypeId}
         );
@@ -511,11 +511,11 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeInactive, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCCourseConStudentInactiveFix, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );
@@ -561,7 +561,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeValid, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );
@@ -612,7 +612,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{courseConnModSettMod.facultyRecordTypeId}
         );
@@ -659,7 +659,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeNotFound, 
             new List<Object>{courseConnModSettMod.facultyRecordTypeId}
         );
@@ -706,11 +706,11 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeInactive, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );
-        String expectedFix = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedFix = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCCourseConFacultyInactiveFix, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );
@@ -756,7 +756,7 @@ private class CourseConSettingHealthCheckVMapper_TEST {
                                                                                        1,
                                                                                        hlthChkGroupVMod);
 
-        String expectedDescription = StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+        String expectedDescription = StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
             Label.stgHCRecordTypeValid, 
             new List<Object>{rtModel.name, rtModel.developerName}
         );

--- a/src/classes/ReciprocalRelHealthCheckVMapper.cls
+++ b/src/classes/ReciprocalRelHealthCheckVMapper.cls
@@ -361,11 +361,11 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
                 settingsLabel,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCPicklistValueNotFound,
                     modelNameListForFormat
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     notFoundFix,
                     modelNameListForFormat
                 ),
@@ -384,13 +384,13 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         if(picklistEntryModel.isActive == false) {
             healthCheckItemVModel.description =
-                String.format(
-                    Label.stgHCPicklistValueInactive,
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                    Label.stgHCPicklistValueInactive, 
                     picklistLabelAndNameForFormat
                 );
             healthCheckItemVModel.recommendedFix = 
-                String.format(
-                    inactiveFix,
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                    inactiveFix, 
                     picklistLabelAndNameForFormat
                 );
             return healthCheckGroupVModel;
@@ -398,7 +398,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         healthCheckItemVModel.status = 'Pass';
         healthCheckItemVModel.statusLabel = Label.stgHealthCheckStatusPassed;
-        healthCheckItemVModel.description = String.format(
+        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCPicklistValueValid,
                 picklistLabelAndNameForFormat
             );
@@ -451,11 +451,11 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
                 Label.stgHCReciprocalRelNameUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCReciprocalRelNameNotUniqueDesc,
                     modelNameListForFormat
                 ),
-                String.format(
+                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                     Label.stgHCReciprocalRelNameNotUniqueFix,
                     modelNameListForFormat
                 ),
@@ -471,7 +471,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         healthCheckItemVModel.status = 'Pass';
         healthCheckItemVModel.statusLabel = Label.stgHealthCheckStatusPassed;
-        healthCheckItemVModel.description = String.format(
+        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
                 Label.stgHCReciprocalRelNameUniqueDesc,
                 modelNameListForFormat
             );
@@ -504,7 +504,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
 
         return new HealthCheckItemVModel(
             relationshipLookupModel.name,
-            String.format(Label.stgHCReciprocalRelSetting,listForSettingsLabel),
+            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(Label.stgHCReciprocalRelSetting,listForSettingsLabel),
             'Pass',
             Label.stgHealthCheckStatusPassed,
             '',
@@ -529,5 +529,14 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     @TestVisible
     private RelationshipLookupSettingsService locateRelationshipLookupSettingsService(){
         return RelationshipLookupSettingsService.getInstance();
+    }
+
+    /***************************************************************************
+    * @description Retrieves an instance of StringHandlingService. 
+    * @return An instance of StringHandlingService.
+    ***************************************************************************/
+    @TestVisible
+    private StringHandlingService locateStringHandlingService(){
+        return StringHandlingService.getInstance();
     }
 }

--- a/src/classes/ReciprocalRelHealthCheckVMapper.cls
+++ b/src/classes/ReciprocalRelHealthCheckVMapper.cls
@@ -361,11 +361,11 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
                 settingsLabel,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCPicklistValueNotFound,
                     modelNameListForFormat
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     notFoundFix,
                     modelNameListForFormat
                 ),
@@ -384,12 +384,12 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         if(picklistEntryModel.isActive == false) {
             healthCheckItemVModel.description =
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCPicklistValueInactive, 
                     picklistLabelAndNameForFormat
                 );
             healthCheckItemVModel.recommendedFix = 
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     inactiveFix, 
                     picklistLabelAndNameForFormat
                 );
@@ -398,7 +398,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         healthCheckItemVModel.status = 'Pass';
         healthCheckItemVModel.statusLabel = Label.stgHealthCheckStatusPassed;
-        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCPicklistValueValid,
                 picklistLabelAndNameForFormat
             );
@@ -451,11 +451,11 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
                 Label.stgHCReciprocalRelNameUniqueTitle,
                 'Fail',
                 Label.stgHealthCheckStatusFailed,
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCReciprocalRelNameNotUniqueDesc,
                     modelNameListForFormat
                 ),
-                this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+                this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                     Label.stgHCReciprocalRelNameNotUniqueFix,
                     modelNameListForFormat
                 ),
@@ -471,7 +471,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
     
         healthCheckItemVModel.status = 'Pass';
         healthCheckItemVModel.statusLabel = Label.stgHealthCheckStatusPassed;
-        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithQuotationsAndParameters(
+        healthCheckItemVModel.description = this.locateStringHandlingService().formatStringWithApostrophesAndParameters(
                 Label.stgHCReciprocalRelNameUniqueDesc,
                 modelNameListForFormat
             );
@@ -504,7 +504,7 @@ public virtual with sharing class ReciprocalRelHealthCheckVMapper {
 
         return new HealthCheckItemVModel(
             relationshipLookupModel.name,
-            this.locateStringHandlingService().formatStringWithQuotationsAndParameters(Label.stgHCReciprocalRelSetting,listForSettingsLabel),
+            this.locateStringHandlingService().formatStringWithApostrophesAndParameters(Label.stgHCReciprocalRelSetting,listForSettingsLabel),
             'Pass',
             Label.stgHealthCheckStatusPassed,
             '',

--- a/src/classes/ReciprocalRelHealthCheckVMapper_TEST.cls
+++ b/src/classes/ReciprocalRelHealthCheckVMapper_TEST.cls
@@ -1467,7 +1467,7 @@ private class ReciprocalRelHealthCheckVMapper_TEST {
             'The Health Check Item\'s status label should match the specified label.'
         );
         System.assertEquals(
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 description,
                 labelAndNameForFormat
             ),
@@ -1475,7 +1475,7 @@ private class ReciprocalRelHealthCheckVMapper_TEST {
             'The Health Check Item\'s description should match the specified label.'
         );
         System.assertEquals(
-            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
+            StringHandlingService.getInstance().formatStringWithApostrophesAndParameters(
                 recommendedFix,
                 labelAndNameForFormat
             ),

--- a/src/classes/ReciprocalRelHealthCheckVMapper_TEST.cls
+++ b/src/classes/ReciprocalRelHealthCheckVMapper_TEST.cls
@@ -1368,6 +1368,36 @@ private class ReciprocalRelHealthCheckVMapper_TEST {
     }
 
     /***************************************************************************
+    * @description Test method to verify that a
+    * StringHandlingService is retrieved by the locator method.
+    ***************************************************************************/
+    @isTest 
+    private static void locateStringHandlingService(){
+        StringHandlingService expectedStringHandlingService
+            = StringHandlingService.getInstance();
+
+        ReciprocalRelHealthCheckVMapper reciprocalRelHealthCheckVMapper =
+            ReciprocalRelHealthCheckVMapper.getInstance();
+
+        Test.startTest();
+            StringHandlingService StringHandlingService
+                = reciprocalRelHealthCheckVMapper.locateStringHandlingService();
+        Test.stopTest();
+
+        System.assertNotEquals(
+            null,
+            StringHandlingService,
+            'Instance of service class should not be null.'
+        );
+
+        System.assertEquals(
+            expectedStringHandlingService,
+            StringHandlingService,
+            'Instance of service class from view model mapper should match the singleton instance.'
+        );
+    }
+
+    /***************************************************************************
     *******************************TEST HELPERS*********************************
     ***************************************************************************/
 
@@ -1437,7 +1467,7 @@ private class ReciprocalRelHealthCheckVMapper_TEST {
             'The Health Check Item\'s status label should match the specified label.'
         );
         System.assertEquals(
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 description,
                 labelAndNameForFormat
             ),
@@ -1445,7 +1475,7 @@ private class ReciprocalRelHealthCheckVMapper_TEST {
             'The Health Check Item\'s description should match the specified label.'
         );
         System.assertEquals(
-            String.format(
+            StringHandlingService.getInstance().formatStringWithQuotationsAndParameters(
                 recommendedFix,
                 labelAndNameForFormat
             ),

--- a/src/classes/StringHandlingService.cls
+++ b/src/classes/StringHandlingService.cls
@@ -56,13 +56,13 @@ public with sharing class StringHandlingService {
     }
 
     /**************************************************************************************************
-    * @description Prepends a single quotation (') character to escape existing single quotations 
-    * in a string and substitutes parameters with values provided.
-    * @param  stringToFormat A string with single quotes to escape and parameters to substitute
+    * @description Prepends an apostrophe (') character to escape existing apostrophes in a string and 
+    * substitutes parameters with values provided.
+    * @param  stringToFormat A string with apostrophes to escape and parameters to substitute
     * @param  stringParameterList A list of string parameters
-    * @return A formatted string with single quotes escaped and parameters populated.
+    * @return A formatted string with apostrophes escaped and parameters populated.
     **************************************************************************************************/
-    public String formatStringWithQuotationsAndParameters(
+    public String formatStringWithApostrophesAndParameters(
         String stringToFormat, 
         List<Object> stringParameterList
     ) {

--- a/src/classes/StringHandlingService.cls
+++ b/src/classes/StringHandlingService.cls
@@ -70,7 +70,7 @@ public with sharing class StringHandlingService {
         String escapedSingleQuote = '\'\'';
 
         String stringWithEscapedSingleQuotes = 
-            stringToFormat.replace(unescapedSingleQuote,  escaptedSingleQuote);
+            stringToFormat.replace(unescapedSingleQuote, escapedSingleQuote);
 
         String stringWithEscapedQuotesAndParameters = 
             String.format(

--- a/src/classes/StringHandlingService.cls
+++ b/src/classes/StringHandlingService.cls
@@ -67,7 +67,7 @@ public with sharing class StringHandlingService {
         List<Object> stringParameterList
     ) {
         String unescapedSingleQuote = '\'';
-        String escaptedSingleQuote = '\'\'';
+        String escapedSingleQuote = '\'\'';
 
         String stringWithEscapedSingleQuotes = 
             stringToFormat.replace(unescapedSingleQuote,  escaptedSingleQuote);

--- a/src/classes/StringHandlingService.cls
+++ b/src/classes/StringHandlingService.cls
@@ -1,0 +1,83 @@
+/*
+    Copyright (c) 2021, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @group 
+* @group-content ../../ApexDocContent/
+* @description Service class to address String functionality not provided out of the box.
+*/
+public with sharing class StringHandlingService {
+    /*********************************************
+    * @description Instance for Singleton Pattern
+    **********************************************/
+    @TestVisible
+    private static StringHandlingService instance;
+
+    /*********************************************************************
+    * @description Empty constructor is not public for Singleton Pattern
+    **********************************************************************/
+    public StringHandlingService() {}
+
+    /******************************************************************************
+    * @description Static method to get the current instance for Singleton pattern
+    * @return The instance of StringHandlingService.
+    ******************************************************************************/
+    public static StringHandlingService getInstance() {
+        if (instance == null) {
+            instance = new StringHandlingService();
+        }
+
+        return instance;
+    }
+
+    /**************************************************************************************************
+    * @description Prepends a single quotation (') character to escape existing single quotations 
+    * in a string and substitutes parameters with values provided.
+    * @param  stringToFormat A string with single quotes to escape and parameters to substitute
+    * @param  stringParameterList A list of string parameters
+    * @return A formatted string with single quotes escaped and parameters populated.
+    **************************************************************************************************/
+    public String formatStringWithQuotationsAndParameters(
+        String stringToFormat, 
+        List<Object> stringParameterList
+    ) {
+        String unescapedSingleQuote = '\'';
+        String escaptedSingleQuote = '\'\'';
+
+        String stringWithEscapedSingleQuotes = 
+            stringToFormat.replace(unescapedSingleQuote,  escaptedSingleQuote);
+
+        String stringWithEscapedQuotesAndParameters = 
+            String.format(
+                stringWithEscapedSingleQuotes,
+                stringParameterList
+            );
+
+        return stringWithEscapedQuotesAndParameters;
+    }
+}

--- a/src/classes/StringHandlingService.cls-meta.xml
+++ b/src/classes/StringHandlingService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/StringHandlingService_TEST.cls
+++ b/src/classes/StringHandlingService_TEST.cls
@@ -66,17 +66,17 @@ public with sharing class StringHandlingService_TEST {
     }
 
     /**********************************************************************************************************
-    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
-    * single quotes escaped and parameters substituted when a string with parameters and single quotes is passed as a parameter.
+    * @description Test method to verify that formatStringWithApostrophesAndParameters() returns a string with 
+    * single Apostrophes escaped and parameters substituted when a string with parameters and single Apostrophes is passed as a parameter.
     **********************************************************************************************************/ 
     @isTest 
-    private static void formatStringWithQuotationsAndParametersWithQuotesAndParams() {
+    private static void formatStringWithApostrophesAndParametersWithApostrophesAndParams() {
         String testString = 'Checkin\' to make sure test string with parameters {0} and {1} isn\'t returnin\' an invalid result.';
         StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
 
         Test.startTest();
         String formattedStringResult = 
-            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+            stringHandlingServiceInstance.formatStringWithApostrophesAndParameters(
                 testString, 
                 new List<Object>{'1', '2'}
             );
@@ -86,22 +86,22 @@ public with sharing class StringHandlingService_TEST {
         System.assertEquals(
             expectedString, 
             formattedStringResult, 
-            'Formatted string should substitute parameters and escape single quotes.'
+            'Formatted string should substitute parameters and escape single Apostrophes.'
         );
     }
 
     /**********************************************************************************************************
-    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
-    * single quotes escaped when a string single quotes but no parameters is passed as a parameter.
+    * @description Test method to verify that formatStringWithApostrophesAndParameters() returns a string with 
+    * single Apostrophes escaped when a string single Apostrophes but no parameters is passed as a parameter.
     **********************************************************************************************************/ 
     @isTest 
-    private static void formatStringWithQuotationsAndParametersWithQuotesNoParams() {
+    private static void formatStringWithApostrophesAndParametersWithApostrophesNoParams() {
         String testString = 'Checkin\' to make sure test string without parameters isn\'t returnin\' an invalid result.';
         StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
 
         Test.startTest();
         String formattedStringResult = 
-            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+            stringHandlingServiceInstance.formatStringWithApostrophesAndParameters(
                 testString, 
                 new List<Object>()
             );
@@ -111,22 +111,22 @@ public with sharing class StringHandlingService_TEST {
         System.assertEquals(
             expectedString, 
             formattedStringResult, 
-            'Formatted string should escape single quotes.'
+            'Formatted string should escape single Apostrophes.'
         );
     }
 
     /**********************************************************************************************************
-    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
-    * parameters substituted when a string with parameters, but no single quotes is passed as a parameter.
+    * @description Test method to verify that formatStringWithApostrophesAndParameters() returns a string with 
+    * parameters substituted when a string with parameters, but no single Apostrophes is passed as a parameter.
     **********************************************************************************************************/ 
     @isTest 
-    private static void formatStringWithQuotationsAndParametersNoQuotesWithParams() {
+    private static void formatStringWithApostrophesAndParametersNoApostrophesWithParams() {
         String testString = 'Checking to make sure test string with parameters {0} and {1} returns a valid result.';
         StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
 
         Test.startTest();
         String formattedStringResult = 
-            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+            stringHandlingServiceInstance.formatStringWithApostrophesAndParameters(
                 testString, 
                 new List<Object>{'1', '2'}
             );
@@ -141,17 +141,17 @@ public with sharing class StringHandlingService_TEST {
     }
 
     /**********************************************************************************************************
-    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns the original 
-    * string with no modifications when a string with no parameters or single quotes is passed as a parameter.
+    * @description Test method to verify that formatStringWithApostrophesAndParameters() returns the original 
+    * string with no modifications when a string with no parameters or single Apostrophes is passed as a parameter.
     **********************************************************************************************************/ 
     @isTest 
-    private static void formatStringWithQuotationsAndParametersNoQuotesNoParams() {
+    private static void formatStringWithApostrophesAndParametersNoApostrophesNoParams() {
         String testString = 'Checking to make sure a plain test string returns a valid result.';
         StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
 
         Test.startTest();
         String formattedStringResult = 
-            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+            stringHandlingServiceInstance.formatStringWithApostrophesAndParameters(
                 testString, 
                 new List<Object>()
             );

--- a/src/classes/StringHandlingService_TEST.cls
+++ b/src/classes/StringHandlingService_TEST.cls
@@ -1,0 +1,167 @@
+/*
+    Copyright (c) 2021, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @group 
+* @group-content ../../ApexDocContent/Tests.htm
+* @description Test class for StringHandlingService class.
+*/
+@isTest 
+public with sharing class StringHandlingService_TEST {
+    /**************************************************************************************************************************
+    * @description Test method to verify that the getInstance method returns a new instance of the 
+    * StringHandlingService class when one does not already exist.
+    ***************************************************************************************************************************/
+    @isTest
+    private static void getInstanceNew() {
+
+        Test.startTest();
+            StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance();
+        Test.stopTest();
+
+        System.assertEquals(StringHandlingService.instance, stringHandlingServiceInstance, 'Instance of mapper class returned should match static instance variable.');
+        System.assertEquals(true, stringHandlingServiceInstance != null, 'Instance of mapper class should not be null.');
+    }
+
+    /**************************************************************************************************************************
+    * @description Test method to verify that the getInstance method returns the existing instance of the 
+    * StringHandlingService class when one already exists.
+    ***************************************************************************************************************************/
+    @isTest
+    private static void getInstanceExisting() {
+
+        Test.startTest();
+            StringHandlingService stringHandlingServiceInstance1 = StringHandlingService.getInstance();
+            StringHandlingService stringHandlingServiceInstance2 = StringHandlingService.getInstance();
+        Test.stopTest();
+
+        System.assertEquals(StringHandlingService.instance, stringHandlingServiceInstance1, 'Instance of mapper class returned should match static instance variable.');
+        System.assertEquals(stringHandlingServiceInstance1, stringHandlingServiceInstance2, 'Subsequent retrievals of mapper class instance should return existing instance.');
+        System.assertEquals(true, stringHandlingServiceInstance1 != null, 'Instance of mapper class should not be null.');
+    }
+
+    /**********************************************************************************************************
+    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
+    * single quotes escaped and parameters substituted when a string with parameters and single quotes is passed as a parameter.
+    **********************************************************************************************************/ 
+    @isTest 
+    private static void formatStringWithQuotationsAndParametersWithQuotesAndParams() {
+        String testString = 'Checkin\' to make sure test string with parameters {0} and {1} isn\'t returnin\' an invalid result.';
+        StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
+
+        Test.startTest();
+        String formattedStringResult = 
+            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+                testString, 
+                new List<Object>{'1', '2'}
+            );
+        Test.stopTest();
+
+        String expectedString = 'Checkin\' to make sure test string with parameters 1 and 2 isn\'t returnin\' an invalid result.';
+        System.assertEquals(
+            expectedString, 
+            formattedStringResult, 
+            'Formatted string should substitute parameters and escape single quotes.'
+        );
+    }
+
+    /**********************************************************************************************************
+    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
+    * single quotes escaped when a string single quotes but no parameters is passed as a parameter.
+    **********************************************************************************************************/ 
+    @isTest 
+    private static void formatStringWithQuotationsAndParametersWithQuotesNoParams() {
+        String testString = 'Checkin\' to make sure test string without parameters isn\'t returnin\' an invalid result.';
+        StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
+
+        Test.startTest();
+        String formattedStringResult = 
+            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+                testString, 
+                new List<Object>()
+            );
+        Test.stopTest();
+
+        String expectedString = 'Checkin\' to make sure test string without parameters isn\'t returnin\' an invalid result.';
+        System.assertEquals(
+            expectedString, 
+            formattedStringResult, 
+            'Formatted string should escape single quotes.'
+        );
+    }
+
+    /**********************************************************************************************************
+    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns a string with 
+    * parameters substituted when a string with parameters, but no single quotes is passed as a parameter.
+    **********************************************************************************************************/ 
+    @isTest 
+    private static void formatStringWithQuotationsAndParametersNoQuotesWithParams() {
+        String testString = 'Checking to make sure test string with parameters {0} and {1} returns a valid result.';
+        StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
+
+        Test.startTest();
+        String formattedStringResult = 
+            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+                testString, 
+                new List<Object>{'1', '2'}
+            );
+        Test.stopTest();
+
+        String expectedString = 'Checking to make sure test string with parameters 1 and 2 returns a valid result.';
+        System.assertEquals(
+            expectedString, 
+            formattedStringResult, 
+            'Formatted string should substitue parameter values.'
+        );
+    }
+
+    /**********************************************************************************************************
+    * @description Test method to verify that formatStringWithQuotationsAndParameters() returns the original 
+    * string with no modifications when a string with no parameters or single quotes is passed as a parameter.
+    **********************************************************************************************************/ 
+    @isTest 
+    private static void formatStringWithQuotationsAndParametersNoQuotesNoParams() {
+        String testString = 'Checking to make sure a plain test string returns a valid result.';
+        StringHandlingService stringHandlingServiceInstance = StringHandlingService.getInstance(); 
+
+        Test.startTest();
+        String formattedStringResult = 
+            stringHandlingServiceInstance.formatStringWithQuotationsAndParameters(
+                testString, 
+                new List<Object>()
+            );
+        Test.stopTest();
+
+        String expectedString = 'Checking to make sure a plain test string returns a valid result.';
+        System.assertEquals(
+            expectedString, 
+            formattedStringResult, 
+            'Formatted string should return original string.'
+        );
+    }
+}

--- a/src/classes/StringHandlingService_TEST.cls-meta.xml
+++ b/src/classes/StringHandlingService_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1412,8 +1412,8 @@
         <categories>Setup</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Description when a mapping&apos;s Contact Primary Affiliation field isn''t valid</shortDescription>
-        <value>{0} isn''t a valid Contact field.</value>
+        <shortDescription>Description when a mapping&apos;s Contact Primary Affiliation field isn't valid</shortDescription>
+        <value>{0} isn't a valid Contact field.</value>
     </labels>
     <labels>
         <fullName>stgHCAfflMapContactPrimaryFieldNotUnique</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -227,6 +227,8 @@
         <members>STG_Courses_TEST</members>
         <members>STG_InstallScript</members>
         <members>STG_InstallScript_TEST</members>
+        <members>StringHandlingService</members>
+        <members>StringHandlingService_TEST</members>
         <members>TB_CannotDelete_TDTM</members>
         <members>TB_CannotDelete_TEST</members>
         <members>TB_StartEndTime_TDTM</members>


### PR DESCRIPTION
# Critical Changes

# Changes

Incorporated string service class to address issue associated with formatting for Health Check custom labels that utilize parameters and single quotes.
- stgHCAfflMapContactPrimaryFieldInvalid
- stgHCAfflMapAutoEnrollStatusInactive
- stgHCAfflMapAutoEnrollStatusInactiveFix
- stgHCAfflMapAutoEnrollRoleInactiveFix
- stgHCAfflMapAutoEnrollRoleInactive
- stgHCAfflMapAutoEnrollRoleNotFound
- stgHCAfflMapAccRecordTypeInactiveFix
- stgHCCourseConFacultyInactiveFix
- stgHCCourseConStudentInactiveFix
- stgHCPicklistValueInactive
- stgHCPicklistValueNotFound
- stgHCReciprocalRelFemaleInactiveFix
- stgHCReciprocalRelMaleInactiveFix
- stgHCReciprocalRelNameInactiveFix
- stgHCReciprocalRelNameNotUniqueDesc
- stgHCReciprocalRelNeutralInactiveFix
- stgHCRecordTypeNotFound
- stgHCAfflMapAutoEnrollStatusNotFound

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
