### PR TITLE
Updated apiVersions to 51.0

### DIFF
--- a/force-app/main/default/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp-meta.xml
+++ b/force-app/main/default/aura/CMP_Acc_Naming_Dropdown/CMP_Acc_Naming_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Component for account(Admin and HH) name format settings</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp-meta.xml
+++ b/force-app/main/default/aura/CMP_Picklist_Dropdown/CMP_Picklist_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/CMP_RecTypes/CMP_RecTypes.cmp-meta.xml
+++ b/force-app/main/default/aura/CMP_RecTypes/CMP_RecTypes.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>DESCRIPTION</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/CMP_RecTypes_Dropdown/CMP_RecTypes_Dropdown.cmp-meta.xml
+++ b/force-app/main/default/aura/CMP_RecTypes_Dropdown/CMP_RecTypes_Dropdown.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>DESCRIPTION</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_App/STG_App.app-meta.xml
+++ b/force-app/main/default/aura/STG_App/STG_App.app-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Addr/STG_CMP_Addr.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Addr/STG_CMP_Addr.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Affl/STG_CMP_Affl.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Affl/STG_CMP_Affl.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Base/STG_CMP_Base.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Base/STG_CMP_Base.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Container/STG_CMP_Container.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Container/STG_CMP_Container.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Container for the settings components</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_CourseConnections/STG_CMP_CourseConnections.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Course Connections Settings Component</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Courses/STG_CMP_Courses.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Courses/STG_CMP_Courses.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A settings component for Courses</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Header/STG_CMP_Header.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Header/STG_CMP_Header.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_ProgramPlans/STG_CMP_ProgramPlans.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_ProgramPlans/STG_CMP_ProgramPlans.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>STG_CMP_ProgramPlans</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Rel/STG_CMP_Rel.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Rel/STG_CMP_Rel.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_System/STG_CMP_System.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_System/STG_CMP_System.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp-meta.xml
+++ b/force-app/main/default/aura/STG_CMP_Tabs/STG_CMP_Tabs.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_EVT_Cancel/STG_EVT_Cancel.evt-meta.xml
+++ b/force-app/main/default/aura/STG_EVT_Cancel/STG_EVT_Cancel.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Edit Settings Event</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_EVT_Edit/STG_EVT_Edit.evt-meta.xml
+++ b/force-app/main/default/aura/STG_EVT_Edit/STG_EVT_Edit.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Edit Settings Event</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/STG_EVT_Save/STG_EVT_Save.evt-meta.xml
+++ b/force-app/main/default/aura/STG_EVT_Save/STG_EVT_Save.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Save Settings Event</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/autocomplete/autocomplete.cmp-meta.xml
+++ b/force-app/main/default/aura/autocomplete/autocomplete.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/autocompleteDataProvider/autocompleteDataProvider.cmp-meta.xml
+++ b/force-app/main/default/aura/autocompleteDataProvider/autocompleteDataProvider.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Provider for the Autocomplete</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/autocompleteOption/autocompleteOption.cmp-meta.xml
+++ b/force-app/main/default/aura/autocompleteOption/autocompleteOption.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/autocompleteSelectListOption/autocompleteSelectListOption.evt-meta.xml
+++ b/force-app/main/default/aura/autocompleteSelectListOption/autocompleteSelectListOption.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/dataProviderInterface/dataProviderInterface.intf-meta.xml
+++ b/force-app/main/default/aura/dataProviderInterface/dataProviderInterface.intf-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/edaSettingsContainer/edaSettingsContainer.cmp-meta.xml
+++ b/force-app/main/default/aura/edaSettingsContainer/edaSettingsContainer.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/svgIcon/svgIcon.cmp-meta.xml
+++ b/force-app/main/default/aura/svgIcon/svgIcon.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/svgIcon_EVT_Press/svgIcon_EVT_Press.evt-meta.xml
+++ b/force-app/main/default/aura/svgIcon_EVT_Press/svgIcon_EVT_Press.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <description>Icon Press Event</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/classes/ACCT_AdministrativeNameRefresh_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_AdministrativeNameRefresh_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_AdministrativeNameRefresh_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_AdministrativeNameRefresh_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_HouseholdNameRefresh_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_HouseholdNameRefresh_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_HouseholdNameRefresh_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_HouseholdNameRefresh_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Account_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Account_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Address_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Address_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Addresses_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Addresses_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Addresses_UTIL.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Addresses_UTIL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_AdminAcc_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_AdminAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Contact_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Contact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Contact_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Contact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_HouseholdAcc_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_HouseholdAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_OtherAcc_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_OtherAcc_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Seasonal_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Seasonal_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Seasonal_SCHED.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Seasonal_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Seasonal_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Seasonal_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ADDR_Seasonal_UTIL.cls-meta.xml
+++ b/force-app/main/default/classes/ADDR_Seasonal_UTIL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_AccChange_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_AccChange_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_AccRecordType_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_AccRecordType_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_AccRecordType_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_AccRecordType_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_ContactAccChange_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_ContactAccChange_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_ContactChange_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_ContactChange_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AFFL_MultiRecordTypeMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AFFL_MultiRecordTypeMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ATTD_CourseConnectionContact_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/ATTD_CourseConnectionContact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ATTD_CourseConnectionContact_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ATTD_CourseConnectionContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelHealthCheckVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelHealthCheckVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelHealthCheckVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelHealthCheckVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsModel.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsService.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountModelSettingsVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountModelSettingsVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingFormatModel.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingFormatModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingFormatModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingFormatModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingService.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsModel.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsService.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountNamingSettingsVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountNamingSettingsVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionModel.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionServ_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionServ_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountRecordTypeAutoDeletionService.cls-meta.xml
+++ b/force-app/main/default/classes/AccountRecordTypeAutoDeletionService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Advancement_Adapter.cls-meta.xml
+++ b/force-app/main/default/classes/Advancement_Adapter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Advancement_Adapter_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/Advancement_Adapter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Advancement_Info.cls-meta.xml
+++ b/force-app/main/default/classes/Advancement_Info.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsHCVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsHCVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsHealthCheckVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsHealthCheckVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsModel.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsService.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AffiliationMappingsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/AffiliationMappingsService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/BEH_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/BEH_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/BEH_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/BEH_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CASE_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CASE_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CASE_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CASE_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_ConnectionBackfill_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_ConnectionBackfill_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_ConnectionBackfill_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_ConnectionBackfill_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_Faculty_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_Faculty_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_Faculty_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_Faculty_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_PreventUpdate_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_PreventUpdate_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CCON_PreventUpdate_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CCON_PreventUpdate_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CENR_AcademicProgram_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CENR_AcademicProgram_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CENR_AcademicProgram_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CENR_AcademicProgram_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CLAN_PrimaryLanguage_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CLAN_PrimaryLanguage_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CLAN_PrimaryLanguage_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CLAN_PrimaryLanguage_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CMP_SettingsDataProvider.cls-meta.xml
+++ b/force-app/main/default/classes/CMP_SettingsDataProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CMP_SettingsDataProvider_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CMP_SettingsDataProvider_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COFF_Affiliation_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/COFF_Affiliation_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COFF_Affiliation_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/COFF_Affiliation_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COFF_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/COFF_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COFF_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/COFF_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_DoNotContact_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_DoNotContact_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_DoNotContact_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_DoNotContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_Email_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/CON_Email_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_EthnicityRace_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/CON_EthnicityRace_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_EthnicityRace_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_EthnicityRace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_Phone.cls-meta.xml
+++ b/force-app/main/default/classes/CON_Phone.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PreferredPhone_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PreferredPhone_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PreferredPhone_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PreferredPhone_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_Preferred_Email_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_Preferred_Email_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_Preferred_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_Preferred_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_Preferred_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_Preferred_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PrimaryAffls_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PrimaryAffls_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PrimaryAffls_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PrimaryAffls_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PrimaryLanguage_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CON_PrimaryLanguage_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COS_StartEndTime_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/COS_StartEndTime_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COS_StartEndTime_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/COS_StartEndTime_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COUR_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/COUR_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COUR_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/COUR_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COUR_DescriptionCopy_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/COUR_DescriptionCopy_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/COUR_DescriptionCopy_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/COUR_DescriptionCopy_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelAutoCreateMappingModel.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelAutoCreateMappingModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelAutoCreateMappingModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelAutoCreateMappingModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelAutoCreateService.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelAutoCreateService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelAutoCreateService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelAutoCreateService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelationshipsModel.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelationshipsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactRelationshipsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ContactRelationshipsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactsRelationshipsModel.cls-meta.xml
+++ b/force-app/main/default/classes/ContactsRelationshipsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactsRelationshipsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ContactsRelationshipsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConSettingHealthCheckVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConSettingHealthCheckVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConSettingHealthCheckVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConSettingHealthCheckVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsModel.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsService.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CourseConnectionSettingsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CourseConnectionSettingsService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls-meta.xml
+++ b/force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/EDAHealthCheckGroupAPIService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/EDAHealthCheckGroupAPIService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/EDASettingsController.cls-meta.xml
+++ b/force-app/main/default/classes/EDASettingsController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/EDASettingsController_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/EDASettingsController_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_AsyncErrors.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_AsyncErrors.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_AsyncErrors_SCHED.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_AsyncErrors_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_AsyncErrors_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_AsyncErrors_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_DeleteOutdated_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_DeleteOutdated_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_DeleteOutdated_SCHED.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_DeleteOutdated_SCHED.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_DeleteOutdated_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_DeleteOutdated_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_ExceptionHandler.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_ExceptionHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_ExceptionHandler_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_ExceptionHandler_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_Handler.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_Handler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_Handler_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_Handler_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ERR_Notifier.cls-meta.xml
+++ b/force-app/main/default/classes/ERR_Notifier.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FACI_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/FACI_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FACI_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/FACI_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterDateModel.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterDateModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterDateModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterDateModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterMapper.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterModel.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterService.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FeatureParameterService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/FeatureParameterService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckController.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckController_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckController_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionMapper.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionModel.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionService.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionVModel.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionVModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckDefinitionVModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckDefinitionVModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupAPIServiceInterface.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupAPIServiceInterface.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupController.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupController_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupController_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupService.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupVModel.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupVModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckGroupVModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckGroupVModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckItemVModel.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckItemVModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckItemVModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckItemVModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckVModel.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckVModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HealthCheckVModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HealthCheckVModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsChangesController.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsChangesController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsChangesVModel.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsChangesVModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsChangesVModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsChangesVModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsModel.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HierarchySettingsService.cls-meta.xml
+++ b/force-app/main/default/classes/HierarchySettingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldMapper.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldModel.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldService.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/LookupFieldService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/LookupFieldService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls-meta.xml
+++ b/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MAPR_CON_PreferredEmailFields_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MAPR_CON_PreferredEmailFields_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MAPR_PrimaryAffiliations.cls-meta.xml
+++ b/force-app/main/default/classes/MAPR_PrimaryAffiliations.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MAPR_PrimaryAffiliations_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MAPR_PrimaryAffiliations_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PreferredEmailField.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PreferredEmailField.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PreferredEmailField_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PreferredEmailField_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PreferredEmailSettings.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PreferredEmailSettings.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PreferredEmailSettings_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PreferredEmailSettings_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PrimaryAfflMapper.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PrimaryAfflMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/MODL_PrimaryAfflMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MODL_PrimaryAfflMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PPlan_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PPlan_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PPlan_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PPlan_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PPlan_Primary_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PPlan_Primary_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PPlan_Primary_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PPlan_Primary_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_Affiliation_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_Affiliation_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_Affiliation_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_Affiliation_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_ProgramPlan_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREN_ProgramPlan_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PREN_ProgramPlan_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREQ_PreventPPlanParent_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PREQ_PreventPPlanParent_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PREQ_PreventPPlanParent_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PREQ_PreventPPlanParent_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PReq_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/PReq_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PReq_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PReq_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PermissionSetAssignmentMapper.cls-meta.xml
+++ b/force-app/main/default/classes/PermissionSetAssignmentMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PermissionSetAssignmentMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PermissionSetAssignmentMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PermissionSetMapper.cls-meta.xml
+++ b/force-app/main/default/classes/PermissionSetMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PermissionSetMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PermissionSetMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryMapper.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryModel.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryService.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PicklistEntryService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PicklistEntryService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Relationships_Con_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Relationships_Con_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Relationships_Con_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Relationships_Con_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Relationships_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Relationships_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Relationships_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Relationships_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/REL_Utils.cls-meta.xml
+++ b/force-app/main/default/classes/REL_Utils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ReciprocalRelHealthCheckVMapper.cls-meta.xml
+++ b/force-app/main/default/classes/ReciprocalRelHealthCheckVMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ReciprocalRelHealthCheckVMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ReciprocalRelHealthCheckVMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeMapper.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeModel.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeService.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RecordTypeService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RecordTypeService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelAutoCreateSettingsMapper.cls-meta.xml
+++ b/force-app/main/default/classes/RelAutoCreateSettingsMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelAutoCreateSettingsMapperService.cls-meta.xml
+++ b/force-app/main/default/classes/RelAutoCreateSettingsMapperService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelAutoCreateSettingsMapperService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RelAutoCreateSettingsMapperService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelAutoCreateSettingsMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RelAutoCreateSettingsMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupMapper.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupMapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupMapper_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupMapper_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupModel.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupModel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupModel_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupModel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupSettingsService.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupSettingsService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RelationshipLookupSettingsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/RelationshipLookupSettingsService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_ContactPrimaryLanguage.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_ContactPrimaryLanguage.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_ContactPrimaryLanguage_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_ContactPrimaryLanguage_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PreferredEmail.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PreferredEmail.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PreferredEmail_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PreferredEmail_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PreventDeletion.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PreventDeletion.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PreventDeletion_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PreventDeletion_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PrimaryAffiliations.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PrimaryAffiliations.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_Contact_PrimaryAffiliations_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_Contact_PrimaryAffiliations_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_UniqueRecord.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_UniqueRecord.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SRVC_UniqueRecord_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/SRVC_UniqueRecord_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_Base_CTRL.cls-meta.xml
+++ b/force-app/main/default/classes/STG_Base_CTRL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_Base_CTRL_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/STG_Base_CTRL_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_CourseConnections.cls-meta.xml
+++ b/force-app/main/default/classes/STG_CourseConnections.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_CourseConnections_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/STG_CourseConnections_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_Courses.cls-meta.xml
+++ b/force-app/main/default/classes/STG_Courses.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_Courses_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/STG_Courses_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_InstallScript.cls-meta.xml
+++ b/force-app/main/default/classes/STG_InstallScript.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/StringHandlingService.cls-meta.xml
+++ b/force-app/main/default/classes/StringHandlingService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/StringHandlingService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/StringHandlingService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TB_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TB_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TB_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TB_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TB_StartEndTime_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TB_StartEndTime_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TB_StartEndTime_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TB_StartEndTime_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TERM_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TERM_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TERM_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TERM_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TERM_CourseOff_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TERM_CourseOff_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TERM_CourseOff_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TERM_CourseOff_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TGRD_TermGradeValidator.cls-meta.xml
+++ b/force-app/main/default/classes/TGRD_TermGradeValidator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TGRD_ValidateData_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TGRD_ValidateData_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TGRD_ValidateData_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TGRD_ValidateData_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/THAN_ClearCache_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/THAN_ClearCache_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/THAN_ClearCache_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/THAN_ClearCache_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/THAN_Filter_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/THAN_Filter_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/THAN_Filter_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/THAN_Filter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TST_CannotDelete_TDTM.cls-meta.xml
+++ b/force-app/main/default/classes/TST_CannotDelete_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TST_CannotDelete_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/TST_CannotDelete_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_ACCT_Naming.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_ACCT_Naming.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_CustomSettingsFacade_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_CustomSettingsFacade_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_CustomSettings_API.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_CustomSettings_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Debug.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Debug.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Describe.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Describe.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Describe_API.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Describe_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Describe_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Describe_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_FeatureManagement.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_FeatureManagement.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_FeatureManagement_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_FeatureManagement_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Namespace.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Namespace.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Namespace_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Namespace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_OrgTelemetry_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Profile.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Profile.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_Profile_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_Profile_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_SortContact.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_SortContact.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_SortContact_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_SortContact_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_UnitTestData_API.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_UnitTestData_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UserPermissionService.cls-meta.xml
+++ b/force-app/main/default/classes/UserPermissionService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/UserPermissionService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/UserPermissionService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/lwc/accountModelSettings/accountModelSettings.js-meta.xml
+++ b/force-app/main/default/lwc/accountModelSettings/accountModelSettings.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/addressSettings/addressSettings.js-meta.xml
+++ b/force-app/main/default/lwc/addressSettings/addressSettings.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>50</apiVersion>
+	<apiVersion>51</apiVersion>
 	<isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/affiliationSettings/affiliationSettings.js-meta.xml
+++ b/force-app/main/default/lwc/affiliationSettings/affiliationSettings.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/edaSettings/edaSettings.js-meta.xml
+++ b/force-app/main/default/lwc/edaSettings/edaSettings.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>50</apiVersion>
+	<apiVersion>51</apiVersion>
 	<isExposed>true</isExposed>
 	<targets>
 		<target>lightning__Tab</target>

--- a/force-app/main/default/lwc/healthCheck/healthCheck.js-meta.xml
+++ b/force-app/main/default/lwc/healthCheck/healthCheck.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>EDA Settings Health Check</description>
     <masterLabel>Settings Health Check</masterLabel>
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
     <targets>
         <target>lightning__Tab</target>

--- a/force-app/main/default/lwc/healthCheckDisplay/healthCheckDisplay.js-meta.xml
+++ b/force-app/main/default/lwc/healthCheckDisplay/healthCheckDisplay.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/healthCheckGroup/healthCheckGroup.js-meta.xml
+++ b/force-app/main/default/lwc/healthCheckGroup/healthCheckGroup.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/healthCheckHighlightsPanel/healthCheckHighlightsPanel.js-meta.xml
+++ b/force-app/main/default/lwc/healthCheckHighlightsPanel/healthCheckHighlightsPanel.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>EDA Settings Health Check highlights panel</description>
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/healthCheckRun/healthCheckRun.js-meta.xml
+++ b/force-app/main/default/lwc/healthCheckRun/healthCheckRun.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>EDA Settings Health Check component with description and run button</description>
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/settingsSaveCanvas/settingsSaveCanvas.js-meta.xml
+++ b/force-app/main/default/lwc/settingsSaveCanvas/settingsSaveCanvas.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50</apiVersion>
+    <apiVersion>51</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/systemTools/systemTools.js-meta.xml
+++ b/force-app/main/default/lwc/systemTools/systemTools.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50</apiVersion>
+    <apiVersion>51</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/triggers/TDTM_Account.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Account.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Address.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Address.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Affiliation.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Affiliation.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Application.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Application.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_AttendanceEvent.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_AttendanceEvent.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Attribute.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Attribute.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Behavior_Involvement.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Behavior_Involvement.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Behavior_Response.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Behavior_Response.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Campaign.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Campaign.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_CampaignMember.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_CampaignMember.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Case.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Case.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Contact.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Contact.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_ContactLanguage.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_ContactLanguage.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_ContentDocumentLink.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_ContentDocumentLink.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Course.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Course.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_CourseEnrollment.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_CourseEnrollment.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_CourseOffering.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_CourseOffering.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_CourseOfferingSchedule.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_CourseOfferingSchedule.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_EducationHistory.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_EducationHistory.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Event.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Event.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Facility.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Facility.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Language.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Language.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Lead.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Lead.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Opportunity.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Opportunity.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_PlanRequirement.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_PlanRequirement.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_ProgramEnrollment.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_ProgramEnrollment.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_ProgramPlan.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_ProgramPlan.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Relationship.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Relationship.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Task.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Task.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Term.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Term.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_TermGrade.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_TermGrade.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Test.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Test.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_Test_Score.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_Test_Score.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_TimeBlock.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_TimeBlock.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_TriggerHandler.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_TriggerHandler.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/TDTM_User.trigger-meta.xml
+++ b/force-app/main/default/triggers/TDTM_User.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/tdtm/classes/TDTM_Config.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Config.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_DMLgt200_TEST.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_DMLgt200_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_DefaultConfig.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_DefaultConfig.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_ExcludedUserNames.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_ExcludedUserNames.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Filter.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Filter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Filter_TEST.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Filter_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Global_API.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Global_API.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Manager.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Manager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Manager_TEST.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Manager_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_ProcessControl.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_ProcessControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_Runnable.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_Runnable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_TriggerActionHelper.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_TriggerActionHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_TriggerHandler.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_TriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/tdtm/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
+++ b/force-app/main/tdtm/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/config/install_emulator/classes/ArbitraryInstallContext.cls-meta.xml
+++ b/unpackaged/config/install_emulator/classes/ArbitraryInstallContext.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_Utility_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_Utility_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_customEmailEnglish_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_customEmailEnglish_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_customEmailSpanish_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_customEmailSpanish_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_duplicateField_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_duplicateField_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_picklistMissingEmail_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_picklistMissingEmail_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_untranslatPcklstSpsh_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_untranslatPcklstSpsh_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_untranslatedSpsh_MTST.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/CON_Pref_Email_untranslatedSpsh_MTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_managed_only/preferred_email/classes/Describe_Utility.cls-meta.xml
+++ b/unpackaged/test_managed_only/preferred_email/classes/Describe_Utility.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_packaged/primary_affiliations/classes/STG_UnmanagedInstall.cls-meta.xml
+++ b/unpackaged/test_packaged/primary_affiliations/classes/STG_UnmanagedInstall.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_packaged/primary_affiliations/classes/UTIL_Describe_PTST.cls-meta.xml
+++ b/unpackaged/test_packaged/primary_affiliations/classes/UTIL_Describe_PTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_packaged/relationship_autocreate/classes/REL_Relationships_Con_PTST.cls-meta.xml
+++ b/unpackaged/test_packaged/relationship_autocreate/classes/REL_Relationships_Con_PTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/test_unpackaged/account_model_health_checks/classes/RecordTypeMapper_UTST.cls-meta.xml
+++ b/unpackaged/test_unpackaged/account_model_health_checks/classes/RecordTypeMapper_UTST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>51.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
# Critical Changes

# Changes
Updated all metadata apiVersions <51.0 to be 51.0.  [Ticket link](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008wucVIAQ/view).

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
