### PR TITLE
[EDA] ContentVersion trigger

### DIFF
--- a/force-app/main/default/triggers/TDTM_ContentVersion.trigger
+++ b/force-app/main/default/triggers/TDTM_ContentVersion.trigger
@@ -1,0 +1,42 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+trigger TDTM_ContentVersion on ContentVersion (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
+    TDTM_Global_API.run(
+        Trigger.isBefore,
+        Trigger.isAfter,
+        Trigger.isInsert,
+        Trigger.isUpdate,
+        Trigger.isDelete,
+        Trigger.isUndelete,
+        Trigger.new,
+        Trigger.old,
+        Schema.SObjectType.ContentVersion
+    );
+}

--- a/force-app/main/default/triggers/TDTM_ContentVersion.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_ContentVersion.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>51.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/force-app/main/tdtm/classes/TDTM_TriggerScaffolds_TEST.cls
+++ b/force-app/main/tdtm/classes/TDTM_TriggerScaffolds_TEST.cls
@@ -168,4 +168,18 @@ private class TDTM_TriggerScaffolds_TEST {
         System.assert(true, 'No exception thrown'); //Just checking that we get to this point = no exception thrown
     }
 
+    public static testmethod void tdtmContentVersion() {
+        //Currently we don't have any Trigger_Handler__c record for ContentVersion. This test is
+        //just for test coverage, and to verify no exception gets thrown.        
+        Test.startTest();
+        insert new ContentVersion(
+            Title = 'Test',
+            PathOnClient = 'Test.jpg',
+            VersionData = Blob.valueOf('Test Content Data')
+        );
+        Test.stopTest();
+       
+        System.assert(true, 'No exception thrown'); //Just checking that we get to this point = no exception thrown
+    }
+
 }


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
[W-9203961](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000KXiMYAW/view)
# New Metadata

**Triggers**
- TDTM_ContentVersion.trigger

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes

1. Trigger appeared with proper name and version setting in Setup > Apex Triggers and contained NO logic.
2. Triggers did not appear in a search in the Trigger Handler tab. I tested this by entering the trigger name into the Trigger Handler "All Trigger Handlers" list view
