### PR TITLE
Account Naming and Multi Address Fixes

### DIFF
--- a/force-app/main/default/classes/AddressSettingsMapper.cls
+++ b/force-app/main/default/classes/AddressSettingsMapper.cls
@@ -67,7 +67,7 @@ public virtual with sharing class AddressSettingsMapper {
         List<String> accountRecordTypesForAddress = new List<String>();
 
         if (String.isNotEmpty(hierarchySettings.Accounts_Addresses_Enabled__c)) {
-            accountRecordTypesForAddress = hierarchySettings.Accounts_Addresses_Enabled__c.split(';');
+            accountRecordTypesForAddress = hierarchySettings.Accounts_Addresses_Enabled__c.split(';\\s?');
         }
 
         return new AddressSettingsModel(

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -269,7 +269,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Picklist value for naming format used for Administrative and Household Accounts</shortDescription>
-        <value>Custom Format</value>
+        <value>Other</value>
     </labels>
     <labels>
         <fullName>adapterException</fullName>

--- a/force-app/main/default/translations/ca.translation-meta.xml
+++ b/force-app/main/default/translations/ca.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Format personalitzat</label>
+        <label>Altres</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/de.translation-meta.xml
+++ b/force-app/main/default/translations/de.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Benutzerdefiniertes Format</label>
+        <label>Sonstiges</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/en_GB.translation-meta.xml
+++ b/force-app/main/default/translations/en_GB.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Custom Format</label>
+        <label>Other</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/es.translation-meta.xml
+++ b/force-app/main/default/translations/es.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Formato personalizado</label>
+        <label>Otros</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/es_MX.translation-meta.xml
+++ b/force-app/main/default/translations/es_MX.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Formato personalizado</label>
+        <label>Otros</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/fi.translation-meta.xml
+++ b/force-app/main/default/translations/fi.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Mukautettu muoto</label>
+        <label>Muu</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/fr.translation-meta.xml
+++ b/force-app/main/default/translations/fr.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Format personnalisé</label>
+        <label>Autre</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/ja.translation-meta.xml
+++ b/force-app/main/default/translations/ja.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>カスタム形式</label>
+        <label>その他</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>

--- a/force-app/main/default/translations/nl_NL.translation-meta.xml
+++ b/force-app/main/default/translations/nl_NL.translation-meta.xml
@@ -137,7 +137,7 @@
         <name>RelationshipsLookupDescription</name>
     </customLabels>
     <customLabels>
-        <label>Aangepaste indeling</label>
+        <label>Overig</label>
         <name>acctNamingOther</name>
     </customLabels>
     <customLabels>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
* Reverted the Label Change to acctNamingOther as it is used as a hard configuration value.
* Accounted for space splitting to pull legacy multiaddress values