### PR TITLE
Settings Product Interoperability additional setup

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -101,6 +101,12 @@ tasks:
         class_path: cumulusci.tasks.salesforce.Deploy
         options:
             path: unpackaged/config/release_gating
+    deploy_settings_product:
+        group: "EDA: Metadata"
+        description: mocked settings product information metadata to display a demo product.
+        class_path: cumulusci.tasks.salesforce.Deploy
+        options:
+            path: unpackaged/config/settings_product
 
     deploy_workbench_translation_settings:
         description: Deploys settings to enable Translation Workbench, end user languages, and platform languages.
@@ -412,6 +418,8 @@ flows:
                 flow: eda_settings
             8:
                 task: deploy_release_gating
+            9:
+                task: deploy_settings_product
 
     config_dev_namespaced:
         # description: Configure an org for use as a namespaced dev org after package metadata is deployed.
@@ -436,6 +444,8 @@ flows:
                 flow: eda_settings
             7:
                 task: deploy_release_gating
+            8:
+                task: deploy_settings_product
 
     config_managed:
         # description: Configure an org for use as a dev org after package metadata is deployed.
@@ -482,6 +492,8 @@ flows:
                 flow: eda_settings
             9:
                 task: deploy_release_gating
+            10:
+                task: deploy_settings_product
 
     config_regression:
         # description: Configure an org for QA regression after the package is installed.

--- a/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductInformationMapper.cls
+++ b/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductInformationMapper.cls
@@ -70,11 +70,12 @@ public virtual with sharing class EDCSettingsProductInformationMapper {
      * @description Returns an instance of EDCSettingsProductInformationModel
      ********************************************************************************************/
     public virtual EDCSettingsProductInformationModel getProductInformationModel() {
+        String navigationPrefix = UTIL_Namespace.StrTokenNSPrefixComponent();
         EDCSettingsProductInformationModel productInformation = new EDCSettingsProductInformationModel(
             PRODUCT_EDA_INITIALS,
             PRODUCT_EDA_NAME,
             PRODUCT_EDA_DESCRIPTION,
-            PRODUCT_EDA_SETTINGSCOMPONENT,
+            navigationPrefix + PRODUCT_EDA_SETTINGSCOMPONENT,
             PRODUCT_EDA_DOCUMENTATIONURL,
             PRODUCT_EDA_TRAILHEADURL,
             PRODUCT_EDA_ICON

--- a/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductInformationMapper_TEST.cls
+++ b/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductInformationMapper_TEST.cls
@@ -60,8 +60,10 @@ private class EDCSettingsProductInformationMapper_TEST {
             productInformationModel.name,
             'name should be set to ' + EDCSettingsProductInformationMapper.PRODUCT_EDA_NAME
         );
+
+        String navigationPrefix = UTIL_Namespace.StrTokenNSPrefixComponent();
         System.assertEquals(
-            EDCSettingsProductInformationMapper.PRODUCT_EDA_SETTINGSCOMPONENT,
+            navigationPrefix + EDCSettingsProductInformationMapper.PRODUCT_EDA_SETTINGSCOMPONENT,
             productInformationModel.settingsComponent,
             'settingsComponent should be set to ' + EDCSettingsProductInformationMapper.PRODUCT_EDA_SETTINGSCOMPONENT
         );

--- a/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductVMapper.cls
+++ b/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductVMapper.cls
@@ -75,12 +75,11 @@ public virtual with sharing class EDCSettingsProductVMapper {
             return null;
         }
 
-        String navigationPrefix = UTIL_Namespace.StrTokenNSPrefixComponent();
         return new EDCSettingsProductVModel(
             productInformation.initials,
             productInformation.name,
             productInformation.description,
-            navigationPrefix + productInformation.settingsComponent,
+            productInformation.settingsComponent,
             productInformation.documentationUrl,
             productInformation.trailheadUrl,
             productInformation.icon

--- a/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductVMapper_TEST.cls
+++ b/force-app/main/educationCloudSettings/classes/settingsProduct/EDCSettingsProductVMapper_TEST.cls
@@ -62,9 +62,10 @@ private class EDCSettingsProductVMapper_TEST {
         System.assertEquals(initials, productVModel.initials, 'initials should be set to ' + initials);
         System.assertEquals(name, productVModel.name, 'name should be set to ' + name);
         System.assertEquals(description, productVModel.description, 'description should be set to ' + description);
-        System.assert(
-            productVModel.settingsComponent.contains(settingsComponent),
-            'settingsComponent should contains ' + settingsComponent
+        System.assertEquals(
+            settingsComponent,
+            productVModel.settingsComponent,
+            'settingsComponent should be ' + settingsComponent
         );
         System.assertEquals(
             documentationUrl,

--- a/unpackaged/config/settings_product/classes/TALDemoSettingsProductInfoAPIService.cls
+++ b/unpackaged/config/settings_product/classes/TALDemoSettingsProductInfoAPIService.cls
@@ -1,0 +1,260 @@
+/*
+    Copyright (c) 2021, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @date 2021
+ * @group
+ * @group-content
+ * @description A demo service class to simulate an API which provides the Settings Product Information for
+ * Test Advisor Link product
+ */
+global virtual with sharing class TALDemoSettingsProductInfoAPIService implements Callable {
+    public static final string PRODUCT_INFORMATION_ACTION = 'Settings Product Information';
+
+    public TALDemoSettingsProductInfoAPIService() {
+    }
+
+    /********************************************************************************************
+     * @description Returns an object which is a serialized version of
+     * EDCSettingsProdInfoActionResultModel
+     * @param  action A string representing the specific action or method to execute
+     * @param  args   A map of String and Object representing the parameters provided for this call
+     * @return An object which is a serialized version of
+     * EDCSettingsProdInfoActionResultModel
+     ********************************************************************************************/
+    public Object call(String action, Map<String, Object> args) {
+        TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel actionResult;
+        Decimal apiVersion;
+
+        try {
+            apiVersion = this.getApiVersion(args);
+        } catch (TALDemoSettingsProductInfoAPIService.ApiVersionNotFoundException avnfe) {
+            actionResult = this.createErrorActionResult(400, avnfe.getMessage());
+            return JSON.serialize(actionResult);
+        }
+
+        try {
+            actionResult = this.handleAction(action, apiVersion);
+        } catch (TALDemoSettingsProductInfoAPIService.InvalidActionException iae) {
+            actionResult = this.createErrorActionResult(400, iae.getMessage());
+            return JSON.serialize(actionResult);
+        }
+
+        return JSON.serialize(actionResult);
+    }
+
+    /********************************************************************************************
+     * @description Returns an instance of EDCSettingsProdInfoActionResultModel
+     * containing the product information related to EDA
+     * @return An instance of EDCSettingsProdInfoActionResultModel
+     ********************************************************************************************/
+    public TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel getSettingsProductInformation() {
+        Boolean managedEnv;
+        String namespace = 'hed';
+        try {
+            managedEnv = Userinfo.isCurrentUserLicensed(namespace);
+        } catch (System.TypeException te) {
+            managedEnv = false;
+        }
+
+        String settingsContainerPrefix;
+        if (managedEnv) {
+            settingsContainerPrefix = namespace + '__';
+        } else {
+            settingsContainerPrefix = 'c__';
+        }
+
+        //Instead of building the model directly, use a mapper for building the model
+        TALDemoSettingsProductInfoAPIService.EDCSettingsProductInformationModel productInformation = new TALDemoSettingsProductInfoAPIService.EDCSettingsProductInformationModel(
+            'TAL',
+            'Test Advisor Link',
+            'Test Advisor Link gives advisors and advisees new tools to help foster focused conversations about education success. With Advisor Link, advisees can book advising appointments online, right from their smartphones. While advisors can spend more time on strategic engagement, support, and follow-up, and less time on getting advisees in the door.',
+            settingsContainerPrefix + 'EdaSettingsContainer',
+            'https://powerofus.force.com/s/article/SAL-Documentation',
+            'https://trailhead.salesforce.com/en/content/learn/modules/student-advising-with-salesforce-advisor-link',
+            'standard:avatar'
+        );
+
+        TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel actionResult = new TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel(
+            productInformation,
+            true,
+            null
+        );
+
+        return actionResult;
+    }
+
+    /********************************************************************************************
+     * @description Constructs and returns an instance of EDCSettingsProdInfoActionResultModel
+     * with success set to false and a CallableError instance to provide details about the error
+     * @param  code         code description
+     * @param  errorMessage errorMessage description
+     * @return              return description
+     ********************************************************************************************/
+    @TestVisible
+    private virtual TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel createErrorActionResult(
+        Integer code,
+        String errorMessage
+    ) {
+        TALDemoSettingsProductInfoAPIService.CallableError error = new TALDemoSettingsProductInfoAPIService.CallableError(
+            code,
+            errorMessage
+        );
+
+        TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel actionResult = new TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel(
+            null,
+            false,
+            error
+        );
+        return actionResult;
+    }
+
+    /********************************************************************************************
+     * @description Returns the decimal Api Version provided as parameter, otherwise it throws
+     * an ApiVersionNotFoundException
+     * @param  args A map of String and Object which contain the parameters needed for this call
+     * @return A decimal Api Version retrieved from the parameters
+     ********************************************************************************************/
+    @TestVisible
+    private Decimal getApiVersion(Map<String, Object> args) {
+        if (args.containsKey('Api Version') == false || args.get('Api Version') == null) {
+            throw new TALDemoSettingsProductInfoAPIService.ApiVersionNotFoundException(
+                'You gotta have an API version!'
+            );
+        }
+        return (Decimal) args.get('Api Version');
+    }
+
+    /********************************************************************************************
+     * @description Returns the EDCSettingsProdInfoActionResultModel
+     * for the specified action, if the action is not valid an InvalidActionException is thrown
+     * @param  action     A string representing the specific action or method to execute
+     * @param  apiVersion A decimal representing the api version needed for this call
+     * @return            return description
+     ********************************************************************************************/
+    @TestVisible
+    private TALDemoSettingsProductInfoAPIService.EDCSettingsProdInfoActionResultModel handleAction(
+        String action,
+        Decimal apiVersion
+    ) {
+        if (action == PRODUCT_INFORMATION_ACTION) {
+            return this.getSettingsProductInformation();
+        }
+        throw new TALDemoSettingsProductInfoAPIService.InvalidActionException('Action: ' + action + ' not implemented');
+    }
+
+    @TestVisible
+    private class ApiVersionNotFoundException extends Exception {
+    }
+    @TestVisible
+    private class InvalidActionException extends Exception {
+    }
+
+    public class EDCSettingsProdInfoActionResultModel extends TALDemoSettingsProductInfoAPIService.CallableResult {
+        public TALDemoSettingsProductInfoAPIService.EDCSettingsProductInformationModel result;
+
+        public EDCSettingsProdInfoActionResultModel(
+            TALDemoSettingsProductInfoAPIService.EDCSettingsProductInformationModel result,
+            Boolean success,
+            TALDemoSettingsProductInfoAPIService.CallableError error
+        ) {
+            super(success, error);
+            this.result = result;
+        }
+    }
+
+    public class EDCSettingsProductInformationModel {
+        public String initials { get; private set; }
+        public String name { get; private set; }
+        public String description { get; private set; }
+        public String settingsComponent { get; private set; }
+        public String documentationUrl { get; private set; }
+        public String trailheadUrl { get; private set; }
+        public String icon { get; private set; }
+
+        /********************************************************************************************
+         * @description Seven argument constructor
+         * @param  initials          A string representing the product initials
+         * @param  name              A string representing the product name
+         * @param  description       A string representing the product description
+         * @param  settingsComponent A string representing the component the Settings link will redirect to
+         * @param  documentationUrl  A string representing the url to the documentation
+         * @param  trailheadUrl      A string representing the trailhead url
+         * @param  icon              A string representing the icon to use
+         * @return                   A EDCSettingsProductInformationModel with all its properties populated
+         ********************************************************************************************/
+        public EDCSettingsProductInformationModel(
+            String initials,
+            String name,
+            String description,
+            String settingsComponent,
+            String documentationUrl,
+            String trailheadUrl,
+            String icon
+        ) {
+            this.initials = initials;
+            this.name = name;
+            this.description = description;
+            this.settingsComponent = settingsComponent;
+            this.documentationUrl = documentationUrl;
+            this.trailheadUrl = trailheadUrl;
+            this.icon = icon;
+        }
+    }
+
+    public virtual class CallableResult {
+        public Boolean success;
+        public TALDemoSettingsProductInfoAPIService.CallableError error;
+
+        /********************************************************************************************
+         * @description Two argument constructor
+         * @param  success A boolean representing if the call was successful or not
+         * @param  error A CallableError representing the error in case the call was not successful
+         * @return A CallableResult with all properties populated.
+         ********************************************************************************************/
+        public CallableResult(Boolean success, TALDemoSettingsProductInfoAPIService.CallableError error) {
+            this.success = success;
+            this.error = error;
+        }
+    }
+
+    public class CallableError {
+        public Integer code;
+        public String message;
+
+        /********************************************************************************************
+         * @description Two argument constructor
+         * @param  code An Integer representing the error code
+         * @param  message A string representing the error message
+         * @return A CallableError with all properties populated.
+         ********************************************************************************************/
+        public CallableError(Integer code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+    }
+}

--- a/unpackaged/config/settings_product/classes/TALDemoSettingsProductInfoAPIService.cls-meta.xml
+++ b/unpackaged/config/settings_product/classes/TALDemoSettingsProductInfoAPIService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/unpackaged/config/settings_product/customMetadata/___NAMESPACE___Product_Registry.TALDemoProductInformation.md-meta.xml
+++ b/unpackaged/config/settings_product/customMetadata/___NAMESPACE___Product_Registry.TALDemoProductInformation.md-meta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>TALDemoProductInformation</label>
+    <protected>false</protected>
+    <values>
+        <field>%%%NAMESPACE%%%API_Version__c</field>
+        <value xsi:type="xsd:double">52.0</value>
+    </values>
+    <values>
+        <field>%%%NAMESPACE%%%Action__c</field>
+        <value xsi:type="xsd:string">Settings Product Information</value>
+    </values>
+    <values>
+        <field>%%%NAMESPACE%%%Class_Name__c</field>
+        <value xsi:type="xsd:string">TALDemoSettingsProductInfoAPIService</value>
+    </values>
+    <values>
+        <field>%%%NAMESPACE%%%Enabled__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>%%%NAMESPACE%%%Namespace__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/settings_product/package.xml
+++ b/unpackaged/config/settings_product/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>TALDemoSettingsProductInfoAPIService</members>
+        <name>ApexClass</name>
+    </types>
+    <types>
+        <members>%%%NAMESPACE%%%Product_Registry.TALDemoProductInformation</members>
+        <name>CustomMetadata</name>
+    </types>    
+    <version>52.0</version>
+</Package>


### PR DESCRIPTION
Created a new task deploy_settings_product to create a demo product registry and the referenced classes.
Refactored EDCSettingsProductInformationMapper class to pre-append the component prefix instead of handling it in the EDCSettingsProductVMapper class.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
