### PR TITLE
[W-10302340] Feature Parameter - Admin Error Notifications Recipients

### DIFF
--- a/force-app/main/default/classes/FeatureParameterMapper.cls
+++ b/force-app/main/default/classes/FeatureParameterMapper.cls
@@ -111,6 +111,7 @@ public virtual with sharing class FeatureParameterMapper {
             HasUserManagedTDTM,
             HasValueInversionReciprocalMethod,
             IsEnabled_StoreErrors,
+            HasErrorNotificationsAdminRecipients,
             IsEnabled_AutomaticHouseholdNaming,
             IsEnabled_CourseConnections,
             IsEnabled_ErrorHandling,

--- a/force-app/main/default/classes/UTIL_OrgTelemetry.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry.cls
@@ -94,6 +94,7 @@ public without sharing class UTIL_OrgTelemetry {
         HasUserManagedTDTM,
         HasValueInversionReciprocalMethod,
         IsEnabled_StoreErrors,
+        HasErrorNotificationsAdminRecipients,
         UsingOldContactEthnicity,
         UsingOldCourseDescription,
         HasAffiliationsRelatedToDeletedProgramEnrollments,
@@ -213,6 +214,11 @@ public without sharing class UTIL_OrgTelemetry {
         featureManager.setPackageBooleanValue(
             TelemetryParameterName.IsEnabled_StoreErrors.name(),
             edaSettings.Store_Errors_On__c
+        );
+
+        featureManager.setPackageBooleanValue(
+            TelemetryParameterName.HasErrorNotificationsAdminRecipients.name(),
+            edaSettings.Error_Notifications_To__c == 'All Sys Admins'
         );
 
         featureManager.setPackageBooleanValue(

--- a/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/force-app/main/default/classes/UTIL_OrgTelemetry_TEST.cls
@@ -126,6 +126,11 @@ private class UTIL_OrgTelemetry_TEST {
         );
 
         assertBooleanValue(
+            UTIL_OrgTelemetry.TelemetryParameterName.HasErrorNotificationsAdminRecipients.name(),
+            edaSettings.Error_Notifications_To__c == 'All Sys Admins'
+        );
+
+        assertBooleanValue(
             UTIL_OrgTelemetry.TelemetryParameterName.AutodeleteNoContactHouseholdAcc.name(),
             orgTelemetry.hasAutoDeletionHouseholdAccts(edaSettings)
         );

--- a/force-app/main/default/featureParameters/HasErrorNotificationsAdminRecipients.featureParameterBoolean-meta.xml
+++ b/force-app/main/default/featureParameters/HasErrorNotificationsAdminRecipients.featureParameterBoolean-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterBoolean xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Has Error Notifications Admin Recipients</masterLabel>
+    <value>false</value>
+</FeatureParameterBoolean>


### PR DESCRIPTION
# Changes
- This child branch contains the feature parameter for error notifications for admins, the associated logic & unit tests. WE can now get a count of the orgs that have All Sys Admin selected for this setting.

# Issues Closed
- [W-10302340](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUcjFYAT/view)

# New Metadata
- Has Error Notifications Admin Recipients

# Testing Notes
- [T-8132282](https://gus.lightning.force.com/lightning/r/ADM_Test_Scenario__c/a80EE000000kynZYAQ/view)

_Note: [Parent branch](https://github.com/SalesforceFoundation/EDA/tree/feature/238__zhussain_telemetryEnhancements) will consist of all aggregated [telemetry 238 deliverables](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE0000002Z9l2AE/related/Work__r/view), to be tested/verified as part of [W-10302537](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XUui3YAD/view)._