### PR TITLE
[W-10385099] Error message styling for EDA Settings with Insufficient Permissions

### DIFF
--- a/force-app/main/default/lwc/edaSettings/edaSettings.html
+++ b/force-app/main/default/lwc/edaSettings/edaSettings.html
@@ -33,7 +33,7 @@
         <template if:true={currentUserHasAccessWireResolved}>
             <template if:false={currentUserHasAccess}>
                 <div
-                    class="slds-col slds-size_12-of-12 slds-theme_default slds-p-around_small"
+                    class="slds-col slds-size_12-of-12 slds-theme_default slds-var-p-around_small slds-no-flex eda-height_full"
                     data-testid="eda-settings-error-insufficient-access"
                 >
                     {labelReference.insufficientAccessError}


### PR DESCRIPTION
# Critical Changes

# Changes
* Fixed a bug where the error message for insufficient permissions in EDA Settings was in the center of the page.

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes

* Remove access to EDASettingsController from the current user
* Access EDA Settings