### PR TITLE
Mark credentialing fields as optional for installer

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -153,8 +153,8 @@ tasks:
                 name: EDA - Education Data Architecture App
             credentialing_fields:
                 name: EDA - Credentialing Ids
-                checked: True
-                optional: True
+                is_required: False
+                is_recommended: False
 
     deploy_pre:
         ui_options:


### PR DESCRIPTION
We are making deploying unmanaged credential ids as optional for EDA installer.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
