### PR TITLE
[W-10302289/W-10302295/W-10302298/W-10302302/W-10302306] Feature Parameter - No Contacts Account Auto Deletion

### DIFF
--- a/force-app/main/default/classes/FeatureParameterMapper.cls
+++ b/force-app/main/default/classes/FeatureParameterMapper.cls
@@ -117,7 +117,12 @@ public virtual with sharing class FeatureParameterMapper {
             Org_CountActiveCourseConnectionRecordTypes,
             SettingsHealthCheckLastRunDate,
             UsingOldContactEthnicity,
-            UsingOldCourseDescription
+            UsingOldCourseDescription,
+            AutodeleteNoContactHouseholdAcc,
+            AutodeleteNoContactProgramAcc,
+            AutodeleteNoContactEducationalInstitutionAcc,
+            AutodeleteNoContactBusinessOrganizationAcc,
+            AutodeleteNoContactUniversityDepartmentAcc
     }
 
     /**********************************************************************************

--- a/force-app/main/default/classes/UTIL_Describe.cls
+++ b/force-app/main/default/classes/UTIL_Describe.cls
@@ -861,6 +861,42 @@ public class UTIL_Describe {
     }
 
     /*******************************************************************************************************
+     * @description Returns the ID of the University Department Account record type, if it exists.
+     * @return String The ID of the University Department Account record type as a String.
+     */
+    public static String getUniversityAccRecTypeID() {
+        String recTypeId = getRecTypesMapByDevName('Account').get('University_Department');
+
+        if (String.isBlank(recTypeId) && Test.isRunningTest()) {
+            if (getRecTypesMapByDevName('Account').values().size() > 1) {
+                return getRecTypesMapByDevName('Account').values()[1];
+            } else {
+                return null;
+            }
+        } else {
+            return recTypeId;
+        }
+    }
+
+    /*******************************************************************************************************
+     * @description Returns the ID of the Educational Institution Account record type, if it exists.
+     * @return String The ID of the Educational Institution Account record type as a String.
+     */
+    public static String getEducationalInstitutionAccRecTypeID() {
+        String recTypeId = getRecTypesMapByDevName('Account').get('Educational_Institution');
+
+        if (String.isBlank(recTypeId) && Test.isRunningTest()) {
+            if (getRecTypesMapByDevName('Account').values().size() > 1) {
+                return getRecTypesMapByDevName('Account').values()[1];
+            } else {
+                return null;
+            }
+        } else {
+            return recTypeId;
+        }
+    }
+
+    /*******************************************************************************************************
      * @description Returns the ID of the custom Household Account record type
      * @return The ID of the custom Household Account record type.
      */

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -97,7 +97,12 @@ public without sharing class UTIL_OrgTelemetry {
         UsingOldContactEthnicity,
         UsingOldCourseDescription,
         Data_CountSeasonalAddresses,
-        Data_CountCurrentYearSeasonalAddresses
+        Data_CountCurrentYearSeasonalAddresses,
+        AutodeleteNoContactHouseholdAcc,
+        AutodeleteNoContactProgramAcc,
+        AutodeleteNoContactEducationalInstitutionAcc,
+        AutodeleteNoContactBusinessOrganizationAcc,
+        AutodeleteNoContactUniversityDepartmentAcc
     }
 
     /**
@@ -204,6 +209,31 @@ public without sharing class UTIL_OrgTelemetry {
         featureManager.setPackageBooleanValue(
             TelemetryParameterName.IsEnabled_StoreErrors.name(),
             edaSettings.Store_Errors_On__c
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.AutodeleteNoContactHouseholdAcc.name(),
+            this.hasAutoDeletionHouseholdAccts(edaSettings)
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.AutodeleteNoContactProgramAcc.name(),
+            this.hasAutoDeletionProgramAccts(edaSettings)
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.AutodeleteNoContactEducationalInstitutionAcc.name(),
+            this.hasAutoDeletionEducationalInstitutionAccts(edaSettings)
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.AutodeleteNoContactBusinessOrganizationAcc.name(),
+            this.hasAutoDeletionEducationalInstitutionAccts(edaSettings)
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.AutodeleteNoContactUniversityDepartmentAcc.name(),
+            this.hasAutoDeletionUniversityDeptAccts(edaSettings)
         );
     }
 
@@ -466,5 +496,64 @@ public without sharing class UTIL_OrgTelemetry {
                     AND CreatedDate = LAST_N_DAYS:365
             ]
         );
+    }
+
+    /**
+     * @description Returns true if household accounts without contacts are marked
+     * for deletion.
+     */
+    private Boolean hasAutoDeletionHouseholdAccts(Hierarchy_Settings__c edaSettings) {
+        return this.hasContactAutoDeletionEnabled(edaSettings, Util_Describe.getHhAccRecTypeID());
+    }
+
+    /**
+     * @description Returns true if academic program accounts without contacts are marked
+     * for deletion.
+     */
+    private Boolean hasAutoDeletionProgramAccts(Hierarchy_Settings__c edaSettings) {
+        return this.hasContactAutoDeletionEnabled(edaSettings, Util_Describe.getAcademicAccRecTypeID());
+    }
+
+    /**
+     * @description Returns true if educational institution accounts without contacts are marked
+     * for deletion.
+     */
+    private Boolean hasAutoDeletionEducationalInstitutionAccts(Hierarchy_Settings__c edaSettings) {
+        return this.hasContactAutoDeletionEnabled(edaSettings, Util_Describe.getEducationalInstitutionAccRecTypeID());
+    }
+
+    /**
+     * @description Returns true if business organization accounts without contacts are marked
+     * for deletion.
+     */
+    private Boolean hasAutoDeletionBusinessOrgAccts(Hierarchy_Settings__c edaSettings) {
+        return this.hasContactAutoDeletionEnabled(edaSettings, Util_Describe.getBizAccRecTypeID());
+    }
+
+    /**
+     * @description Returns true if university department accounts without contacts are marked
+     * for deletion.
+     */
+    private Boolean hasAutoDeletionUniversityDeptAccts(Hierarchy_Settings__c edaSettings) {
+        return this.hasContactAutoDeletionEnabled(edaSettings, Util_Describe.getUniversityAccRecTypeID());
+    }
+
+    /**
+     * @description Returns true if the specified account record type is enabled for contacts
+     * auto-deletion.
+     */
+    private Boolean hasContactAutoDeletionEnabled(Hierarchy_Settings__c edaSettings, String accountRT) {
+        Boolean autodeleteContactsEnabled = false;
+        Boolean autoDeletionConfigPopulated = edaSettings.Accounts_to_Delete__c != null;
+
+        if (autoDeletionConfigPopulated) {
+            Boolean currentAccountRTDefined = accountRT != null;
+            if (currentAccountRTDefined) {
+                autodeleteContactsEnabled = edaSettings.Accounts_to_Delete__c.Contains(accountRT)
+                    ? true
+                    : autodeleteContactsEnabled;
+            }
+        }
+        return autodeleteContactsEnabled;
     }
 }

--- a/force-app/main/default/featureParameters/AutodeleteNoContactBusinessOrganizationAcc.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/AutodeleteNoContactBusinessOrganizationAcc.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Auto Delete No Contact Business Organization Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>

--- a/force-app/main/default/featureParameters/AutodeleteNoContactEducationalInstitutionAcc.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/AutodeleteNoContactEducationalInstitutionAcc.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Auto Delete No Contact Educational Institution Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>

--- a/force-app/main/default/featureParameters/AutodeleteNoContactHouseholdAcc.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/AutodeleteNoContactHouseholdAcc.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Auto Delete No Contact Household Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>

--- a/force-app/main/default/featureParameters/AutodeleteNoContactProgramAcc.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/AutodeleteNoContactProgramAcc.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Auto Delete No Contact Program Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>

--- a/force-app/main/default/featureParameters/AutodeleteNoContactUniversityDepartmentAcc.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/AutodeleteNoContactUniversityDepartmentAcc.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Auto Delete No Contact University Department Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>


### PR DESCRIPTION
This child branch contains the three Feature Parameters for accounts without contacts marked for auto-deletion and the associated logic & unit tests.

# Issues Closed
- [W-10302289](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUa4fYAD/view)
- [W-10302295](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUP4lYAH/view)
- [W-10302298](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUZQMYA5/view)
- [W-10302302](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUbQXYA1/view)
- [W-10302306](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUZ74YAH/view)

# New Metadata
- Auto Delete No Contact Household Accounts
- Auto Delete No Contact Program Accounts
- Auto Delete No Contact Educational Institution Accounts
- Auto Delete No Contact Business Organization Accounts
- Auto Delete No Contact University Department Accounts

# Testing Notes
- Pending

_Note: [Parent branch](https://github.com/SalesforceFoundation/EDA/tree/feature/238__zhussain_telemetryEnhancements) will consist of all aggregated [telemetry 238 deliverables](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE0000002Z9l2AE/related/Work__r/view), to be tested/verified as part of [W-10302537](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUui3YAD/view)._