### PR TITLE
JP translation fix - April 2021

### DIFF
--- a/force-app/main/default/objectTranslations/Application__c-ja/Application__c-ja.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-ja/Application__c-ja.objectTranslation-meta.xml
@@ -14,6 +14,6 @@
     </standardFields>
     <caseValues>
         <plural>false</plural>
-        <value>申請</value>
+        <value>出願</value>
     </caseValues>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/Course_Enrollment__c-ja/Course_Enrollment__c-ja.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Course_Enrollment__c-ja/Course_Enrollment__c-ja.objectTranslation-meta.xml
@@ -14,6 +14,6 @@
     </standardFields>
     <caseValues>
         <plural>false</plural>
-        <value>科目接続</value>
+        <value>履修科目</value>
     </caseValues>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/Course_Offering_Schedule__c-ja/Course_Offering_Schedule__c-ja.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Course_Offering_Schedule__c-ja/Course_Offering_Schedule__c-ja.objectTranslation-meta.xml
@@ -18,6 +18,6 @@
     </standardFields>
     <caseValues>
         <plural>false</plural>
-        <value>提供科目スケジュール</value>
+        <value>開講科目スケジュール</value>
     </caseValues>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/Course__c-ja/Course__c-ja.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Course__c-ja/Course__c-ja.objectTranslation-meta.xml
@@ -14,6 +14,6 @@
     </standardFields>
     <caseValues>
         <plural>false</plural>
-        <value>コース</value>
+        <value>科目</value>
     </caseValues>
 </CustomObjectTranslation>


### PR DESCRIPTION
# Critical Changes

Fixes wrong Japanese translation as per

W-9143514 (https://gus.lightning.force.com/a07AH000000AzbjYAC)

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
