### PR TITLE
[W-9393925, W-9495251] New date fields on application

### DIFF
--- a/force-app/main/default/layouts/Application__c-EDA Application Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Application__c-EDA Application Layout.layout-meta.xml
@@ -30,6 +30,14 @@
                 <behavior>Edit</behavior>
                 <field>Preparer__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Open_Date__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Due_Date__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/Application__c/fields/Due_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Application__c/fields/Due_Date__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Due_Date__c</fullName>
+    <description>The date by which applicants must submit an application.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The date by which applicants must submit an application.</inlineHelpText>
+    <label>Due Date</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/Application__c/fields/Open_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Application__c/fields/Open_Date__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Open_Date__c</fullName>
+    <description>The date when applicants can submit an application.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The date when applicants can submit an application.</inlineHelpText>
+    <label>Open Date</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Date</type>
+</CustomField>


### PR DESCRIPTION
# Changes
Open Date and Due Date fields have been added to the application object.

# Issues Closed
[W-9393925](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000NwjVYAS/view) - EDA
[W-9384949](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Nt64YAC/view) - R&A

# New Metadata
## Fields
- Application -> Open Date
- Application -> Due Date

# Changed Metadata
## Layout
- EDA Application Layout

# Testing Notes
