### PR TITLE
[W-10302181/W-10302198] Feature Parameter - Seasonal address

### DIFF
--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -274,33 +274,6 @@ public without sharing class UTIL_OrgTelemetry {
             TelemetryParameterName.UsingOldCourseDescription.name(),
             usingOldCourseDescription
         );
-
-        featureManager.setPackageIntegerValue(
-            TelemetryParameterName.Data_CountSeasonalAddresses.name(),
-            [
-                SELECT COUNT()
-                FROM Address__c
-                WHERE
-                    Seasonal_Start_Month__c != NULL
-                    AND Seasonal_Start_Day__c != NULL
-                    AND Seasonal_End_Month__c != NULL
-                    AND Seasonal_End_Day__c != NULL
-            ]
-        );
-
-        featureManager.setPackageIntegerValue(
-            TelemetryParameterName.Data_CountCurrentYearSeasonalAddresses.name(),
-            [
-                SELECT COUNT()
-                FROM Address__c
-                WHERE
-                    Seasonal_Start_Month__c != NULL
-                    AND Seasonal_Start_Day__c != NULL
-                    AND Seasonal_End_Month__c != NULL
-                    AND Seasonal_End_Day__c != NULL
-                    AND CreatedDate = THIS_YEAR
-            ]
-        );
     }
 
     /**
@@ -465,6 +438,33 @@ public without sharing class UTIL_OrgTelemetry {
         featureManager.setPackageIntegerValue(
             TelemetryParameterName.Data_CountLicenseCredentials.name(),
             countLicenseCredentials
+        );
+
+        featureManager.setPackageIntegerValue(
+            TelemetryParameterName.Data_CountSeasonalAddresses.name(),
+            [
+                SELECT COUNT()
+                FROM Address__c
+                WHERE
+                    Seasonal_Start_Month__c != NULL
+                    AND Seasonal_Start_Day__c != NULL
+                    AND Seasonal_End_Month__c != NULL
+                    AND Seasonal_End_Day__c != NULL
+            ]
+        );
+
+        featureManager.setPackageIntegerValue(
+            TelemetryParameterName.Data_CountCurrentYearSeasonalAddresses.name(),
+            [
+                SELECT COUNT()
+                FROM Address__c
+                WHERE
+                    Seasonal_Start_Month__c != NULL
+                    AND Seasonal_Start_Day__c != NULL
+                    AND Seasonal_End_Month__c != NULL
+                    AND Seasonal_End_Day__c != NULL
+                    AND CreatedDate = THIS_YEAR
+            ]
         );
     }
 }

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -95,7 +95,9 @@ public without sharing class UTIL_OrgTelemetry {
         HasValueInversionReciprocalMethod,
         IsEnabled_StoreErrors,
         UsingOldContactEthnicity,
-        UsingOldCourseDescription
+        UsingOldCourseDescription,
+        Data_CountSeasonalAddresses,
+        Data_CountCurrentYearSeasonalAddresses
     }
 
     /**
@@ -271,6 +273,33 @@ public without sharing class UTIL_OrgTelemetry {
         featureManager.setPackageBooleanValue(
             TelemetryParameterName.UsingOldCourseDescription.name(),
             usingOldCourseDescription
+        );
+
+        featureManager.setPackageIntegerValue(
+            TelemetryParameterName.Data_CountSeasonalAddresses.name(),
+            [
+                SELECT COUNT()
+                FROM Address__c
+                WHERE
+                    Seasonal_Start_Month__c != NULL
+                    AND Seasonal_Start_Day__c != NULL
+                    AND Seasonal_End_Month__c != NULL
+                    AND Seasonal_End_Day__c != NULL
+            ]
+        );
+
+        featureManager.setPackageIntegerValue(
+            TelemetryParameterName.Data_CountCurrentYearSeasonalAddresses.name(),
+            [
+                SELECT COUNT()
+                FROM Address__c
+                WHERE
+                    Seasonal_Start_Month__c != NULL
+                    AND Seasonal_Start_Day__c != NULL
+                    AND Seasonal_End_Month__c != NULL
+                    AND Seasonal_End_Day__c != NULL
+                    AND CreatedDate = THIS_YEAR
+            ]
         );
     }
 

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -463,7 +463,7 @@ public without sharing class UTIL_OrgTelemetry {
                     AND Seasonal_Start_Day__c != NULL
                     AND Seasonal_End_Month__c != NULL
                     AND Seasonal_End_Day__c != NULL
-                    AND CreatedDate = THIS_YEAR
+                    AND CreatedDate = LAST_N_DAYS:365
             ]
         );
     }

--- a/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
@@ -295,6 +295,12 @@ private class UTIL_OrgTelemetry_TEST {
 
         insert academicCertificationsToInsert;
 
+        //Seasonal Addresses
+        List<Address__c> addresses = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
+        List<Address__c> seasonalAddresses = UTIL_UnitTestData_TEST.getMultipleSeasonalTestAddresses(2);
+        addresses.addAll(seasonalAddresses);
+        insert addresses;
+
         //Insert data for Credentials
         List<Credential__c> credentialsToInsert = new List<Credential__c>();
 
@@ -399,6 +405,16 @@ private class UTIL_OrgTelemetry_TEST {
         assertIntegerValue(
             UTIL_OrgTelemetry.TelemetryParameterName.Data_CountLicenseCredentials.name(),
             licenseCredentials.size()
+        );
+
+        assertIntegerValue(
+            UTIL_OrgTelemetry.TelemetryParameterName.Data_CountSeasonalAddresses.name(),
+            seasonalAddresses.size()
+        );
+
+        assertIntegerValue(
+            UTIL_OrgTelemetry.TelemetryParameterName.Data_CountCurrentYearSeasonalAddresses.name(),
+            seasonalAddresses.size()
         );
     }
 

--- a/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls
+++ b/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls
@@ -231,6 +231,26 @@ public class UTIL_UnitTestData_TEST {
     }
 
     /*********************************************************************************************************
+     * @description Initializes (but not inserts) N new Seasonal Address objects.
+     * @param addrCount the number of Address objects to create
+     * @return The list of Address__c objects
+     **********************************************************************************************************/
+    public static List<Address__c> getMultipleSeasonalTestAddresses(Integer addrCount) {
+        List<Address__c> addresses = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
+        for (Address__c currentAddress : addresses) {
+            currentAddress.Default_Address__c = false;
+            currentAddress.Seasonal_Start_Month__c = String.valueOf(System.today().addMonths(-1).month());
+            currentAddress.Seasonal_Start_Day__c = '1';
+            currentAddress.Seasonal_End_Month__c = String.valueOf(System.today().addMonths(1).month());
+            currentAddress.Seasonal_End_Day__c = '28';
+            currentAddress.MailingStreet__c = 'New Seasonal Street';
+            currentAddress.MailingCity__c = 'New Seasonal City';
+            currentAddress.MailingCounty__c = 'New Seasonal County';
+        }
+        return addresses;
+    }
+
+    /*********************************************************************************************************
      * @description Sets up common test data for Account Addresses tests.
      * @param accCount Number of Accounts to create.
      * @param recTypeID The record type to use when creating Accounts.

--- a/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls
+++ b/force-app/main/default/classes/UTIL_UnitTestData_TEST.cls
@@ -236,7 +236,7 @@ public class UTIL_UnitTestData_TEST {
      * @return The list of Address__c objects
      **********************************************************************************************************/
     public static List<Address__c> getMultipleSeasonalTestAddresses(Integer addrCount) {
-        List<Address__c> addresses = UTIL_UnitTestData_TEST.getMultipleTestAddresses(2);
+        List<Address__c> addresses = UTIL_UnitTestData_TEST.getMultipleTestAddresses(addrCount);
         for (Address__c currentAddress : addresses) {
             currentAddress.Default_Address__c = false;
             currentAddress.Seasonal_Start_Month__c = String.valueOf(System.today().addMonths(-1).month());

--- a/force-app/main/default/featureParameters/Data_CountCurrentYearSeasonalAddresses.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/Data_CountCurrentYearSeasonalAddresses.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Count of Seasonal Addresses for current year</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>

--- a/force-app/main/default/featureParameters/Data_CountSeasonalAddresses.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/Data_CountSeasonalAddresses.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Count of Seasonal Addresses</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
This child branch contains the two Feature Parameters for seasonal addresses and the associated logic & unit tests.

# Issues Closed
- [W-10302181](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XU7iuYAD/view)
- [W-10302198](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUCgtYAH/view)

# New Metadata
- Count of Seasonal Addresses
- Count of Current Year Seasonal Addresses

# Testing Notes
- [T-8129674](https://gus.lightning.force.com/lightning/r/ADM_Test_Scenario__c/a80EE000000ktXlYAI/view)

_Note: [Parent branch](https://github.com/SalesforceFoundation/EDA/tree/feature/238__zhussain_telemetryEnhancements) will consist of all aggregated [telemetry 238 deliverables](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE0000002Z9l2AE/related/Work__r/view), to be tested/verified as part of [W-10302537](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUui3YAD/view)._