### PR TITLE
[W-10059980] Automate Test for Release Management without Access

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -227,6 +227,13 @@ tasks:
             settings_field: IsTranslationWorkbenchEnabled
             value: true
 
+    create_no_access_user:
+        group: "EDA: User Tasks"
+        description: "Create a user with no access to Education Cloud components"
+        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        options:
+            command: "force:user:create -a no_access --definitionfile datasets/dev/users/user-def_no-access.json"
+
     create_tenant_secret:
         group: "EDA: Shield Platform Encryption"
         description: Creates a new tenant secret for Shield Platform Encryption testing.
@@ -440,6 +447,8 @@ flows:
                 task: deploy_release_gating
             9:
                 task: deploy_settings_product
+            10:
+                flow: create_additional_users
 
     config_dev_namespaced:
         # description: Configure an org for use as a namespaced dev org after package metadata is deployed.
@@ -466,6 +475,8 @@ flows:
                 task: deploy_release_gating
             8:
                 task: deploy_settings_product
+            9:
+                flow: create_additional_users
 
     config_managed:
         # description: Configure an org for use as a dev org after package metadata is deployed.
@@ -514,6 +525,8 @@ flows:
                 task: deploy_release_gating
             10:
                 task: deploy_settings_product
+            11:
+                flow: create_additional_users
 
     config_regression:
         # description: Configure an org for QA regression after the package is installed.
@@ -528,6 +541,12 @@ flows:
                 flow: eda_settings
             5:
                 flow: run_functional_tests
+
+    create_additional_users:
+        # description: Create additional users
+        steps:
+            1:
+                task: create_no_access_user
 
     deploy_unmanaged:
         # description: Deploy the unmanaged metadata from the package

--- a/datasets/dev/users/user-def_no-access.json
+++ b/datasets/dev/users/user-def_no-access.json
@@ -1,0 +1,13 @@
+{
+    "LastName": "Emerson",
+    "FirstName": "Lily",
+    "Email": "sample@sfdx.org",
+    "Alias": "noaccess",
+    "TimeZoneSidKey": "America/Denver",
+    "LocaleSidKey": "en_US",
+    "EmailEncodingKey": "UTF-8",
+    "LanguageLocaleKey": "en_US",
+    "profileName": "Standard User",
+    "permsets": ["Internal_Only_for_Testing"],
+    "generatePassword": true
+}

--- a/force-app/main/releaseGating/lwc/releaseGates/__tests__/releaseGates.test.js
+++ b/force-app/main/releaseGating/lwc/releaseGates/__tests__/releaseGates.test.js
@@ -144,29 +144,6 @@ describe("c-release-gates", () => {
             });
     });
 
-    it("Check if component is handling getReleaseGateVModel errors", () => {
-        const element = createElement("c-release-gates", {
-            is: ReleaseGates,
-        });
-        document.body.appendChild(element);
-        const errorMessageHandler = jest.fn();
-        element.addEventListener("errormessage", errorMessageHandler);
-
-        getProductRegistryReleaseGateVModels.emit(PRODUCT_REGISTRIES);
-
-        return Promise.resolve()
-            .then(async () => {
-                await expect(element).toBeAccessible();
-                const releaseGateItems = element.shadowRoot.querySelectorAll("c-release-gate-product");
-                expect(releaseGateItems).not.toBeNull();
-                expect(releaseGateItems.length).toBe(2);
-                getReleaseGateVModel.error();
-            })
-            .then(() => {
-                expect(errorMessageHandler).toHaveBeenCalled();
-            });
-    });
-
     it("Check if component is handling successful activateReleaseGate", () => {
         const element = createElement("c-release-gates", {
             is: ReleaseGates,

--- a/robot/EDA/resources/EDA.robot
+++ b/robot/EDA/resources/EDA.robot
@@ -13,7 +13,7 @@ Capture Screenshot and Delete Records and Close Browser
     [Documentation]         Captures screenshot if a test fails, deletes session records
     ...                     and closes the browser
     Run Keyword If Any Tests Failed      Capture Page Screenshot
-    Close Browser
+    Close All Browsers
     Delete Session Records
 
 API create program plan

--- a/robot/EDA/resources/EducationCloudSettingsPageObject.py
+++ b/robot/EDA/resources/EducationCloudSettingsPageObject.py
@@ -44,4 +44,4 @@ class EducationCloudSettingsPage(BaseEDAPage, HomePage):
         """
         locator = eda_lex_locators["eda_settings_new"]["error_toast"].format(value)
         self.selenium.wait_until_page_contains_element(locator, timeout=60, error=f'{locator} is not available')
-        self.selenium.wait_until_element_is_visible(locator, error= "{locator} is not displayed for the user")
+        self.selenium.wait_until_element_is_visible(locator, error= f'{locator} is not displayed for the user')

--- a/robot/EDA/resources/EducationCloudSettingsPageObject.py
+++ b/robot/EDA/resources/EducationCloudSettingsPageObject.py
@@ -42,8 +42,6 @@ class EducationCloudSettingsPage(BaseEDAPage, HomePage):
     def verify_error_is_displayed(self,value):
         """Verifies an error message displayed in a toast within education cloud settings
         """
-        locator = eda_lex_locators["eda_settings_new"]["error_toast"]
-        self.selenium.wait_until_element_is_visible(locator)
-        toastErrorMessage = self.selenium.get_webelement(locator).text
-        if value not in toastErrorMessage:
-            raise Exception (f"Toast error message is {toastErrorMessage} but expected to be {value}")
+        locator = eda_lex_locators["eda_settings_new"]["error_toast"].format(value)
+        self.selenium.wait_until_page_contains_element(locator, timeout=60, error=f'{locator} is not available')
+        self.selenium.wait_until_element_is_visible(locator, error= "{locator} is not displayed for the user")

--- a/robot/EDA/resources/EducationCloudSettingsPageObject.py
+++ b/robot/EDA/resources/EducationCloudSettingsPageObject.py
@@ -38,3 +38,12 @@ class EducationCloudSettingsPage(BaseEDAPage, HomePage):
         self.selenium.wait_until_element_is_visible(locator,
                                                 error= "Element is not displayed for the user")
         self.selenium.click_element(locator)
+
+    def verify_error_is_displayed(self,value):
+        """Verifies an error message displayed in a toast within education cloud settings
+        """
+        locator = eda_lex_locators["eda_settings_new"]["error_toast"]
+        self.selenium.wait_until_element_is_visible(locator)
+        toastErrorMessage = self.selenium.get_webelement(locator).text
+        if value not in toastErrorMessage:
+            raise Exception (f"Toast error message is {toastErrorMessage} but expected to be {value}")

--- a/robot/EDA/resources/locators_53.py
+++ b/robot/EDA/resources/locators_53.py
@@ -115,6 +115,7 @@ eda_lex_locators = {
         "edc_header": "//h2[contains(@class, 'header')]/descendant::span[text()='{}']",
         "toast_message": "//div[contains(@class, 'slds-theme--success slds-notify--toast slds-notify slds-notify--toast forceToastMessage')]/descendant::span[text()='{}']",
         "custom_toast": "//div[contains(@class, 'forceToastMessage')]/descendant::span[contains(@class, 'toastMessage')]",
+        "error_toast": "//div[contains(@class, 'slds-theme--error slds-notify--toast slds-notify slds-notify--toast forceToastMessage')]/descendant::span[contains(@class, 'toastMessage')]",
         "settings_nav_title": "//div[@data-qa-locator='edaSettingsNavigation']/descendant::a[text()='{}']",
         "dropdown_input": "//label[text()='{}']/../descendant::input[@role='combobox']",
         "settings_dropdown": "//label[text()='{}']/../descendant::span[text()='{}']",

--- a/robot/EDA/resources/locators_53.py
+++ b/robot/EDA/resources/locators_53.py
@@ -115,7 +115,7 @@ eda_lex_locators = {
         "edc_header": "//h2[contains(@class, 'header')]/descendant::span[text()='{}']",
         "toast_message": "//div[contains(@class, 'slds-theme--success slds-notify--toast slds-notify slds-notify--toast forceToastMessage')]/descendant::span[text()='{}']",
         "custom_toast": "//div[contains(@class, 'forceToastMessage')]/descendant::span[contains(@class, 'toastMessage')]",
-        "error_toast": "//div[contains(@class, 'slds-theme--error slds-notify--toast slds-notify slds-notify--toast forceToastMessage')]/descendant::span[contains(@class, 'toastMessage')]",
+        "error_toast": "//div[contains(@class, 'slds-theme--error slds-notify--toast slds-notify slds-notify--toast forceToastMessage')]/descendant::span[text()=\"{}\"]",
         "settings_nav_title": "//div[@data-qa-locator='edaSettingsNavigation']/descendant::a[text()='{}']",
         "dropdown_input": "//label[text()='{}']/../descendant::input[@role='combobox']",
         "settings_dropdown": "//label[text()='{}']/../descendant::span[text()='{}']",

--- a/robot/EDA/tests/browser/settings/home/edc_experience.robot
+++ b/robot/EDA/tests/browser/settings/home/edc_experience.robot
@@ -51,7 +51,7 @@ Verify user without class access renders release management page with toast erro
     Current page should be                  Home        Education Cloud Settings
     Click app in edc home                   Go to Release Management
     Current page should be                  Home        Release Management
-    Verify error is displayed           You do not have access to the Apex class named \'ReleaseGateController\'
+    Verify error is displayed           You do not have access to the Apex class named 'ReleaseGateController'
 
     #remove permission added for test
     Run task        add_permission_set_perms

--- a/robot/EDA/tests/browser/settings/home/edc_experience.robot
+++ b/robot/EDA/tests/browser/settings/home/edc_experience.robot
@@ -51,7 +51,7 @@ Verify user without class access renders release management page with toast erro
     Current page should be                  Home        Education Cloud Settings
     Click app in edc home                   Go to Release Management
     Current page should be                  Home        Release Management
-    Verify error is displayed           You do not have access to the Apex class named 'ReleaseGateController'
+    Verify error is displayed           You do not have access to the Apex class named 'ReleaseGateController'.
 
     #remove permission added for test
     Run task        add_permission_set_perms

--- a/robot/EDA/tests/browser/settings/home/edc_experience.robot
+++ b/robot/EDA/tests/browser/settings/home/edc_experience.robot
@@ -5,19 +5,21 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/EDA/resources/EducationCloudSettingsPageObject.py
 ...             robot/EDA/resources/ReleaseManagementPageObject.py
 
-Suite Setup     Open Test Browser
+Suite Setup     Initialize test data
 Suite Teardown  Capture screenshot and delete records and close browser
 
 *** Test Cases ***
 Verify education cloud settings app is displayed
     [Documentation]         Validates 'Education Cloud Settings" app is displayed under app tile.
     [tags]                  rbt:high        W-9549044
+    Open test browser 
     Open app launcher
     Verify item exists       Education Cloud Settings
 
 Verify products tools and resources tiles are displayed
     [Documentation]         Validates the products, tools and resources tiles are displayed.
     [tags]                  rbt:high        W-9549044
+    Open test browser 
     Go to education cloud settings home
     Current page should be                  Home        Education Cloud Settings
     Verify app tiles displayed
@@ -30,7 +32,34 @@ Verify products tools and resources tiles are displayed
 Verify release management page is displayed when user clicks on go to release management button
     [Documentation]         Validates 'Release Management' page is displayed after clicking on the Go to Release Management
     [tags]                  rbt:high        W-10059978
+    Open test browser 
     Go to education cloud settings home
     Current page should be                  Home        Education Cloud Settings
     Click app in edc home                   Go to Release Management
     Current page should be                  Home        Release Management
+
+Verify user without class access renders release management page with toast error
+    [Documentation]         Validates 'Release Management' page with access error is displayed after clicking on the Go to Release Management
+    [tags]                  rbt:high        W-10059980
+    #give user partial permission to access Release Management page, but not see the release gates
+    Run task        add_permission_set_perms
+    ...             api_names=Internal_Only_for_Testing
+    ...             class_accesses=${{ [{"apexClass": "${ns}EducationCloudSettingsController", "enabled": True}] }}
+
+    Open test browser        useralias=noaccess
+    Go to education cloud settings home
+    Current page should be                  Home        Education Cloud Settings
+    Click app in edc home                   Go to Release Management
+    Current page should be                  Home        Release Management
+    Verify error is displayed           You do not have access to the Apex class named \'ReleaseGateController\'
+
+    #remove permission added for test
+    Run task        add_permission_set_perms
+    ...             api_names=Internal_Only_for_Testing
+    ...             class_accesses=${{ [{"apexClass": "${ns}EducationCloudSettingsController", "enabled": False}] }}
+
+
+*** Keywords ***
+Initialize test data
+    [Documentation]         
+    ${ns} =     Get EDA namespace prefix

--- a/unpackaged/config/dev/package.xml
+++ b/unpackaged/config/dev/package.xml
@@ -13,6 +13,10 @@
         <name>CompactLayout</name>
     </types>
     <types>
+        <members>Internal_Only_for_Testing</members>
+        <name>PermissionSet</name>
+    </types>
+    <types>
         <members>Admin</members>
         <name>Profile</name>
     </types>

--- a/unpackaged/config/dev/permissionsets/Internal_Only_for_Testing.permissionset
+++ b/unpackaged/config/dev/permissionsets/Internal_Only_for_Testing.permissionset
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Internal Only - Provides Education Cloud Settings tab visibility to users for internal QA/dev permissioning testing.</description>
+    <label>Internal Only - For Testing</label>
+    <tabSettings>
+        <tab>%%%NAMESPACE%%%Education_Cloud_Settings</tab>
+        <visibility>Available</visibility>
+    </tabSettings>
+</PermissionSet>


### PR DESCRIPTION
# Issues Closed
[W-10059980
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000HzwyZYAR/view
)

# New Metadata

- Permission Set (unpackaged)
   - Internal_Only_for_Testing


# Testing Notes

- [T-6951039](https://gus.lightning.force.com/lightning/r/ADM_Test_Scenario__c/a80EE000000DKSLYA4/view)

- Created new User with Standard profile
- Created new permission set for internal testing that only has tab visibility access for Education Cloud Settings
