### PR TITLE
[W-10150836] Replace email field label with apex field name

### DIFF
--- a/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
+++ b/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
@@ -99,14 +99,14 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
            to be then used to create and return MODL_PreferredEmailSettings.cls record */
         for (String contactEmailfieldAPIName: contactEmailFieldsByApiName.keySet()) {
 
-            String contactEmailFieldName = contactEmailFieldsByApiName.get(contactEmailfieldAPIName).getName();
+            String contactEmailFieldLabel = contactEmailFieldsByApiName.get(contactEmailfieldAPIName).getLabel();
 
-            if (contactEmailfieldAPIName == standardEmailFieldName || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldName, contactEmailfieldAPIName) == true) {
+            if (contactEmailfieldAPIName == standardEmailFieldName || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldLabel, contactEmailfieldAPIName) == true) {
                 continue;
             }
 
-            String preferredLabel = this.getPreferredLabelFromLabel(contactEmailFieldName, preferredEmailPicklistValuesByLabel, legacyPreferredEmailPicklistValuesByLabel);
-            MODL_PreferredEmailField prefEmailFieldModel = new MODL_PreferredEmailField(contactEmailFieldName, contactEmailfieldAPIName, PreferredLabel);
+            String preferredLabel = this.getPreferredLabelFromLabel(contactEmailFieldLabel, preferredEmailPicklistValuesByLabel, legacyPreferredEmailPicklistValuesByLabel);
+            MODL_PreferredEmailField prefEmailFieldModel = new MODL_PreferredEmailField(contactEmailFieldLabel, contactEmailfieldAPIName, PreferredLabel);
 
             if (contactEmailfieldAPIName == UTIL_Namespace.StrTokenNSPrefix('AlternateEmail__c')) {
                 alternateEmailFieldPrefLabel = prefEmailFieldModel.preferredLabel ;

--- a/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
+++ b/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
@@ -86,7 +86,7 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
 
         Boolean isPreferredEmailValidationEnabled = this.getPreferredEmailValidationEnabled();
         Map<String, Schema.DescribeFieldResult> contactEmailFieldsByApiName = this.getContactEmailFieldByApiName();
-        String standardEmailFieldName = contactEmailFieldsByApiName.get('Email').getName();
+        Schema.DescribeFieldResult standardEmailField = contactEmailFieldsByApiName.get('Email');
         Map<String, String> preferredEmailPicklistValuesByLabel = this.getPreferredEmailPicklistValuesByLabel();
         Map<String, String> legacyPreferredEmailPicklistValuesByLabel = this.getLegacyPreferredEmailPicklistValuesByLabel();
         Map<String, String> preferredEmailPicklistLabelByApiName = this.getPreferredEmailPicklistLabelByApiName();
@@ -101,7 +101,7 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
 
             String contactEmailFieldLabel = contactEmailFieldsByApiName.get(contactEmailfieldAPIName).getLabel();
 
-            if (contactEmailfieldAPIName == standardEmailFieldName || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldLabel, contactEmailfieldAPIName) == true) {
+            if (contactEmailfieldAPIName == standardEmailField.getName() || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldLabel, contactEmailfieldAPIName) == true) {
                 continue;
             }
 
@@ -114,7 +114,7 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
             prefEmailFieldModels.add(prefEmailFieldModel);
         }
 
-        MODL_PreferredEmailSettings prefEmailSettingsModel = new MODL_PreferredEmailSettings(prefEmailFieldModels, alternateEmailFieldPrefLabel, standardEmailFieldName, isPreferredEmailValidationEnabled, preferredEmailPicklistLabelByApiName);
+        MODL_PreferredEmailSettings prefEmailSettingsModel = new MODL_PreferredEmailSettings(prefEmailFieldModels, alternateEmailFieldPrefLabel, standardEmailField.getLabel(), isPreferredEmailValidationEnabled, preferredEmailPicklistLabelByApiName);
 
         return prefEmailSettingsModel;
     }

--- a/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
+++ b/force-app/main/default/classes/MAPR_CON_PreferredEmailFields.cls
@@ -86,7 +86,7 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
 
         Boolean isPreferredEmailValidationEnabled = this.getPreferredEmailValidationEnabled();
         Map<String, Schema.DescribeFieldResult> contactEmailFieldsByApiName = this.getContactEmailFieldByApiName();
-        String standardEmailFieldLabel = contactEmailFieldsByApiName.get('Email').getLabel();
+        String standardEmailFieldName = contactEmailFieldsByApiName.get('Email').getName();
         Map<String, String> preferredEmailPicklistValuesByLabel = this.getPreferredEmailPicklistValuesByLabel();
         Map<String, String> legacyPreferredEmailPicklistValuesByLabel = this.getLegacyPreferredEmailPicklistValuesByLabel();
         Map<String, String> preferredEmailPicklistLabelByApiName = this.getPreferredEmailPicklistLabelByApiName();
@@ -99,14 +99,14 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
            to be then used to create and return MODL_PreferredEmailSettings.cls record */
         for (String contactEmailfieldAPIName: contactEmailFieldsByApiName.keySet()) {
 
-            String contactEmailFieldLabel = contactEmailFieldsByApiName.get(contactEmailfieldAPIName).getLabel();
+            String contactEmailFieldName = contactEmailFieldsByApiName.get(contactEmailfieldAPIName).getName();
 
-            if (contactEmailfieldAPIName == standardEmailFieldLabel || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldLabel, contactEmailfieldAPIName) == true) {
+            if (contactEmailfieldAPIName == standardEmailFieldName || edaEmailFieldModel.hasDuplicateLabelForEDAField(contactEmailFieldName, contactEmailfieldAPIName) == true) {
                 continue;
             }
 
-            String preferredLabel = this.getPreferredLabelFromLabel(contactEmailFieldLabel, preferredEmailPicklistValuesByLabel, legacyPreferredEmailPicklistValuesByLabel);
-            MODL_PreferredEmailField prefEmailFieldModel = new MODL_PreferredEmailField(contactEmailFieldLabel, contactEmailfieldAPIName, PreferredLabel);
+            String preferredLabel = this.getPreferredLabelFromLabel(contactEmailFieldName, preferredEmailPicklistValuesByLabel, legacyPreferredEmailPicklistValuesByLabel);
+            MODL_PreferredEmailField prefEmailFieldModel = new MODL_PreferredEmailField(contactEmailFieldName, contactEmailfieldAPIName, PreferredLabel);
 
             if (contactEmailfieldAPIName == UTIL_Namespace.StrTokenNSPrefix('AlternateEmail__c')) {
                 alternateEmailFieldPrefLabel = prefEmailFieldModel.preferredLabel ;
@@ -114,7 +114,7 @@ public virtual with sharing class MAPR_CON_PreferredEmailFields {
             prefEmailFieldModels.add(prefEmailFieldModel);
         }
 
-        MODL_PreferredEmailSettings prefEmailSettingsModel = new MODL_PreferredEmailSettings(prefEmailFieldModels, alternateEmailFieldPrefLabel, standardEmailFieldLabel, isPreferredEmailValidationEnabled, preferredEmailPicklistLabelByApiName);
+        MODL_PreferredEmailSettings prefEmailSettingsModel = new MODL_PreferredEmailSettings(prefEmailFieldModels, alternateEmailFieldPrefLabel, standardEmailFieldName, isPreferredEmailValidationEnabled, preferredEmailPicklistLabelByApiName);
 
         return prefEmailSettingsModel;
     }


### PR DESCRIPTION
This pull request ensures the standard email field is excluded from translations associated to preferred email.

# Issues Closed
- [W-10150836](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000NZVofYAH/view)

# Testing Notes

- Test Results: [Before](https://user-images.githubusercontent.com/16750742/143525156-1232a869-ee47-44e9-8de7-52e87b2aa9af.mp4)
- Test Results: [After](https://user-images.githubusercontent.com/16750742/143525160-294f0d6d-a832-4aea-bc17-ab9f713b2943.mp4)

Test scenarios updated: 
- [T-4509341: Verify Preferred Email works as expected with a Custom Email Field](https://gus.lightning.force.com/lightning/r/ADM_Test_Scenario__c/a80AH0000000oaJYAQ/view)

Manual test above to be automated in [W-10244155](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000UBLfqYAH/view).