### PR TITLE
Fix non-english program enrollment bug

### DIFF
--- a/force-app/main/default/classes/AFFL_MultiRecordTypeMapper.cls
+++ b/force-app/main/default/classes/AFFL_MultiRecordTypeMapper.cls
@@ -80,6 +80,11 @@ public virtual with sharing class AFFL_MultiRecordTypeMapper {
     public Map<String, String> accRecTypeLabelToAPI;
 
     /*******************************************************************************************************
+     * @description Map of Account Record Type Labels in English to User Language Label
+     ********************************************************************************************************/
+    private Map<String, String> accRecTypeEnglishToTranslation;
+
+    /*******************************************************************************************************
      * @description Constructor that initializes class properties.
      ********************************************************************************************************/
     public AFFL_MultiRecordTypeMapper() {
@@ -98,6 +103,9 @@ public virtual with sharing class AFFL_MultiRecordTypeMapper {
         // Map of Account RecordType Label To API
         //NOTE: Consider a refactor relative to case sensitivity
         this.accRecTypeLabelToAPI = this.getAccRecTypeLabelToAPIMap();
+
+        // Map of Account RecordType English label to Translated Label
+        this.accRecTypeEnglishToTranslation = this.getAccRecTypeEnglishLabelToTranslation();
 
         //Note: Given the supportable number of records for affiliation mappings, having multiple small loops
         //is an acceptable and negligible performance hit so we can apply a separation of concerns for future refactoring.
@@ -161,6 +169,23 @@ public virtual with sharing class AFFL_MultiRecordTypeMapper {
             labelsnames.put(field.Name, field.DeveloperName);
         }
         return labelsnames;
+    }
+
+    /**
+     * @description Returns a map of the English label to the current running user's language
+     */
+    @TestVisible
+    private Map<String, String> getAccRecTypeEnglishLabelToTranslation() {
+        Map<String, String> labels = new Map<String, String>();
+
+        for (String englishLabel : accRecTypeLabelToAPI.keySet()) {
+            labels.put(
+                englishLabel,
+                accountRecordTypeInfosByDeveloperName.get(accRecTypeLabelToAPI.get(englishLabel)).getName()
+            );
+        }
+
+        return labels;
     }
 
     /**
@@ -329,8 +354,14 @@ public virtual with sharing class AFFL_MultiRecordTypeMapper {
             return false;
         }
 
+        // we need to use the "english to translation" map since Affiliation_Type__c is a formula field
+        // and formula fields aren't translated into the running user's language.
+        if (!accRecTypeEnglishToTranslation.containsKey(affiliation.Affiliation_Type__c)) {
+            return false;
+        }
+
         Affl_Mappings__c affiliationMapping = primaryAffiliationMappingsByAccountRecordTypeName.get(
-            affiliation.Affiliation_Type__c
+            accRecTypeEnglishToTranslation.get(affiliation.Affiliation_Type__c)
         );
 
         if (affiliationMapping?.Auto_Program_Enrollment__c != true) {


### PR DESCRIPTION
Bug W-11472755 - When the user’s language was something other than English, the Program Enrollment wasn’t being created due to the way that the Affiliation_Type field was using the record type label in English, while the queries were translating the label to the user’s language.

Signed-off-by: jcschultz <jschultz@salesforce.com>

# Critical Changes

# Changes

# Issues Closed
[W-11472755](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE0000121fWuYAI)

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
1. Switch your language to something other than English
2. Create an Affiliated Account record on a contact where the chosen is the Academic Program record type, and the contact's role is Student
3. After saving the record, refresh the contact's record and verify that a new Program Enrollment has been created