### PR TITLE
[W-9566536, W-9580101] Add a picklist option to application status field

### DIFF
--- a/force-app/main/default/objectTranslations/Application__c-ca/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-ca/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Oferta rebutjada</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-de/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-de/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Abgelehntes Angebot</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-en_GB/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-en_GB/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Declined Offer</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-en_US/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-en_US/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Waitlist</masterLabel>
         <translation><!-- Waitlist --></translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-es/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-es/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Oferta declinada</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-es_MX/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-es_MX/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Oferta declinada</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-fi/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-fi/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Hylätty tarjous</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-fr/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-fr/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Offre refusée</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-ja/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-ja/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>却下された提案</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Application__c-nl_NL/Application_Status__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Application__c-nl_NL/Application_Status__c.fieldTranslation-meta.xml
@@ -47,4 +47,8 @@
         <masterLabel>Declined Offer</masterLabel>
         <translation>Aanbod geweigerd</translation>
     </picklistValues>
+    <picklistValues>
+        <masterLabel>Started</masterLabel>
+        <translation><!-- Started --></translation>
+    </picklistValues>
 </CustomFieldTranslation>

--- a/force-app/main/default/objects/Application__c/fields/Application_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Application__c/fields/Application_Status__c.field-meta.xml
@@ -13,6 +13,11 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
+                <fullName>Started</fullName>
+                <default>false</default>
+                <label>Started</label>
+            </value>
+            <value>
                 <fullName>Submitted</fullName>
                 <default>false</default>
                 <label>Submitted</label>
@@ -66,11 +71,6 @@
                 <fullName>Declined Offer</fullName>
                 <default>false</default>
                 <label>Declined Offer</label>
-            </value>
-            <value>
-                <fullName>Started</fullName>
-                <default>false</default>
-                <label>Started</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/force-app/main/default/objects/Application__c/fields/Application_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Application__c/fields/Application_Status__c.field-meta.xml
@@ -67,6 +67,11 @@
                 <default>false</default>
                 <label>Declined Offer</label>
             </value>
+            <value>
+                <fullName>Started</fullName>
+                <default>false</default>
+                <label>Started</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
# Changes
## New Application Status Picklist Value
To help your recruiting and admissions team better track the status of an application, we added a new picklist value, Started, to the Application Status field (hed__Application_Status__c) on the Application object. If you're starting with this version of EDA, it's included automatically. If you started with an earlier version, add this new value to the Status field. For details, see [Add Custom Fields and Picklist Values](https://powerofus.force.com/s/article/EDA-Add-Custom-Picklist-Values).

# Issues Closed
[W-9566536](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000QXDQYA4/view) - R&A
[W-9580101](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000QlfCYAS/view) - EDA

# New Metadata
## Picklist Option
- Application -> Application Status: "Started"

# Testing Notes
