### PR TITLE
[W-10023407] Education History Page Layout Section Rename

### DIFF
--- a/force-app/main/default/layouts/Education_History__c-EDA Education History Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Education_History__c-EDA Education History Layout.layout-meta.xml
@@ -55,7 +55,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Credential Details</label>
+        <label>Diploma, Degree, Certification Details</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -177,7 +177,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h17000007sRJl</masterLabel>
+        <masterLabel>00hR0000003srRI</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Education_History__c-EDA Education History Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Education_History__c-EDA Education History Layout.layout-meta.xml
@@ -177,7 +177,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hR0000003srRI</masterLabel>
+        <masterLabel>00h17000007sRJl</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>


### PR DESCRIPTION
# Changes
- In Education History, to avoid confusion with other object names, we've changed the name of the **Credential Details** section to **Diploma, Degree, Certification Details**. Existing customers will need to update their Education History page layouts to get this change. Learn about updating page layouts in [Configure a New or Enhanced Object](https://powerofus.force.com/s/article/EDA-Display-Cust-Obj-Post-Rel#topic-6835).

# Issues Closed
[W-10023407
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000Fs5GeYAJ/view)

# Testing Notes
The identified Page Layout section in the WI is renamed to `Diploma, Degree, Certification Details`
