### PR TITLE
Incorrect new/old Contact matching causing added cycles in TDTM

### DIFF
--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -246,26 +246,42 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         List<Contact> contactsNeedAccounts = new List<Contact>();
         HandleUpdateWrapperLogic updateWrapper;
         HandleInsertWrapperLogic insertWrapper;
-        Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
         Integer conProcessed = 0;
 
-        for (Contact con : newContacts) {
-            //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
-            if (con.AccountId == null && defaultRecTypeId != null) {
-                contactsNeedAccounts.add(con);
-            }
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+            for (Contact con : newContacts) {
+                //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
+                if (con.AccountId == null && defaultRecTypeId != null) {
+                    contactsNeedAccounts.add(con);
+                }
 
-            //AFTER INSERT
-            if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
                 if (insertWrapper == null) {
                     insertWrapper = new HandleInsertWrapperLogic();
                 }
 
                 insertWrapper.handleInsertData(con);
+
+                conProcessed += 1;
             }
 
-            //AFTER UPDATE
-            if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+            TDTM_ProcessControl.setRecursionFlag(
+                TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert,
+                true
+            );
+            handleInsertProcessing(insertWrapper, contactsNeedAccounts);
+            handleUpdateProcessing(updateWrapper, contactsNeedAccounts);
+            return;
+        }
+
+        if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+            Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
+
+            for (Contact con : newContacts) {
+                //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
+                if (con.AccountId == null && defaultRecTypeId != null) {
+                    contactsNeedAccounts.add(con);
+                }
+
                 if (updateWrapper == null) {
                     updateWrapper = new HandleUpdateWrapperLogic();
                 }
@@ -284,24 +300,26 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     triggerAction,
                     numOfContactsLeft
                 );
+
+                conProcessed += 1;
             }
 
-            conProcessed += 1;
-        }
-
-        //Set recursion flag
-        if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
-            TDTM_ProcessControl.setRecursionFlag(
-                TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Insert,
-                true
-            );
-        }
-
-        if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
             TDTM_ProcessControl.setRecursionFlag(
                 TDTM_ProcessControl.registeredTrigger.ACCT_IndividualAccounts_TDTM_After_Update,
                 true
             );
+            handleInsertProcessing(insertWrapper, contactsNeedAccounts);
+            handleUpdateProcessing(updateWrapper, contactsNeedAccounts);
+            return;
+        }
+
+        for (Contact con : newContacts) {
+            //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
+            if (con.AccountId == null && defaultRecTypeId != null) {
+                contactsNeedAccounts.add(con);
+            }
+
+            conProcessed += 1;
         }
 
         if (triggerAction == TDTM_Runnable.Action.AfterDelete) {

--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -277,7 +277,14 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     numOfContactsLeft = accountIdNumOfCons.get(con.AccountId);
                 }
 
-                updateWrapper.handleUpdateData(con, oldContacts[conProcessed], triggerAction, numOfContactsLeft);
+                Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
+
+                updateWrapper.handleUpdateData(
+                    con,
+                    oldContactByContactId.get(con.Id),
+                    triggerAction,
+                    numOfContactsLeft
+                );
             }
 
             conProcessed += 1;

--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -246,8 +246,9 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         List<Contact> contactsNeedAccounts = new List<Contact>();
         HandleUpdateWrapperLogic updateWrapper;
         HandleInsertWrapperLogic insertWrapper;
-
+        Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
         Integer conProcessed = 0;
+
         for (Contact con : newContacts) {
             //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
             if (con.AccountId == null && defaultRecTypeId != null) {
@@ -276,8 +277,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 if (accountIdNumOfCons.containsKey(con.AccountId)) {
                     numOfContactsLeft = accountIdNumOfCons.get(con.AccountId);
                 }
-
-                Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
 
                 updateWrapper.handleUpdateData(
                     con,

--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -250,7 +250,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
 
         if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             for (Contact con : newContacts) {
-                //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
                 if (con.AccountId == null && defaultRecTypeId != null) {
                     contactsNeedAccounts.add(con);
                 }
@@ -277,7 +276,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             Map<Id, Contact> oldContactByContactId = new Map<Id, Contact>(oldContacts);
 
             for (Contact con : newContacts) {
-                //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
                 if (con.AccountId == null && defaultRecTypeId != null) {
                     contactsNeedAccounts.add(con);
                 }
@@ -314,7 +312,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         }
 
         for (Contact con : newContacts) {
-            //Account needs to be created if (1) Account does not exist or (2) Account model is not blank
             if (con.AccountId == null && defaultRecTypeId != null) {
                 contactsNeedAccounts.add(con);
             }


### PR DESCRIPTION
Used a map to pass matching oldContact and process update data. 

Dev testing confirmed that update trigger wouldn't falsely run anymore.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
