### PR TITLE
Fix robot test  - verify EDA app

### DIFF
--- a/robot/EDA/tests/browser/settings/eda_tile.robot
+++ b/robot/EDA/tests/browser/settings/eda_tile.robot
@@ -9,4 +9,4 @@ Suite Teardown  Capture screenshot and delete records and close browser
 Verify EDA tile
     [Documentation]     Verifies if the EDA app is displayed in app launcher menu
     Open app launcher
-    Verify app exists    EDA
+    Verify app exists    Education Data Architecture


### PR DESCRIPTION
Test case should verify Education Data Architecture instead of the EDA app

# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
