### PR TITLE
[Robot] Verify account model and contact information settings

### DIFF
--- a/robot/EDA/resources/EDA.py
+++ b/robot/EDA/resources/EDA.py
@@ -596,6 +596,23 @@ class EDA(BaseEDAPage):
                                                 error= f"{locator} is not displayed for the user")
         self.selenium.click_element(locator)
 
+    def select_and_move_from_list(self, settingName, recordType):
+        """ This method will select and move the record type from available record type list to
+            selected record type list. It accepts the name of the setting and name of the record
+            type as parameters and then selects the record type and click on the move button
+        """
+        locator = eda_lex_locators["eda_settings_new"]["select_from_list"].format(settingName,recordType)
+        self.selenium.wait_until_page_contains_element(locator, timeout=60)
+        self.selenium.wait_until_element_is_visible(locator,
+                                                error= f"{locator} is not displayed for the user")
+        self.selenium.click_element(locator)
+        locator = eda_lex_locators["eda_settings_new"]["move_to_selected"].format(settingName)
+        self.selenium.wait_until_page_contains_element(locator, timeout=60)
+        self.selenium.wait_until_element_is_visible(locator,
+                                                error= f"{locator} is not displayed for the user")
+        self.selenium.click_element(locator)
+
+
     def update_settings_dropdown_value(self,**kwargs):
         """ This method will update the drop down field value passed in keyword arguments in new
             EDA settings. Pass the expected value to be set in the drop down field from the tests

--- a/robot/EDA/resources/locators_51.py
+++ b/robot/EDA/resources/locators_51.py
@@ -116,6 +116,8 @@ eda_lex_locators = {
         "settings_nav_title": "//div[@data-qa-locator='edaSettingsNavigation']/descendant::h3/a[text()='{}']",
         "dropdown_input": "//label[text()='{}']/../descendant::input[@role='combobox']",
         "settings_dropdown": "//label[text()='{}']/../descendant::span[text()='{}']",
+        "select_from_list": "//div[text()='{}']/../following-sibling::div/descendant::div[contains(@class, 'list__options')]/descendant::span[text()='{}']",
+        "move_to_selected": "//div[text()='{}']/../following-sibling::div/descendant::button[@type='button' and @title='Move selection to Selected Account Record Types']",
     },
      "eda_settings_cc": {
         "default_cc_checkbox": "//div[text()='Enable Course Connections']/following-sibling::div/descendant::img",

--- a/robot/EDA/tests/browser/settings/account_model/accounts_without_contacts.robot
+++ b/robot/EDA/tests/browser/settings/account_model/accounts_without_contacts.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Documentation   Validates accounts without contacts settings in account model
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+Suite Setup     Run keywords
+...             Open Test Browser
+...             Setup Test Data
+Suite Teardown  Capture screenshot and delete records and close browser
+
+Test Setup      Go to new eda settings
+
+*** Keywords ***
+
+Setup Test Data
+    ${admin_id} =              Get Record Type Id        ${sObject_name}     ${admin_record_type}
+    Set suite variable         ${admin_id}
+
+*** Variables ***
+${admin_record_type}       Administrative
+${sObject_name}            Account
+
+*** Test Cases ***
+Validate accounts without contacts settings are updated in hierarchy settings
+    [Documentation]         Verifies the account without contacts setting can be updated in
+    ...                     EDA Settings page and the same record type is updated in hierarchy
+    ...                     settings under custom settings.
+    [tags]                                      unstable        W-9225285       rbt:high
+    Select settings from navigation pane        Account Model
+    Click action button on new EDA settings     Edit
+    Select and move from list                   Accounts Without Contacts       Administrative
+    Click action button on new EDA settings     Save
+    ${acc_to_delete}=                           Get Custom Settings Value       Accounts_to_Delete__c
+    Should Be Equal As Strings                  ${acc_to_delete}      ${admin_id}

--- a/robot/EDA/tests/browser/settings/account_model/admin_household.robot
+++ b/robot/EDA/tests/browser/settings/account_model/admin_household.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Documentation   Validates administrative and household record type settings in account model
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+Suite Setup     Run keywords
+...             Open Test Browser
+...             Setup Test Data
+Suite Teardown  Capture screenshot and delete records and close browser
+
+Test Setup      Go to new eda settings
+
+*** Keywords ***
+
+Setup Test Data
+    ${admin_id} =              Get Record Type Id        ${sObject_name}     ${admin_record_type}
+    Set suite variable         ${admin_id}
+    ${hh_id} =                 Get Record Type Id        ${sObject_name}     ${hh_record_type}
+    Set suite variable         ${hh_id}
+
+*** Variables ***
+${admin_record_type}       Household Account
+${hh_record_type}          Administrative
+${sObject_name}            Account
+
+*** Test Cases ***
+Validate admin and household account record type settings are updated in hierarchy settings
+    [Documentation]         Verifies the admin and household record type settings can be updated in
+    ...                     EDA Settings page and the same record types are updated in hierarchy
+    ...                     settings under custom settings.
+    [tags]                                      unstable        W-9225268       rbt:high
+    Select settings from navigation pane        Account Model
+    Click action button on new EDA settings     Edit
+    Update settings dropdown value
+    ...                                         Administrative Account Record Type=Household Account
+    ...                                         Household Account Record Type=Administrative
+    Click action button on new EDA settings     Save
+    ${admin_acc_rt}=                            Get Custom Settings Value       Administrative_Account_Record_Type__c
+    ${hh_acc_rt}=                               Get Custom Settings Value       Household_Addresses_RecType__c
+    Should Be Equal As Strings                  ${admin_acc_rt}      ${admin_id}
+    Should Be Equal As Strings                  ${hh_acc_rt}         ${hh_id}

--- a/robot/EDA/tests/browser/settings/contact_information/contact_info.robot
+++ b/robot/EDA/tests/browser/settings/contact_information/contact_info.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Documentation   Validates contact information settings in new EDA settings
+Resource        robot/EDA/resources/EDA.robot
+Library         cumulusci.robotframework.PageObjects
+Suite Setup     Open Test Browser
+Suite Teardown  Capture screenshot and delete records and close browser
+
+Test Setup      Go to new eda settings
+
+*** Variables ***
+${fluency}                  Intermediate
+${preferred_phone}          Mobile Phone
+
+*** Test Cases ***
+Validate contact language fluency and default phone settings are updated in hierarchy settings
+    [Documentation]         Verifies the contact language fluency and default preferred phone can be
+    ...                     updated in EDA Settings page and the same record types are updated in
+    ...                     hierarchy settings under custom settings.
+    [tags]                                      unstable        W-9225304       rbt:high
+    Select settings from navigation pane        Contact Information
+    Click action button on new EDA settings     Edit
+    Update settings dropdown value
+    ...                                         Contact Language Fluency=${fluency}
+    ...                                         Default Preferred Phone=${preferred_phone}
+    Click action button on new EDA settings     Save
+    ${con_lang_fluency}=                        Get Custom Settings Value       Default_Contact_Language_Fluency__c
+    ${pref_phone}=                              Get Custom Settings Value       Preferred_Phone_Selection__c
+    Should Be Equal As Strings                  ${con_lang_fluency}      ${fluency}
+    Should Be Equal As Strings                  ${pref_phone}         ${preferred_phone}


### PR DESCRIPTION
Added tests to validate account model settings and contact information settings in new EDA settings

WI - W-9225285, W-9225268 and W-9225304

# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
