### PR TITLE
Update release notes generation to use static text

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,4 +1,4 @@
-minimum_cumulusci_version: 3.9.0
+minimum_cumulusci_version: 3.74.0
 project:
     name: EDA
     package:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -319,6 +319,11 @@ tasks:
             path: scripts/setup.cls
             apex: qaSetup();
 
+    github_release:
+        options:
+            release_content: |
+                Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
+
     github_release_notes:
         options:
             trial_info: "`TBD`"
@@ -622,6 +627,11 @@ flows:
                 flow: qa_org_2gp
             2:
                 flow: run_functional_tests
+
+    release_production:
+        steps:
+            3:
+                task: None
 
     run_functional_tests:
         # description: Configure an org for use as a dev org after package metadata is deployed.


### PR DESCRIPTION
Auto generated release notes should now use static text linking to the H&T SFDO release notes. This change updates how the release notes are generated for each production release to instead use that static text.

See: [TD-0127818](https://gus.lightning.force.com/lightning/r/ADM_Team_Dependency__c/a0nEE0000008Y2vYAE/view)

# Critical Changes

# Changes

# Issues Closed
[W-12659914](https://gus.my.salesforce.com/a07EE00001MlV8NYAV)

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
