### PR TITLE
[W-10302313] Feature Parameter - Rename Household Accounts

### DIFF
--- a/force-app/main/default/classes/FeatureParameterMapper.cls
+++ b/force-app/main/default/classes/FeatureParameterMapper.cls
@@ -125,7 +125,8 @@ public virtual with sharing class FeatureParameterMapper {
             AutodeleteNoContactUniversityDepartmentAcc,
             HasAffiliationsRelatedToDeletedProgramEnrollments,
             HasAffiliationStartDate,
-            HasAffiliationEndDate
+            HasAffiliationEndDate,
+            HasAutomaticallyRenameHouseholdAccounts
     }
 
     /**********************************************************************************

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -99,6 +99,7 @@ public without sharing class UTIL_OrgTelemetry {
         HasAffiliationsRelatedToDeletedProgramEnrollments,
         HasAffiliationStartDate,
         HasAffiliationEndDate,
+        HasAutomaticallyRenameHouseholdAccounts,
         Data_CountSeasonalAddresses,
         Data_CountCurrentYearSeasonalAddresses,
         AutodeleteNoContactHouseholdAcc,
@@ -253,6 +254,11 @@ public without sharing class UTIL_OrgTelemetry {
         featureManager.setPackageBooleanValue(
             TelemetryParameterName.HasAffiliationEndDate.name(),
             edaSettings.Affl_ProgEnroll_Copy_End_Date__c
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.HasAutomaticallyRenameHouseholdAccounts.name(),
+            edaSettings.Automatic_Household_Naming__c
         );
     }
 

--- a/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
@@ -164,6 +164,11 @@ private class UTIL_OrgTelemetry_TEST {
             UTIL_OrgTelemetry.TelemetryParameterName.HasAffiliationEndDate.name(),
             edaSettings.Affl_ProgEnroll_Copy_End_Date__c
         );
+
+        assertBooleanValue(
+            UTIL_OrgTelemetry.TelemetryParameterName.HasAutomaticallyRenameHouseholdAccounts.name(),
+            edaSettings.Automatic_Household_Naming__c
+        );
     }
 
     /*******************************************************************************************************

--- a/force-app/main/default/featureParameters/HasAutomaticallyRenameHouseholdAccounts.featureParameterBoolean-meta copy.xml
+++ b/force-app/main/default/featureParameters/HasAutomaticallyRenameHouseholdAccounts.featureParameterBoolean-meta copy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Has Automatically Rename Household Accounts</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>


### PR DESCRIPTION
This child branch contains the Feature Parameter for household account renaming, the associated logic & unit tests.

# Issues Closed
- [W-10302313](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUZK5YAP/view)

# New Metadata
- Has Automatically Rename Household Accounts

# Testing Notes
- [T-8132282](https://gus.lightning.force.com/lightning/r/ADM_Test_Scenario__c/a80EE000000kynZYAQ/view)

_Note: [Parent branch](https://github.com/SalesforceFoundation/EDA/tree/feature/238__zhussain_telemetryEnhancements) will consist of all aggregated [telemetry 238 deliverables](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE0000002Z9l2AE/related/Work__r/view), to be tested/verified as part of [W-10302537](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUui3YAD/view)._