### PR TITLE
[W-8215945] Military Background Field Typos

### DIFF
--- a/force-app/main/default/objects/Contact/fields/Military_Background__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Military_Background__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Military_Background__c</fullName>
-    <description>Describe this person&apos;s miltary service, for example, the branch of the military, length of time in the miltary, date of discharge, etc.</description>
+    <description>Describe this person&apos;s military service, for example, the branch of the military, length of time in the military, date of discharge, etc.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Describe this person&apos;s miltary service, for example, the branch of the military, length of time in the miltary, date of discharge, etc.</inlineHelpText>
+    <inlineHelpText>Describe this person&apos;s military service, for example, the branch of the military, length of time in the military, date of discharge, etc.</inlineHelpText>
     <label>Military Background</label>
     <length>32768</length>
     <trackFeedHistory>false</trackFeedHistory>


### PR DESCRIPTION
# Changes

- Fixed typo for the word "Military" within the description and help text of the `Military Background` custom field on Contact.

# Issues Closed
[W-8215945
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008KWhCIAW/view)

# Testing Notes

- Confirm "Military" is spelled correctly in description and help text of `Military Background` on Contact.

