### PR TITLE
[Robot] Verify course connections health check when course connections is enabled

### DIFF
--- a/robot/EDA/tests/browser/health_check/course_connections_check.robot
+++ b/robot/EDA/tests/browser/health_check/course_connections_check.robot
@@ -20,3 +20,19 @@ Verify course connections health check when course connections is disabled
     Current page should be      Home        Settings Health Check
     Run health check settings   Course Connections  courseconnection   courseconnectionsettingsResults
     ...                         Enable Course Connections=Warning
+
+Verify course connections health check when course connections is enabled
+    [Documentation]         Validates course connections health check card displays status of all
+    ...                     settings when course connections in EDA Settings is enabled
+    [tags]                  unstable        rbt:high        W-9048400
+    Go to EDA settings tab                      Course Connections
+    Click action button on EDA settings page    Edit
+    Set enable course connections
+    Click action button on EDA settings page    Save
+    Go to settings health check
+    Reload page
+    Current page should be                      Home        Settings Health Check
+    Run health check settings   Course Connections  courseconnection   courseconnectionsettingsResults
+    ...           Default Active Student Record Type=Passed
+    ...           Default Faculty Record Type=Passed
+    ...           Unique Default Faculty Record Type and Default Active Student Record Type Settings=Passed


### PR DESCRIPTION
Added test to verify course connections health check in EDA "Settings Health Check" app when course connections is enabled in EDA Settings

WI - 9048400


# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
